### PR TITLE
Open definitions from definitions

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,6 +14,7 @@
             "elm/svg": "1.0.1",
             "elm/url": "1.0.0",
             "elm-community/json-extra": "4.3.0",
+            "elm-community/list-extra": "8.2.4",
             "krisajenkins/remotedata": "6.0.1",
             "mgold/elm-nonempty-list": "4.1.0",
             "stoeffel/set-extra": "1.2.3",

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -141,6 +141,10 @@ code {
   font-family: var(--font-monospace);
 }
 
+code a:hover {
+  text-decoration: underline;
+}
+
 /* -- Syntax --------------------------------------------------------------- */
 
 .builtin {

--- a/src/Definition.elm
+++ b/src/Definition.elm
@@ -88,8 +88,8 @@ viewLoading =
         )
 
 
-view : msg -> Definition -> Html msg
-view closeMsg definition =
+view : msg -> (Hash -> msg) -> Definition -> Html msg
+view closeMsg toOpenReferenceMsg definition =
     let
         viewDefinitionInfo info source =
             viewClosableRow
@@ -99,10 +99,10 @@ view closeMsg definition =
     in
     case definition of
         Term _ info ->
-            viewDefinitionInfo info (viewTermSource info.name info.source)
+            viewDefinitionInfo info (viewTermSource toOpenReferenceMsg info.name info.source)
 
         Type _ info ->
-            viewDefinitionInfo info (viewTypeSource info.source)
+            viewDefinitionInfo info (viewTypeSource toOpenReferenceMsg info.source)
 
 
 

--- a/src/Source.elm
+++ b/src/Source.elm
@@ -1,5 +1,6 @@
 module Source exposing (TermSource(..), TypeSignature(..), TypeSource(..), viewTermSource, viewTypeSource)
 
+import Hash exposing (Hash)
 import Html exposing (Html, span, text)
 import Html.Attributes exposing (class)
 import Syntax exposing (Syntax)
@@ -20,13 +21,13 @@ type TermSource
     | BuiltinTerm TypeSignature
 
 
-viewTypeSource : TypeSource -> Html msg
-viewTypeSource source =
+viewTypeSource : (Hash -> msg) -> TypeSource -> Html msg
+viewTypeSource toReferenceClickMsg source =
     let
         content =
             case source of
                 TypeSource syntax ->
-                    Syntax.view syntax
+                    Syntax.view toReferenceClickMsg syntax
 
                 BuiltinType ->
                     span
@@ -38,20 +39,20 @@ viewTypeSource source =
     UI.codeBlock content
 
 
-viewTermSource : String -> TermSource -> Html msg
-viewTermSource termName source =
+viewTermSource : (Hash -> msg) -> String -> TermSource -> Html msg
+viewTermSource toReferenceClickMsg termName source =
     let
         content =
             case source of
                 TermSource syntax ->
