### PR TITLE
Scroll to definition on open

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -429,6 +429,7 @@ code a:hover {
 #workspace-content {
   overflow: auto;
   height: calc(100vh - 3.5rem);
+  scroll-behavior: smooth;
   scrollbar-width: auto;
   scrollbar-color: var(--color-workspace-subtle-fg) var(--color-workspace-mg);
 }

--- a/src/Definition.elm
+++ b/src/Definition.elm
@@ -4,7 +4,7 @@ import Api
 import FullyQualifiedName exposing (FQN)
 import Hash exposing (Hash)
 import Html exposing (Html, a, code, div, h3, header, section, text)
-import Html.Attributes exposing (class)
+import Html.Attributes exposing (class, id)
 import Html.Events exposing (onClick)
 import Http
 import Json.Decode as Decode exposing (at, field)
@@ -65,33 +65,34 @@ hash definition =
 -- VIEW
 
 
-viewDefinitionRow : List (Html msg) -> Html msg -> Html msg
-viewDefinitionRow headerItems content =
-    div [ class "definition-row" ]
+viewDefinitionRow : Hash -> List (Html msg) -> Html msg -> Html msg
+viewDefinitionRow hash_ headerItems content =
+    div [ class "definition-row", id ("definition-" ++ Hash.toString hash_) ]
         [ header [] headerItems, section [ class "content" ] [ content ] ]
 
 
-viewClosableRow : msg -> Html msg -> Html msg -> Html msg
-viewClosableRow closeMsg title content =
+viewClosableRow : msg -> Hash -> Html msg -> Html msg -> Html msg
+viewClosableRow closeMsg hash_ title content =
     viewDefinitionRow
+        hash_
         [ h3 [] [ title ]
         , a [ class "close", onClick closeMsg ] [ Icon.view Icon.X ]
         ]
         content
 
 
-viewError : msg -> Http.Error -> Html msg
-viewError closeMsg err =
-    viewClosableRow closeMsg (text "Error") (UI.errorMessage (Api.errorToString err))
+viewError : msg -> Hash -> Http.Error -> Html msg
+viewError closeMsg hash_ err =
+    viewClosableRow closeMsg hash_ (text "Error") (UI.errorMessage (Api.errorToString err))
 
 
-viewLoading : Html msg
-viewLoading =
-    viewDefinitionRow [ UI.loadingPlaceholder ]
+viewLoading : Hash -> Html msg
+viewLoading hash_ =
+    viewDefinitionRow hash_
+        [ UI.loadingPlaceholder ]
         (div
             []
-            [ div [ class "docs" ] [ UI.loadingPlaceholder ]
-            , code [] [ UI.loadingPlaceholder, UI.loadingPlaceholder ]
+            [ code [] [ UI.loadingPlaceholder, UI.loadingPlaceholder ]
             ]
         )
 
@@ -99,18 +100,19 @@ viewLoading =
 view : msg -> (Hash -> msg) -> Definition -> Html msg
 view closeMsg toOpenReferenceMsg definition =
     let
-        viewDefinitionInfo info source =
+        viewDefinitionInfo hash_ info source =
             viewClosableRow
                 closeMsg
+                hash_
                 (div [] [ text info.name ])
                 (div [] [ source ])
     in
     case definition of
-        Term _ info ->
-            viewDefinitionInfo info (viewTermSource toOpenReferenceMsg info.name info.source)
+        Term h info ->
+            viewDefinitionInfo h info (viewTermSource toOpenReferenceMsg info.name info.source)
 
-        Type _ info ->
-            viewDefinitionInfo info (viewTypeSource toOpenReferenceMsg info.source)
+        Type h info ->
+            viewDefinitionInfo h info (viewTypeSource toOpenReferenceMsg info.source)
 
 
 


### PR DESCRIPTION
## Overview
When a definition is opened, either through the sidebar or from another
definition, scroll to it. If the definition is already open, don't
refetch, but do scroll to it.

![scrollto](https://user-images.githubusercontent.com/2371/108868653-6d234580-75c4-11eb-9ade-c870a5fe2019.gif)

## Implementation notes
This uses the default Dom tooling in Elm with a `scroll-behavior` css property for the animation.
This property is not supported in Safari where scrolling will just not animate.

https://caniuse.com/?search=scroll-behavior