### PR TITLE
Add OpenDefinitions type and initial fetch

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,7 +14,8 @@
             "elm/url": "1.0.0",
             "krisajenkins/remotedata": "6.0.1",
             "mgold/elm-nonempty-list": "4.1.0",
-            "stoeffel/set-extra": "1.2.3"
+            "stoeffel/set-extra": "1.2.3",
+            "y0hy0h/ordered-containers": "2.0.1"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/public/main.css
+++ b/public/main.css
@@ -18,7 +18,14 @@ li {
 }
 
 :root {
+  --size-base: 16px;
+
   --main-sidebar-width: 14rem;
+
+  /* -- Font sizes --------------------------------------------------------- */
+
+  --font-size-base: 1rem;
+  --font-size-medium: 0.875rem;
 
   /* -- All colors --------------------------------------------------------- */
 
@@ -69,6 +76,7 @@ li {
   --color-sidebar-highlight-border: var(--color-blue-base);
 
   --color-workspace-fg: var(--color-main-fg);
+  --color-workspace-mg: var(--color-gray-lighten-100);
   --color-workspace-bg: var(--color-gray-lighten-50);
   --color-workspace-border: var(--color-main-border);
   --color-workspace-subtle-fg: var(--color-main-subtle-fg);
@@ -80,7 +88,7 @@ li {
 
 /* -- Global --------------------------------------------------------------- */
 html {
-  font-size: 16px;
+  font-size: var(--base-size);
   font-family: "Inter", sans-serif;
 }
 
@@ -104,6 +112,7 @@ a:hover {
 }
 
 code {
+  display: inline-block;
   font-family: "Roboto Mono", monospace;
 }
 
@@ -111,7 +120,16 @@ code {
 
 .error-message {
   color: var(--color-brand-bright-red);
-  font-weight: bold;
+}
+
+/* Loading placeholders */
+
+.loading-placeholder {
+  display: inline-block;
+  height: calc(var(--font-size-base) * 0.65);
+  border-radius: calc(var(--font-size-base) / 2);
+  background: var(--main-subtle-fg);
+  min-width: calc(var(--font-size-base) * 3);
 }
 
 /* -- Application ---------------------------------------------------------- */
@@ -131,7 +149,7 @@ code {
   border-right: 1px solid var(--color-sidebar-border);
   display: flex;
   flex-direction: column;
-  font-size: 0.875rem;
+  font-size: var(--font-size-medium);
   overflow: auto;
   height: 100vh;
   padding: 1rem 1.5rem;
@@ -150,17 +168,21 @@ code {
   border-radius: 0.2rem;
 }
 
+#main-sidebar .loading-placeholder {
+  background: var(--color-workspace-subtle-fg);
+}
+
 #main-sidebar header {
   margin-bottom: 2.5rem;
 }
 
 #main-sidebar h1 {
-  font-size: 1rem;
+  font-size: var(--font-size-base);
   color: var(--color-sidebar-context-fg);
 }
 
 #main-sidebar h2 {
-  font-size: 0.875rem;
+  font-size: var(--font-size-medium);
   font-weight: normal;
   color: var(--color-sidebar-subtle-fg);
 }
@@ -208,7 +230,9 @@ code {
 #workspace-toolbar {
   height: 3.5rem;
   padding: 0.75rem 1rem;
-  font-size: 0.875rem;
+  font-size: var(--font-size-medium);
+  background: var(--color-workspace-mg);
+  border-bottom: 1px solid var(--color-workspace-border);
 }
 
 #workspace-content {
@@ -219,8 +243,53 @@ code {
 /* -- Definitions ---------------------------------------------------------- */
 
 .definition-row {
-  background: var(--color-main-bg);
-  color: var(--color-main-fg);
+  background: var(--color-workspace-mg);
+  color: var(--color-workspace-fg);
   padding: 1rem;
   margin-bottom: 1px;
+}
+
+.definition-row .loading-placeholder {
+  background: var(--color-workspace-bg);
+}
+
+.definition-row header {
+  color: var(--color-workspace-subtle-fg);
+  font-size: var(--font-size-medium);
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  justify-content: space-between;
+}
+
+.definition-row .content {
+  margin: 2rem 1rem 1rem;
+}
+
+.definition-row .content .docs {
+  margin-bottom: 1rem;
+}
+
+.definition-row .content code {
+  display: block;
+  padding: 1rem 1.25rem;
+  border-radius: 0.25rem;
+  background: var(--color-workspace-subtle-bg);
+}
+
+/* Definition row loading indicator */
+
+.definition-row header .loading-placeholder {
+  width: 10%;
+}
+
+.definition-row .content .loading-placeholder {
+  display: block;
+  width: 40%;
+  margin-bottom: 0.3rem;
+}
+
+.definition-row .content code .loading-placeholder {
+  display: block;
+  width: 40%;
 }

--- a/public/main.css
+++ b/public/main.css
@@ -254,12 +254,16 @@ code {
 }
 
 .definition-row header {
-  color: var(--color-workspace-subtle-fg);
-  font-size: var(--font-size-medium);
   display: flex;
   flex-direction: row;
   flex: 1;
   justify-content: space-between;
+}
+
+.definition-row header h3 {
+  color: var(--color-workspace-fg);
+  font-size: var(--font-size-base);
+  font-weight: bold;
 }
 
 .definition-row .content {

--- a/public/main.css
+++ b/public/main.css
@@ -107,6 +107,13 @@ code {
   font-family: "Roboto Mono", monospace;
 }
 
+/* -- UI ------------------------------------------------------------------- */
+
+.error-message {
+  color: var(--color-brand-bright-red);
+  font-weight: bold;
+}
+
 /* -- Application ---------------------------------------------------------- */
 
 #app {
@@ -190,7 +197,7 @@ code {
   margin-left: 1rem;
 }
 
-/* -- Workspace ---------------------------------------------------------------- */
+/* -- Workspace ------------------------------------------------------------ */
 
 #workspace {
   background: var(--color-workspace-bg);
@@ -207,4 +214,13 @@ code {
 #workspace-content {
   overflow: auto;
   height: calc(100vh - 3.5rem);
+}
+
+/* -- Definitions ---------------------------------------------------------- */
+
+.definition-row {
+  background: var(--color-main-bg);
+  color: var(--color-main-fg);
+  padding: 1rem;
+  margin-bottom: 1px;
 }

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -22,9 +22,11 @@ listUrl namespaceHashOrFQN =
         |> serverUrl [ "list" ]
 
 
-definitionUrl : String
-definitionUrl =
-    serverUrl [ "getDefinition" ] []
+definitionUrl : List String -> String
+definitionUrl hashes =
+    hashes
+        |> List.map (string "names")
+        |> serverUrl [ "getDefinition" ]
 
 
 

--- a/src/App.elm
+++ b/src/App.elm
@@ -3,13 +3,14 @@ module App exposing (..)
 import Api
 import Definition exposing (Definition)
 import FullyQualifiedName exposing (unqualifiedName)
-import Hash exposing (Hash(..))
+import Hash exposing (Hash)
 import HashSet exposing (HashSet)
 import Html exposing (Html, a, article, aside, button, div, h1, h2, header, input, label, nav, section, span, text)
 import Html.Attributes exposing (class, id, placeholder, type_, value)
 import Html.Events exposing (onClick, onInput)
 import Http
 import NamespaceListing exposing (DefinitionListing(..), NamespaceListing(..), NamespaceListingContent)
+import OpenDefinitions exposing (OpenDefinitions)
 import RemoteData exposing (RemoteData(..), WebData)
 import UI
 import UI.Icon
@@ -19,12 +20,8 @@ import UI.Icon
 -- MODEL
 
 
-type alias OpenDefinition =
-    ( Definition, Bool )
-
-
 type alias Model =
-    { openDefinitions : List OpenDefinition
+    { openDefinitions : OpenDefinitions
     , rootNamespaceListing : WebData NamespaceListing
     , expandedNamespaceListings : HashSet
     }
@@ -34,7 +31,7 @@ init : () -> ( Model, Cmd Msg )
 init _ =
     let
         model =
-            { openDefinitions = []
+            { openDefinitions = OpenDefinitions.empty
             , rootNamespaceListing = Loading
             , expandedNamespaceListings = HashSet.empty
             }
@@ -50,6 +47,8 @@ type Msg
     = ToggleExpandedNamespaceListing Hash
     | FetchSubNamespaceListingFinished Hash (Result Http.Error NamespaceListing)
     | FetchRootNamespaceListingFinished (Result Http.Error NamespaceListing)
+    | OpenDefinition Hash
+    | FetchOpenDefinitionsFinished (List Hash) (Result Http.Error (List Definition))
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -105,6 +104,31 @@ update msg model =
                 Err err ->
                     ( { model | rootNamespaceListing = Failure err }, Cmd.none )
 
+        OpenDefinition hash ->
+            ( { model
+                | openDefinitions =
+                    OpenDefinitions.insert hash
+                        Loading
+                        model.openDefinitions
+              }
+            , fetchOpenDefinitions [ hash ]
+            )
+
+        FetchOpenDefinitionsFinished hashes result ->
+            let
+                list =
+                    case result of
+                        Err err ->
+                            List.map (\h -> ( h, Failure err )) hashes
+
+                        Ok definitions ->
+                            List.map (\d -> ( Definition.hash d, Success d )) definitions
+
+                nextOpenDefinitions =
+                    OpenDefinitions.insertList list model.openDefinitions
+            in
+            ( { model | openDefinitions = nextOpenDefinitions }, Cmd.none )
+
 
 
 -- Http
@@ -126,6 +150,14 @@ fetchSubNamespaceListing hash =
         }
 
 
+fetchOpenDefinitions : List Hash -> Cmd Msg
+fetchOpenDefinitions hashes =
+    Http.get
+        { url = Api.definitionUrl (List.map Hash.toString hashes)
+        , expect = Http.expectJson (FetchOpenDefinitionsFinished hashes) Definition.decodeList
+        }
+
+
 
 -- VIEW
 
@@ -134,15 +166,22 @@ viewDefinitionListing : DefinitionListing -> Html Msg
 viewDefinitionListing definition =
     case definition of
         Type hash fqn ->
-            a [ class "node type" ]
-                [ label [] [ text (unqualifiedName fqn) ]
+            a [ class "node type", onClick (OpenDefinition hash) ]
+                [ UI.Icon.type_
+                , label [] [ text (unqualifiedName fqn) ]
                 ]
 
         Term hash fqn ->
-            a [ class "node term" ] [ label [] [ text (unqualifiedName fqn) ] ]
+            a [ class "node term", onClick (OpenDefinition hash) ]
+                [ UI.Icon.term
+                , label [] [ text (unqualifiedName fqn) ]
+                ]
 
         Patch _ ->
-            a [ class "node patch" ] [ label [] [ text "Patch" ] ]
+            a [ class "node patch" ]
+                [ UI.Icon.patch
+                , label [] [ text "Patch" ]
+                ]
 
 
 viewLoadedNamespaceListingContent : HashSet -> NamespaceListingContent -> Html Msg
@@ -164,7 +203,7 @@ viewNamespaceListingContent expandedNamespaceListings content =
             viewLoadedNamespaceListingContent expandedNamespaceListings loadedContent
 
         Failure err ->
-            text (Api.errorToString err)
+            UI.errorMessage (Api.errorToString err)
 
         NotAsked ->
             UI.nothing
@@ -208,7 +247,7 @@ viewAllNamespaces expandedNamespaceListings namespaceRoot =
                     viewNamespaceListingContent expandedNamespaceListings content
 
                 Failure err ->
-                    div [] [ text (Api.errorToString err) ]
+                    UI.errorMessage (Api.errorToString err)
 
                 NotAsked ->
                     UI.spinner
@@ -233,11 +272,42 @@ viewMainSidebar model =
         ]
 
 
+viewDefinition : WebData Definition -> Html Msg
+viewDefinition definition =
+    let
+        row content =
+            div [ class "definition-row" ] [ content ]
+    in
+    case definition of
+        Success def ->
+            row (text (Definition.unqualifiedName def))
+
+        Failure err ->
+            row (UI.errorMessage (Api.errorToString err))
+
+        NotAsked ->
+            UI.nothing
+
+        Loading ->
+            row UI.spinner
+
+
+viewOpenDefinitions : OpenDefinitions -> List (Html Msg)
+viewOpenDefinitions openDefinitions =
+    openDefinitions
+        |> OpenDefinitions.definitions
+        |> List.map viewDefinition
+
+
 viewWorkspace : Model -> Html Msg
 viewWorkspace model =
     article [ id "workspace" ]
-        [ header [ id "workspace-toolbar" ] [ text "Open" ]
-        , section [ id "workspace-pans" ] [ section [ class "definitions-pane" ] [] ]
+        [ header [ id "workspace-toolbar" ] []
+        , section [ id "workspace-pans" ]
+            [ section
+                [ class "definitions-pane" ]
+                (viewOpenDefinitions model.openDefinitions)
+            ]
         ]
 
 

--- a/src/App.elm
+++ b/src/App.elm
@@ -1,11 +1,11 @@
 module App exposing (..)
 
 import Api
-import Definition exposing (Definition)
+import Definition exposing (Definition(..))
 import FullyQualifiedName exposing (unqualifiedName)
 import Hash exposing (Hash)
 import HashSet exposing (HashSet)
-import Html exposing (Html, a, article, aside, button, code, div, h1, h2, header, input, label, nav, section, span, text)
+import Html exposing (Html, a, article, aside, button, code, div, h1, h2, h3, header, input, label, nav, section, span, text)
 import Html.Attributes exposing (class, id, placeholder, type_, value)
 import Html.Events exposing (onClick, onInput)
 import Http
@@ -173,21 +173,21 @@ fetchDefinitions hashes =
 
 
 viewDefinitionListing : DefinitionListing -> Html Msg
-viewDefinitionListing definition =
-    case definition of
-        Type hash fqn ->
+viewDefinitionListing listing =
+    case listing of
+        TypeListing hash fqn ->
             a [ class "node type", onClick (OpenDefinition hash) ]
                 [ UI.Icon.type_
                 , label [] [ text (unqualifiedName fqn) ]
                 ]
 
-        Term hash fqn ->
+        TermListing hash fqn ->
             a [ class "node term", onClick (OpenDefinition hash) ]
                 [ UI.Icon.term
                 , label [] [ text (unqualifiedName fqn) ]
                 ]
 
-        Patch _ ->
+        PatchListing _ ->
             a [ class "node patch" ]
                 [ UI.Icon.patch
                 , label [] [ text "Patch" ]
@@ -284,36 +284,18 @@ viewMainSidebar model =
 
 viewDefinition : Hash -> WebData Definition -> Html Msg
 viewDefinition hash definition =
-    let
-        row headerItems content =
-            div [ class "definition-row" ]
-                [ header [] headerItems, section [ class "content" ] [ content ] ]
-
-        loadedRow title content =
-            row
-                [ div [] [ title ]
-                , a [ class "close", onClick (CloseDefinition hash) ] [ UI.Icon.x ]
-                ]
-                content
-    in
     case definition of
         Success def ->
-            loadedRow (text "base.List") (text (Hash.toString hash))
+            Definition.view (CloseDefinition hash) def
 
         Failure err ->
-            loadedRow (text "Error") (UI.errorMessage (Api.errorToString err))
+            Definition.viewError (CloseDefinition hash) err
 
         NotAsked ->
             UI.nothing
 
         Loading ->
-            row [ UI.loadingPlaceholder ]
-                (div
-                    []
-                    [ div [ class "docs" ] [ UI.loadingPlaceholder ]
-                    , code [] [ UI.loadingPlaceholder, UI.loadingPlaceholder ]
-                    ]
-                )
+            Definition.viewLoading
 
 
 viewOpenDefinitions : OpenDefinitions -> List (Html Msg)

--- a/src/Definition.elm
+++ b/src/Definition.elm
@@ -1,14 +1,95 @@
 module Definition exposing (..)
 
+import FullyQualifiedName exposing (FQN)
+import Hash exposing (Hash)
+import Json.Decode as Decode exposing (andThen, field)
 
-type alias SignaturePart =
-    String
+
+type alias TermSignature =
+    List String
 
 
-type alias Signature =
-    List SignaturePart
+type alias TermBody =
+    List String
+
+
+type alias TypeBody =
+    List String
 
 
 type Definition
-    = Term String Signature
-    | Type String Signature
+    = Term Hash FQN TermSignature TermBody
+    | Type Hash FQN TypeBody
+
+
+
+-- Helpers
+
+
+hash : Definition -> Hash
+hash definition =
+    case definition of
+        Term hash_ _ _ _ ->
+            hash_
+
+        Type hash_ _ _ ->
+            hash_
+
+
+fqn : Definition -> FQN
+fqn definition =
+    case definition of
+        Term _ fqn_ _ _ ->
+            fqn_
+
+        Type _ fqn_ _ ->
+            fqn_
+
+
+unqualifiedName : Definition -> String
+unqualifiedName definition =
+    definition
+        |> fqn
+        |> FullyQualifiedName.unqualifiedName
+
+
+
+-- JSON Decode
+
+
+decodeType : Decode.Decoder Definition
+decodeType =
+    let
+        decodeHash =
+            Decode.map Hash.fromString (field "prefix" Decode.string)
+
+        decodeFqn =
+            Decode.map FullyQualifiedName.fromString (field "prefix" Decode.string)
+    in
+    Decode.map3 Type
+        (Decode.index 0 decodeHash)
+        (Decode.index 0 decodeFqn)
+        (Decode.succeed [])
+
+
+decodeTerm : Decode.Decoder Definition
+decodeTerm =
+    let
+        decodeHash =
+            Decode.map Hash.fromString (field "prefix" Decode.string)
+
+        decodeFqn =
+            Decode.map FullyQualifiedName.fromString (field "prefix" Decode.string)
+    in
+    Decode.map4 Term
+        (Decode.index 0 decodeHash)
+        (Decode.index 0 decodeFqn)
+        (Decode.succeed [])
+        (Decode.succeed [])
+
+
+decodeList : Decode.Decoder (List Definition)
+decodeList =
+    Decode.map2 List.append
+        (field "termDefinitions" (Decode.list decodeTerm))
+        (field "typeDefinitions" (Decode.list decodeType))

--- a/src/FullyQualifiedName.elm
+++ b/src/FullyQualifiedName.elm
@@ -27,9 +27,9 @@ unqualifiedName (FQN nameParts) =
 
 
 
--- JSON Decode
+-- JSON DECODE
 
 
-decode : String -> Decode.Decoder FQN
+decode : Decode.Decoder FQN
 decode =
-    fromString >> Decode.succeed
+    Decode.map fromString Decode.string

--- a/src/FullyQualifiedName.elm
+++ b/src/FullyQualifiedName.elm
@@ -1,5 +1,6 @@
 module FullyQualifiedName exposing (..)
 
+import Json.Decode as Decode
 import List.Nonempty exposing (Nonempty, last)
 
 
@@ -9,8 +10,8 @@ type FQN
 
 {-| Turn a string, like "base.List.map" into FQN ["base", "List", "map"] |
 -}
-fqn : String -> FQN
-fqn rawFqn =
+fromString : String -> FQN
+fromString rawFqn =
     rawFqn
         |> String.split "."
         |> List.map String.trim
@@ -23,3 +24,12 @@ fqn rawFqn =
 unqualifiedName : FQN -> String
 unqualifiedName (FQN nameParts) =
     last nameParts
+
+
+
+-- JSON Decode
+
+
+decode : String -> Decode.Decoder FQN
+decode =
+    fromString >> Decode.succeed

--- a/src/Hash.elm
+++ b/src/Hash.elm
@@ -1,4 +1,6 @@
-module Hash exposing (Hash(..), equals, toString)
+module Hash exposing (Hash, decode, equals, fromString, toString)
+
+import Json.Decode as Decode
 
 
 type Hash
@@ -13,3 +15,17 @@ equals (Hash a) (Hash b) =
 toString : Hash -> String
 toString (Hash raw) =
     raw
+
+
+fromString : String -> Hash
+fromString raw =
+    Hash raw
+
+
+
+-- JSON Decode
+
+
+decode : String -> Decode.Decoder Hash
+decode =
+    fromString >> Decode.succeed

--- a/src/HashSet.elm
+++ b/src/HashSet.elm
@@ -1,6 +1,6 @@
 module HashSet exposing (HashSet, empty, insert, member, remove, toList, toggle)
 
-import Hash exposing (Hash(..))
+import Hash exposing (Hash)
 import Set exposing (Set)
 import Set.Extra
 
@@ -24,27 +24,27 @@ empty =
 
 
 insert : Hash -> HashSet -> HashSet
-insert (Hash raw) (HashSet set) =
-    HashSet (Set.insert raw set)
+insert h (HashSet set) =
+    HashSet (Set.insert (Hash.toString h) set)
 
 
 remove : Hash -> HashSet -> HashSet
-remove (Hash raw) (HashSet set) =
-    HashSet (Set.remove raw set)
+remove h (HashSet set) =
+    HashSet (Set.remove (Hash.toString h) set)
 
 
 member : Hash -> HashSet -> Bool
-member (Hash raw) (HashSet set) =
-    Set.member raw set
+member h (HashSet set) =
+    Set.member (Hash.toString h) set
 
 
 toList : HashSet -> List Hash
 toList (HashSet set) =
     set
         |> Set.toList
-        |> List.map Hash
+        |> List.map Hash.fromString
 
 
 toggle : Hash -> HashSet -> HashSet
-toggle (Hash raw) (HashSet set) =
-    HashSet (Set.Extra.toggle raw set)
+toggle h (HashSet set) =
+    HashSet (Set.Extra.toggle (Hash.toString h) set)

--- a/src/NamespaceListing.elm
+++ b/src/NamespaceListing.elm
@@ -14,9 +14,9 @@ import RemoteData exposing (RemoteData(..), WebData)
 
 
 type DefinitionListing
-    = Type Hash FQN
-    | Term Hash FQN
-    | Patch String
+    = TypeListing Hash FQN
+    | TermListing Hash FQN
+    | PatchListing String
 
 
 type alias NamespaceListingContent =
@@ -45,7 +45,7 @@ decode =
     Decode.map3
         NamespaceListing
         (field "namespaceListingHash" Decode.string |> andThen Hash.decode)
-        (field "namespaceListingName" Decode.string |> andThen FullyQualifiedName.decode)
+        (field "namespaceListingName" FullyQualifiedName.decode)
         -- The main namespace being decoded has children, so we use Success for
         -- the RemoteData. There children of the children however are not yet
         -- fetched
@@ -68,7 +68,7 @@ decodeSubNamespace =
     Decode.map3 NamespaceListing
         -- TODO namespaceName should be namespaceHash
         (field "namespaceName" Decode.string |> andThen Hash.decode)
-        (field "namespaceName" Decode.string |> andThen FullyQualifiedName.decode)
+        (field "namespaceName" FullyQualifiedName.decode)
         (Decode.succeed NotAsked)
         |> andThen (SubNamespace >> Decode.succeed)
 
@@ -76,13 +76,13 @@ decodeSubNamespace =
 decodeSubDefinition : Decode.Decoder DecodedNamespaceChild
 decodeSubDefinition =
     Decode.oneOf
-        [ Decode.map2 Type
+        [ Decode.map2 TypeListing
             (field "typeHash" Decode.string |> andThen Hash.decode)
-            (field "typeName" Decode.string |> andThen FullyQualifiedName.decode)
-        , Decode.map2 Term
+            (field "typeName" FullyQualifiedName.decode)
+        , Decode.map2 TermListing
             (field "termHash" Decode.string |> andThen Hash.decode)
-            (field "termName" Decode.string |> andThen FullyQualifiedName.decode)
-        , Decode.map Patch (field "patchName" Decode.string)
+            (field "termName" FullyQualifiedName.decode)
+        , Decode.map PatchListing (field "patchName" Decode.string)
         ]
         |> andThen (SubDefinition >> Decode.succeed)
 

--- a/src/OpenDefinitions.elm
+++ b/src/OpenDefinitions.elm
@@ -1,0 +1,99 @@
+module OpenDefinitions exposing (OpenDefinitions, definitions, empty, fromList, hashes, insert, insertList, loading, update)
+
+import Definition exposing (Definition)
+import Hash exposing (Hash)
+import OrderedDict exposing (OrderedDict)
+import RemoteData exposing (WebData)
+
+
+
+{-
+   OpenDefinitions is the main data structure for working with definitions in
+   the Workspace area. It wraps an OrderedDirect (Hash to Definition), but is
+   opaque to that underlying data structure and only exposes a few key APIs,
+   including a few convenience functions for working with, loading and opening
+   Definitions.
+-}
+
+
+type OpenDefinitions
+    = OpenDefinitions (OrderedDict String (WebData Definition))
+
+
+
+-- Build
+
+
+empty : OpenDefinitions
+empty =
+    OpenDefinitions OrderedDict.empty
+
+
+loading : List Hash -> OpenDefinitions
+loading list =
+    list
+        |> List.map (\h -> ( h, RemoteData.Loading ))
+        |> fromList
+
+
+fromList : List ( Hash, WebData Definition ) -> OpenDefinitions
+fromList list =
+    list
+        |> List.map (\( h, d ) -> ( Hash.toString h, d ))
+        |> OrderedDict.fromList
+        |> OpenDefinitions
+
+
+update : Hash -> (Maybe (WebData Definition) -> Maybe (WebData Definition)) -> OpenDefinitions -> OpenDefinitions
+update h f (OpenDefinitions dict) =
+    OpenDefinitions (OrderedDict.update (Hash.toString h) f dict)
+
+
+insert : Hash -> WebData Definition -> OpenDefinitions -> OpenDefinitions
+insert h definition (OpenDefinitions dict) =
+    OpenDefinitions (OrderedDict.insert (Hash.toString h) definition dict)
+
+
+insertBefore : Hash -> Hash -> WebData Definition -> OpenDefinitions -> OpenDefinitions
+insertBefore beforeHash insertHash definition (OpenDefinitions dict) =
+    -- TODO
+    OpenDefinitions dict
+
+
+insertList : List ( Hash, WebData Definition ) -> OpenDefinitions -> OpenDefinitions
+insertList list openDefinitions =
+    let
+        inserter ( h, d ) acc =
+            insert h d acc
+    in
+    List.foldl inserter openDefinitions list
+
+
+remove : Hash -> OpenDefinitions -> OpenDefinitions
+remove h (OpenDefinitions dict) =
+    OpenDefinitions (OrderedDict.remove (Hash.toString h) dict)
+
+
+
+-- Query
+
+
+get : Hash -> OpenDefinitions -> Maybe (WebData Definition)
+get h (OpenDefinitions dict) =
+    OrderedDict.get (Hash.toString h) dict
+
+
+
+-- Conversions
+
+
+hashes : OpenDefinitions -> List Hash
+hashes (OpenDefinitions dict) =
+    dict
+        |> OrderedDict.keys
+        |> List.map Hash.fromString
+
+
+definitions : OpenDefinitions -> List (WebData Definition)
+definitions (OpenDefinitions dict) =
+    OrderedDict.values dict

--- a/src/OpenDefinitions.elm
+++ b/src/OpenDefinitions.elm
@@ -1,4 +1,4 @@
-module OpenDefinitions exposing (OpenDefinitions, definitions, empty, fromList, hashes, insert, insertList, loading, update)
+module OpenDefinitions exposing (OpenDefinitions, definitions, empty, fromList, hashes, insert, insertList, loading, remove, toList, update)
 
 import Definition exposing (Definition)
 import Hash exposing (Hash)
@@ -97,3 +97,10 @@ hashes (OpenDefinitions dict) =
 definitions : OpenDefinitions -> List (WebData Definition)
 definitions (OpenDefinitions dict) =
     OrderedDict.values dict
+
+
+toList : OpenDefinitions -> List ( Hash, WebData Definition )
+toList (OpenDefinitions dict) =
+    dict
+        |> OrderedDict.toList
+        |> List.map (\( h, d ) -> ( Hash.fromString h, d ))

--- a/src/UI.elm
+++ b/src/UI.elm
@@ -14,6 +14,16 @@ spinner =
     div [ class "spinner" ] [ text "Loading..." ]
 
 
+type Sizing
+    = Base
+    | Medium
+
+
+loadingPlaceholder : Html msg
+loadingPlaceholder =
+    div [ class "loading-placeholder" ] []
+
+
 errorMessage : String -> Html msg
 errorMessage message =
     div [ class "error-message" ] [ text message ]

--- a/src/UI.elm
+++ b/src/UI.elm
@@ -12,3 +12,8 @@ nothing =
 spinner : Html msg
 spinner =
     div [ class "spinner" ] [ text "Loading..." ]
+
+
+errorMessage : String -> Html msg
+errorMessage message =
+    div [ class "error-message" ] [ text message ]

--- a/src/UI/Icon.elm
+++ b/src/UI/Icon.elm
@@ -1,6 +1,6 @@
 module UI.Icon exposing (..)
 
-import Html exposing (Html, div, i, text)
+import Html exposing (Html, i)
 import Html.Attributes exposing (class)
 
 
@@ -17,3 +17,28 @@ caretRight =
 caretDown : Html msg
 caretDown =
     icon "caret-down"
+
+
+namespace : Html msg
+namespace =
+    icon "box"
+
+
+term : Html msg
+term =
+    icon "code"
+
+
+patch : Html msg
+patch =
+    icon "directions"
+
+
+type_ : Html msg
+type_ =
+    icon "border-none"
+
+
+ability : Html msg
+ability =
+    icon "brackets-curly"

--- a/src/UI/Icon.elm
+++ b/src/UI/Icon.elm
@@ -19,6 +19,11 @@ caretDown =
     icon "caret-down"
 
 
+x : Html msg
+x =
+    icon "times"
+
+
 namespace : Html msg
 namespace =
     icon "box"

--- a/src/Util.elm
+++ b/src/Util.elm
@@ -1,0 +1,22 @@
+module Util exposing (..)
+
+import Json.Decode as Decode
+import List.Nonempty as NEL
+
+
+
+-- Various utility functions and helpers
+
+
+decodeNonEmptyList : Decode.Decoder a -> Decode.Decoder (NEL.Nonempty a)
+decodeNonEmptyList =
+    Decode.list
+        >> Decode.andThen
+            (\list ->
+                case NEL.fromList list of
+                    Just nel ->
+                        Decode.succeed nel
+
+                    Nothing ->
+                        Decode.fail "Decoded an empty list"
+            )


### PR DESCRIPTION
## Overview
This adds initial fetch of definitions

<img width="1698" alt="Screen Shot 2021-02-12 at 16 15 48" src="https://user-images.githubusercontent.com/2371/107823901-8f100300-6d4e-11eb-89f2-d067134617b9.png">

## Implementation notes
Add a new type: `OpenDefinitions` that tracks the state of the
`Definitions` open in the workspace area. It's an opaque wrapper around
an `OrderedMap` from `Hash` `WebData Definition`.

Add `OpenDefinitions` to `App` and use it to fetch `Definitions` by
`Hash`, render a loading indicator for each Definition being fetched
(correctly positioned due to the wrapped `OrderedMap`) and render a
placeholder for when the data is returned from the server.

Additionally, clean up the UI and Icons a little and make `Hash` opaque.

Would love some thoughts on that!