-                    Syntax.view syntax
+                    Syntax.view toReferenceClickMsg syntax
 
                 BuiltinTerm (TypeSignature syntax) ->
                     span
                         []
                         [ span [ class "hash-qualifier" ] [ text termName ]
                         , span [ class "type-ascription-colon" ] [ text " : " ]
-                        , Syntax.view syntax
+                        , Syntax.view toReferenceClickMsg syntax
                         , span [ class "blank" ] [ text "\n" ]
                         , span [ class "hash-qualifier" ] [ text termName ]
                         , span [ class "binding-equals" ] [ text " = " ]

--- a/src/Syntax.elm
+++ b/src/Syntax.elm
@@ -186,17 +186,37 @@ syntaxTypeToClassName sType =
             "doc-keyword"
 
 
-viewSegment : SyntaxSegment -> Html msg
-viewSegment (SyntaxSegment sType sText) =
-    span [ class (syntaxTypeToClassName sType) ] [ text sText ]
+viewSegment : (Hash -> msg) -> SyntaxSegment -> Html msg
+viewSegment toReferenceClickMsg (SyntaxSegment sType sText) =
+    let
+        hash =
+            case sType of
+                Reference h ->
+                    Just h
+
+                Referent h ->
+                    Just h
+
+                _ ->
+                    Nothing
+
+        className =
+            syntaxTypeToClassName sType
+    in
+    case hash of
+        Just h ->
+            a [ class className, onClick (toReferenceClickMsg h) ] [ text sText ]
+
+        Nothing ->
+            span [ class className ] [ text sText ]
 
 
-view : Syntax -> Html msg
-view (Syntax segments) =
+view : (Hash -> msg) -> Syntax -> Html msg
+view toReferenceClickMsg (Syntax segments) =
     let
         renderedSegments =
             segments
-                |> NEL.map viewSegment
+                |> NEL.map (viewSegment toReferenceClickMsg)
                 |> NEL.toList
     in
     span [ class "syntax" ] renderedSegments

--- a/tests/OpenDefinitionsTests.elm
+++ b/tests/OpenDefinitionsTests.elm
@@ -1,0 +1,156 @@
+module OpenDefinitionsTests exposing (..)
+
+import Debug
+import Expect exposing (Expectation)
+import Fuzz exposing (Fuzzer, int, list, string)
+import Hash
+import OpenDefinitions exposing (..)
+import RemoteData exposing (RemoteData(..))
+import Test exposing (..)
+
+
+equalKeys : OpenDefinitions -> OpenDefinitions -> Bool
+equalKeys a b =
+    let
+        keys =
+            OpenDefinitions.toList >> List.map (Tuple.first >> Hash.toString)
+    in
+    keys a == keys b
+
+
+insertAfter : Test
+insertAfter =
+    let
+        afterHash =
+            Hash.fromString "#afterHash"
+
+        insertHash =
+            Hash.fromString "#insertHash"
+    in
+    describe "OpenDefinitions.insertAfter"
+        [ test "Inserts a definition after a Hash" <|
+            \_ ->
+                let
+                    original =
+                        OpenDefinitions.fromList
+                            [ ( Hash.fromString "#foo", NotAsked )
+                            , ( afterHash, NotAsked )
+                            , ( Hash.fromString "#bar", NotAsked )
+                            ]
+
+                    expected =
+                        OpenDefinitions.fromList
+                            [ ( Hash.fromString "#foo", NotAsked )
+                            , ( afterHash, NotAsked )
+                            , ( insertHash, NotAsked )
+                            , ( Hash.fromString "#bar", NotAsked )
+                            ]
+
+                    result =
+                        OpenDefinitions.insertAfter afterHash ( insertHash, NotAsked ) original
+                in
+                Expect.true "keys are equal" (equalKeys expected result)
+        , test "When the Hash is missing from OpenDefinitions, insert at the end" <|
+            \_ ->
+                let
+                    original =
+                        OpenDefinitions.fromList
+                            [ ( Hash.fromString "#foo", NotAsked )
+                            , ( Hash.fromString "#bar", NotAsked )
+                            ]
+
+                    expected =
+                        OpenDefinitions.fromList
+                            [ ( Hash.fromString "#foo", NotAsked )
+                            , ( Hash.fromString "#bar", NotAsked )
+                            , ( insertHash, NotAsked )
+                            ]
+
+                    result =
+                        OpenDefinitions.insertAfter afterHash ( insertHash, NotAsked ) original
+                in
+                Expect.true "keys are equals" (equalKeys expected result)
+        , test "When the definition already exists in OpenDefinitions, replace after the Hash" <|
+            \_ ->
+                let
+                    original =
+                        OpenDefinitions.fromList
+                            [ ( insertHash, NotAsked )
+                            , ( Hash.fromString "#foo", NotAsked )
+                            , ( afterHash, NotAsked )
+                            , ( Hash.fromString "#bar", NotAsked )
+                            ]
+
+                    expected =
+                        OpenDefinitions.fromList
+                            [ ( Hash.fromString "#foo", NotAsked )
+                            , ( afterHash, NotAsked )
+                            , ( insertHash, NotAsked )
+                            , ( Hash.fromString "#bar", NotAsked )
+                            ]
+
+                    result =
+                        OpenDefinitions.insertAfter afterHash ( insertHash, NotAsked ) original
+                in
+                Expect.true "keys equals" (equalKeys expected result)
+        , test "When the Hash is missing and the Definition already exists in OpenDefinitions, replace at the end" <|
+            \_ ->
+                let
+                    original =
+                        OpenDefinitions.fromList
+                            [ ( Hash.fromString "#foo", NotAsked )
+                            , ( insertHash, NotAsked )
+                            , ( Hash.fromString "#bar", NotAsked )
+                            ]
+
+                    expected =
+                        OpenDefinitions.fromList
+                            [ ( Hash.fromString "#foo", NotAsked )
+                            , ( Hash.fromString "#bar", NotAsked )
+                            , ( insertHash, NotAsked )
+                            ]
+
+                    result =
+                        OpenDefinitions.insertAfter afterHash ( insertHash, NotAsked ) original
+                in
+                Expect.true "keys equals" (equalKeys expected result)
+        ]
+
+
+replace : Test
+replace =
+    let
+        replaceHash =
+            Hash.fromString "#replaceHash"
+    in
+    describe "OpenDefinitions.replace"
+        [ test "Replace an existing definition by Hash" <|
+            \_ ->
+                let
+                    openDefs =
+                        OpenDefinitions.fromList
+                            [ ( Hash.fromString "#foo", NotAsked )
+                            , ( Hash.fromString "#replaceHash", NotAsked )
+                            , ( Hash.fromString "#bar", NotAsked )
+                            ]
+
+                    result =
+                        OpenDefinitions.replace replaceHash Loading openDefs
+                in
+                Expect.equal (Just Loading) (OpenDefinitions.get replaceHash result)
+        , test "Do nothing if the Hash is not found" <|
+            \_ ->
+                let
+                    openDefs =
+                        OpenDefinitions.fromList
+                            [ ( Hash.fromString "#foo", NotAsked )
+                            , ( Hash.fromString "#bar", NotAsked )
+                            ]
+
+                    result =
+                        OpenDefinitions.replace replaceHash Loading openDefs
+                in
+                Expect.false
+                    "The element is not part of OpenDefinitions"
+                    (OpenDefinitions.member replaceHash openDefs)
+        ]


### PR DESCRIPTION
## Overview
Open definitions from other definitions immediately below them

![open-below](https://user-images.githubusercontent.com/2371/108532423-d5f97d80-72a5-11eb-9d51-425de7d772cc.gif)

What does this change accomplish and why?
Include a screenshot or GIF of the change if appropriate.

## Implementation notes
Add a new `insertAfter` function on `OpenDefinitions`. If the Definition is
already opened, ignore the open request.

## Interesting/controversial decisions
Include anything that you thought twice about, debated, chose arbitrarily, etc.
What could have been done differently, but wasn't? And why?

## Loose ends
Definitions that are already opened and attempted to re-open via definition links should
be scrolled to — I'll look at that next.

Depends on https://github.com/unisonweb/codebase-ui/pull/7