### PR TITLE
Improve rendering of builtin types and terms

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -134,7 +134,8 @@ code {
 /* -- Syntax --------------------------------------------------------------- */
 
 .builtin {
-  color: var(--color-syntax-keyword);
+  color: var(--color-syntax-base);
+  font-style: italic;
 }
 
 .comment {
@@ -230,7 +231,7 @@ code {
 }
 
 .data-type-modifier {
-  color: var(--color-syntax-operator);
+  color: var(--color-syntax-name);
 }
 
 .use-keyword {

--- a/src/Source.elm
+++ b/src/Source.elm
@@ -1,0 +1,61 @@
+module Source exposing (TermSource(..), TypeSignature(..), TypeSource(..), viewTermSource, viewTypeSource)
+
+import Html exposing (Html, span, text)
+import Html.Attributes exposing (class)
+import Syntax exposing (Syntax)
+import UI
+
+
+type TypeSource
+    = TypeSource Syntax
+    | BuiltinType
+
+
+type TypeSignature
+    = TypeSignature Syntax
+
+
+type TermSource
+    = TermSource Syntax
+    | BuiltinTerm TypeSignature
+
+
+viewTypeSource : TypeSource -> Html msg
+viewTypeSource source =
+    let
+        content =
+            case source of
+                TypeSource syntax ->
+                    Syntax.view syntax
+
+                BuiltinType ->
+                    span
+                        []
+                        [ span [ class "builtin" ] [ text "builtin " ]
+                        , span [ class "data-type-keyword" ] [ text "type" ]
+                        ]
+    in
+    UI.codeBlock content
+
+
+viewTermSource : String -> TermSource -> Html msg
+viewTermSource termName source =
+    let
+        content =
+            case source of
+                TermSource syntax ->
+                    Syntax.view syntax
+
+                BuiltinTerm (TypeSignature syntax) ->
+                    span
+                        []
+                        [ span [ class "hash-qualifier" ] [ text termName ]
+                        , span [ class "type-ascription-colon" ] [ text " : " ]
+                        , Syntax.view syntax
+                        , span [ class "blank" ] [ text "\n" ]
+                        , span [ class "hash-qualifier" ] [ text termName ]
+                        , span [ class "binding-equals" ] [ text " = " ]
+                        , span [ class "builtin" ] [ text "builtin" ]
+                        ]
+    in
+    UI.codeBlock content

--- a/src/UI.elm
+++ b/src/UI.elm
@@ -1,6 +1,6 @@
 module UI exposing (..)
 
-import Html exposing (Html, div, i, text)
+import Html exposing (Html, code, div, i, pre, text)
 import Html.Attributes exposing (class)
 
 
@@ -27,3 +27,13 @@ loadingPlaceholder =
 errorMessage : String -> Html msg
 errorMessage message =
     div [ class "error-message" ] [ text message ]
+
+
+codeInline : Html msg -> Html msg
+codeInline content =
+    code [] [ content ]
+
+
+codeBlock : Html msg -> Html msg
+codeBlock content =
+    pre [] [ code [] [ content ] ]


### PR DESCRIPTION
## Overview
Add a new `Source` module for working with `TermSource` or `TypeSource`,
both wrapping `Syntax` (previously `Code`).

<img width="1146" alt="Screen Shot 2021-02-18 at 12 40 17" src="https://user-images.githubusercontent.com/2371/108407755-26170800-71f2-11eb-8b05-5d6f8cee9e55.png">

## Loose ends
Depends on https://github.com/unisonweb/codebase-ui/pull/5

@pchiusano thoughts on this way to render the builtin terms with like half of a function body?
