### PR TITLE
Add Code: Decode syntax into Code and highlight

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -12,6 +12,7 @@
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/url": "1.0.0",
+            "elm-community/json-extra": "4.3.0",
             "krisajenkins/remotedata": "6.0.1",
             "mgold/elm-nonempty-list": "4.1.0",
             "stoeffel/set-extra": "1.2.3",
@@ -20,9 +21,11 @@
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
+            "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         }
     },
     "test-dependencies": {

--- a/public/main.css
+++ b/public/main.css
@@ -84,6 +84,17 @@ li {
   --color-workspace-highlight-fg: var(--color-blue-base);
   --color-workspace-highlight-bg: var(--color-blue-base);
   --color-workspace-highlight-border: var(--color-blue-base);
+
+  /* -- Default Syntax Theme ------------------------------------------------*/
+
+  --color-syntax-plain: var(--color-main-fg);
+  --color-syntax-subtle: var(--color-main-subtle-fg);
+  --color-syntax-keyword: #225ebe;
+  --color-syntax-operator: #c7474e;
+  --color-syntax-name: #6848ba;
+  --color-syntax-type: #225ebe;
+  --color-syntax-variant: #438443;
+  --color-syntax-text: #438443;
 }
 
 /* -- Global --------------------------------------------------------------- */
@@ -111,9 +122,156 @@ a:hover {
   color: var(--color-main-highlight-fg);
 }
 
+pre {
+  margin: 0;
+}
+
 code {
   display: inline-block;
   font-family: "Roboto Mono", monospace;
+}
+
+/* -- Syntax --------------------------------------------------------------- */
+
+.builtin {
+  color: var(--color-syntax-keyword);
+}
+
+.comment {
+  color: var(--color-syntax-subtle);
+}
+
+.numberic-literal {
+  color: var(--color-syntax-name);
+}
+
+.text-literal {
+  color: var(--color-syntax-text);
+}
+
+.bytes-literal {
+  color: var(--color-syntax-text);
+}
+
+.char-literal {
+  color: var(--color-syntax-text);
+}
+
+.boolean-literal {
+  color: var(--color-syntax-variant);
+}
+
+.blank {
+  color: var(--color-syntax-base);
+}
+
+.var {
+  color: var(--color-syntax-base);
+}
+
+.reference {
+  color: var(--color-syntax-name);
+}
+
+.referent {
+  color: var(--color-syntax-name);
+}
+
+.op.cons {
+  color: var(--color-syntax-operator);
+}
+
+.op.snoc {
+  color: var(--color-syntax-operator);
+}
+
+.op.concat {
+  color: var(--color-syntax-operator);
+}
+
+.constructor {
+  color: var(--color-syntax-variant);
+}
+
+.request {
+  color: var(--color-syntax-name);
+}
+
+.ability-braces {
+  color: var(--color-syntax-subtle);
+}
+
+.control-keyword {
+  color: var(--color-syntax-keyword);
+}
+
+.type-operator {
+  color: var(--color-syntax-operator);
+}
+
+.binding-equals {
+  color: var(--color-syntax-subtle);
+}
+
+.type-ascription-colon {
+  color: var(--color-syntax-operator);
+}
+
+.data-type-keyword {
+  color: var(--color-syntax-keyword);
+}
+
+.data-type-params {
+  color: var(--color-syntax-plain);
+}
+
+.unit {
+  color: var(--color-syntax-subtle);
+}
+
+.data-type-modifier {
+  color: var(--color-syntax-operator);
+}
+
+.use-keyword {
+  color: var(--color-syntax-keyword);
+}
+
+.use-prefix {
+  color: var(--color-syntax-name);
+}
+
+.use-suffix {
+  color: var(--color-syntax-variant);
+}
+
+.hash-qualifier {
+  color: var(--color-syntax-name);
+}
+
+.delay-force-char {
+  color: var(--color-syntax-operator);
+  font-weight: bold;
+}
+
+.delimeter-char {
+  color: var(--color-syntax-subtle);
+}
+
+.parenthesis {
+  color: var(--color-syntax-subtle);
+}
+
+.link-keyword {
+  color: var(--color-syntax-keyword);
+}
+
+.doc-delimeter {
+  color: var(--color-syntax-subtle);
+}
+
+.doc-keyword {
+  color: var(--color-syntax-keyword);
 }
 
 /* -- UI ------------------------------------------------------------------- */

--- a/src/Code.elm
+++ b/src/Code.elm
@@ -1,0 +1,391 @@
+module Code exposing (Code, SyntaxSegment(..), SyntaxType(..), decode, decodeSyntax, view)
+
+import Hash exposing (Hash)
+import Html exposing (Html, a, article, aside, button, code, div, h1, h2, h3, header, input, label, nav, pre, section, span, text)
+import Html.Attributes exposing (class, id, placeholder, type_, value)
+import Html.Events exposing (onClick, onInput)
+import Json.Decode as Decode exposing (andThen, at, field)
+import Json.Decode.Extra exposing (when)
+import List.Nonempty as NEL
+import Util
+
+
+type Code
+    = Builtin
+    | Syntax (NEL.Nonempty SyntaxSegment)
+
+
+type SyntaxSegment
+    = SyntaxSegment SyntaxType String
+
+
+type SeqOp
+    = Cons
+    | Snoc
+    | Concat
+
+
+type HashQualified
+    = NameOnly String
+    | HashOnly Hash
+    | HashQualified String Hash
+
+
+type SyntaxType
+    = NumericLiteral
+    | TextLiteral
+    | BytesLiteral
+    | CharLiteral
+    | BooleanLiteral
+    | Blank
+    | Var
+    | Reference Hash
+    | Referent Hash
+      -- +:|:+|++
+    | Op SeqOp
+    | Constructor
+      -- Ability constructor
+    | Request
+    | AbilityBraces
+      -- let|handle|in|where|match|with|cases|->|if|then|else|and|or
+    | ControlKeyword
+      -- forall|->
+    | TypeOperator
+    | BindingEquals
+    | TypeAscriptionColon
+      -- type|ability
+    | DataTypeKeyword
+    | DataTypeParams
+    | Unit
+      -- unique
+    | DataTypeModifier
+      -- `use Foo bar` is keyword, prefix, suffix
+    | UseKeyword
+    | UsePrefix
+    | UseSuffix
+    | HashQualifier HashQualified
+      -- ! '
+    | DelayForceChar
+      -- ? , ` [ ] @ |
+      -- Currently not all commas in the pretty-print output are marked up as DelimiterChar - we miss
+      -- out characters emitted by Pretty.hs helpers like Pretty.commas.
+    | DelimiterChar
+    | Parenthesis
+    | LinkKeyword -- `typeLink` and `termLink`
+      -- [: :] @[]
+    | DocDelimiter
+      -- the 'include' in @[include], etc
+    | DocKeyword
+
+
+
+-- VIEW
+
+
+syntaxTypeToClassName : SyntaxType -> String
+syntaxTypeToClassName sType =
+    case sType of
+        NumericLiteral ->
+            "numberic-literal"
+
+        TextLiteral ->
+            "text-literal"
+
+        BytesLiteral ->
+            "bytes-literal"
+
+        CharLiteral ->
+            "char-literal"
+
+        BooleanLiteral ->
+            "boolean-literal"
+
+        Blank ->
+            "blank"
+
+        Var ->
+            "var"
+
+        Reference _ ->
+            "reference"
+
+        Referent _ ->
+            "referent"
+
+        Op seqOp ->
+            case seqOp of
+                Cons ->
+                    "op cons"
+
+                Snoc ->
+                    "op snoc"
+
+                Concat ->
+                    "op concat"
+
+        Constructor ->
+            "constructor"
+
+        Request ->
+            "request"
+
+        AbilityBraces ->
+            "ability-braces"
+
+        ControlKeyword ->
+            "control-keyword"
+
+        TypeOperator ->
+            "type-operator"
+
+        BindingEquals ->
+            "binding-equals"
+
+        TypeAscriptionColon ->
+            "type-ascription-colon"
+
+        DataTypeKeyword ->
+            "data-type-keyword"
+
+        DataTypeParams ->
+            "data-type-params"
+
+        Unit ->
+            "unit"
+
+        DataTypeModifier ->
+            "data-type-modifier"
+
+        UseKeyword ->
+            "use-keyword"
+
+        UsePrefix ->
+            "use-prefix"
+
+        UseSuffix ->
+            "use-suffix"
+
+        HashQualifier _ ->
+            "hash-qualifier"
+
+        DelayForceChar ->
+            "delay-force-char"
+
+        DelimiterChar ->
+            "delimeter-char"
+
+        Parenthesis ->
+            "parenthesis"
+
+        LinkKeyword ->
+            "link-keyword"
+
+        DocDelimiter ->
+            "doc-delimeter"
+
+        DocKeyword ->
+            "doc-keyword"
+
+
+viewSegment : SyntaxSegment -> Html msg
+viewSegment (SyntaxSegment sType sText) =
+    span [ class (syntaxTypeToClassName sType) ] [ text sText ]
+
+
+viewSyntaxSegments : NEL.Nonempty SyntaxSegment -> List (Html msg)
+viewSyntaxSegments segments =
+    segments
+        |> NEL.map viewSegment
+        |> NEL.toList
+
+
+view : Code -> Html msg
+view code_ =
+    let
+        content =
+            case code_ of
+                Syntax segments ->
+                    viewSyntaxSegments segments
+
+                Builtin ->
+                    [ span [ class "builtin" ] [ text "Builtin" ] ]
+    in
+    pre [] [ code [] content ]
+
+
+
+-- JSON DECODE
+
+
+simpleSyntaxTypeFromString : String -> SyntaxType
+simpleSyntaxTypeFromString rawType =
+    case rawType of
+        "NumericLiteral" ->
+            NumericLiteral
+
+        "TextLiteral" ->
+            TextLiteral
+
+        "BytesLiteral" ->
+            BytesLiteral
+
+        "CharLiteral" ->
+            CharLiteral
+
+        "BooleanLiteral" ->
+            BooleanLiteral
+
+        "Blank" ->
+            Blank
+
+        "Var" ->
+            Var
+
+        "Constructor" ->
+            Constructor
+
+        "Request" ->
+            Request
+
+        "AbilityBraces" ->
+            AbilityBraces
+
+        "ControlKeyword" ->
+            ControlKeyword
+
+        "TypeOperator" ->
+            TypeOperator
+
+        "BindingEquals" ->
+            BindingEquals
+
+        "TypeAscriptionColon" ->
+            TypeAscriptionColon
+
+        "DataTypeKeyword" ->
+            DataTypeKeyword
+
+        "DataTypeParams" ->
+            DataTypeParams
+
+        "Unit" ->
+            Unit
+
+        "DataTypeModifier" ->
+            DataTypeModifier
+
+        "UseKeyword" ->
+            UseKeyword
+
+        "UsePrefix" ->
+            UsePrefix
+
+        "UseSuffix" ->
+            UseSuffix
+
+        "DelayForceChar" ->
+            DelayForceChar
+
+        "DelimiterChar" ->
+            DelimiterChar
+
+        "Parenthesis" ->
+            Parenthesis
+
+        "LinkKeyword" ->
+            LinkKeyword
+
+        "DocDelimiter" ->
+            DocDelimiter
+
+        "DocKeyword" ->
+            DocKeyword
+
+        _ ->
+            Blank
+
+
+decodeOp : Decode.Decoder SyntaxType
+decodeOp =
+    let
+        decodeOpTag =
+            at [ "annotation", "contents", "tag" ] Decode.string
+    in
+    Decode.map
+        Op
+        (Decode.oneOf
+            [ when decodeOpTag ((==) "Cons") (Decode.succeed Cons)
+            , when decodeOpTag ((==) "Snoc") (Decode.succeed Snoc)
+            , when decodeOpTag ((==) "Concat") (Decode.succeed Concat)
+            ]
+        )
+
+
+decodeHashQualifier : Decode.Decoder SyntaxType
+decodeHashQualifier =
+    let
+        decodeHashQualifierTag =
+            at [ "annotation", "contents", "tag" ] Decode.string
+
+        decodeNameOnly =
+            Decode.map NameOnly (at [ "annotation", "contents", "contents", "toText" ] Decode.string)
+
+        decodeHashOnly =
+            Decode.map HashOnly (at [ "annotation", "contents", "contents" ] Decode.string |> andThen Hash.decode)
+
+        decodeHashQualified =
+            Decode.map2
+                HashQualified
+                (at [ "annotation", "contents", "contents", "toText" ] (Decode.index 0 Decode.string))
+                (at [ "annotation", "contents", "contents" ] (Decode.index 1 Decode.string |> andThen Hash.decode))
+    in
+    Decode.map
+        HashQualifier
+        (Decode.oneOf
+            [ when decodeHashQualifierTag ((==) "NameOnly") decodeNameOnly
+            , when decodeHashQualifierTag ((==) "HashOnly") decodeHashOnly
+            , when decodeHashQualifierTag ((==) "HashQualified") decodeHashQualified
+            ]
+        )
+
+
+decodeTag : Decode.Decoder String
+decodeTag =
+    Decode.oneOf
+        [ at [ "annotation", "tag" ] Decode.string
+        , Decode.succeed "Blank"
+        ]
+
+
+decodeSyntaxSegment : Decode.Decoder SyntaxSegment
+decodeSyntaxSegment =
+    let
+        decodeReferent =
+            Decode.map Referent (at [ "annotation", "contents" ] Decode.string |> andThen Hash.decode)
+
+        decodeReference =
+            Decode.map Reference (at [ "annotation", "contents" ] Decode.string |> andThen Hash.decode)
+    in
+    Decode.map2 SyntaxSegment
+        (Decode.oneOf
+            [ when decodeTag ((==) "Referent") decodeReferent
+            , when decodeTag ((==) "Reference") decodeReference
+            , when decodeTag ((==) "Op") decodeOp
+            , when decodeTag ((==) "HashQualifier") decodeHashQualifier
+            , decodeTag |> andThen (simpleSyntaxTypeFromString >> Decode.succeed)
+            ]
+        )
+        (field "segment" Decode.string)
+
+
+decodeSyntax : Decode.Decoder Code
+decodeSyntax =
+    Decode.map Syntax (Util.decodeNonEmptyList decodeSyntaxSegment)
+
+
+decode : Decode.Decoder Code
+decode =
+    Decode.oneOf
+        [ field "contents" decodeSyntax
+        , Decode.succeed Builtin
+        ]

--- a/src/Definition.elm
+++ b/src/Definition.elm
@@ -1,13 +1,14 @@
 module Definition exposing (..)
 
 import Api
+import Code exposing (Code)
 import FullyQualifiedName exposing (FQN)
 import Hash exposing (Hash)
 import Html exposing (Html, a, article, aside, button, code, div, h1, h2, h3, header, input, label, nav, section, span, text)
 import Html.Attributes exposing (class, id, placeholder, type_, value)
 import Html.Events exposing (onClick, onInput)
 import Http
-import Json.Decode as Decode exposing (andThen, field)
+import Json.Decode as Decode exposing (andThen, at, field)
 import List.Nonempty as NEL
 import UI
 import UI.Icon
@@ -18,30 +19,18 @@ import Util
 -- TYPES
 
 
-type alias Syntax =
-    List String
-
-
-type alias SignatureSyntax =
-    Syntax
-
-
-type alias DefinitionSyntax =
-    Syntax
-
-
 type alias TypeDefinitionInfo =
     { fqns : NEL.Nonempty FQN
     , name : String
-    , definition : Syntax
+    , definition : Code
     }
 
 
 type alias TermDefinitionInfo =
     { fqns : NEL.Nonempty FQN
     , name : String
-    , definition : Syntax
-    , signature : SignatureSyntax
+    , definition : Code
+    , signature : Code
     }
 
 
@@ -107,8 +96,8 @@ view closeMsg definition =
                 closeMsg
                 (div [] [ text info.name ])
                 (div []
-                    [ div [ class "docs" ] [ text "todo docs" ]
-                    , code [] [ text "todo code" ]
+                    [ -- div [ class "docs" ] [ text "todo docs" ]
+                      Code.view info.definition
                     ]
                 )
     in
@@ -129,7 +118,7 @@ decodeTypeDefInfo =
     Decode.map3 TypeDefinitionInfo
         (field "typeNames" (Util.decodeNonEmptyList FullyQualifiedName.decode))
         (field "bestTypeName" Decode.string)
-        (Decode.succeed [])
+        (field "typeDefinition" Code.decode)
 
 
 decodeTypes : Decode.Decoder (List Definition)
@@ -146,8 +135,8 @@ decodeTermDefInfo =
     Decode.map4 TermDefinitionInfo
         (field "termNames" (Util.decodeNonEmptyList FullyQualifiedName.decode))
         (field "bestTermName" Decode.string)
-        (Decode.succeed [])
-        (Decode.succeed [])
+        (field "termDefinition" Code.decode)
+        (field "signature" Code.decodeSyntax)
 
 
 decodeTerms : Decode.Decoder (List Definition)


### PR DESCRIPTION
## Overview
Add a new data type: `Code`, for viewing the syntax highlighted source
code of `Definitions` (with `Builtin` handled).

<img width="1202" alt="Screen Shot 2021-02-17 at 10 21 56" src="https://user-images.githubusercontent.com/2371/108225863-55524a00-710a-11eb-8983-0b3179b01434.png">

## Implementation notes
Mostly mirrors the `Element` type from the backend `Syntax` module.

## Loose ends
* @runarorama It looks like the `HashQualified` variants of `HashOnly` and `HashQualified` will return a `ShortHash` as opposed to a string. Is it possible to get these to strings like we have elsewhere? (I don't know how easy it is to change this so deep in the data structure).  
* There's certainly improvements to be made for theming with separate CSS files etc, but I decided it was out of scope for now.
