### PR TITLE
Style the workspace scrollbar

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -429,6 +429,18 @@ code a:hover {
 #workspace-content {
   overflow: auto;
   height: calc(100vh - 3.5rem);
+  scrollbar-width: auto;
+  scrollbar-color: var(--color-workspace-subtle-fg) var(--color-workspace-mg);
+}
+#workspace-content::-webkit-scrollbar {
+  width: 0.5rem;
+}
+#workspace-content::-webkit-scrollbar-track {
+  background: var(--color-workspace-mg);
+}
+#workspace-content::-webkit-scrollbar-thumb {
+  background-color: var(--color-workspace-subtle-fg);
+  border-radius: 0.25rem;
 }
 
 /* -- Definitions ---------------------------------------------------------- */


### PR DESCRIPTION
## Overview
A minor styling tweak to make the scrollbar of the workspace area more consistent with the rest of the UI.

<img width="82" alt="Screen Shot 2021-02-23 at 12 58 57" src="https://user-images.githubusercontent.com/2371/108886551-196e2780-75d7-11eb-80d9-ba008e7ea9d6.png">
