### PR TITLE
Add definition type color and qualifier to sidebar

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -41,6 +41,8 @@ li {
 
   /* Base colors */
   --color-blue-base: #5695f4;
+  --color-green-base: #27ae60;
+  --color-purple-base: #9a76c8;
   --color-gray-base: #515258;
 
   /* Darker (than base) grays */
@@ -55,7 +57,7 @@ li {
   --color-gray-lighten-40: #d1d5dc;
   --color-gray-lighten-50: #e4e7ec;
   --color-gray-lighten-60: #fafafb;
-  --color-gray-lighten-100: #fff;
+  --color-gray-lighten-100: #ffffff;
 
   /* -- Default Theme -------------------------------------------------------*/
   --color-main-fg: var(--color-gray-darken-30);
@@ -87,6 +89,13 @@ li {
   --color-workspace-highlight-fg: var(--color-blue-base);
   --color-workspace-highlight-bg: var(--color-blue-base);
   --color-workspace-highlight-border: var(--color-blue-base);
+
+  --color-icon-type: var(--color-brand-orange);
+  --color-icon-test: var(--color-green-base);
+  --color-icon-term: var(--color-purple-base);
+  --color-icon-ability: var(--color-brand-bright-red);
+  --color-icon-doc: var(--color-brand-yellow);
+  --color-icon-patch: var(--color-blue-base);
 
   /* -- Default Syntax Theme ------------------------------------------------*/
 
@@ -340,6 +349,30 @@ button {
   transition: all 0.2s;
 }
 
+.icon.type {
+  color: var(--color-icon-type);
+}
+
+.icon.test {
+  color: var(--color-icon-test);
+}
+
+.icon.term {
+  color: var(--color-icon-term);
+}
+
+.icon.ability {
+  color: var(--color-icon-ability);
+}
+
+.icon.doc {
+  color: var(--color-icon-doc);
+}
+
+.icon.patch {
+  color: var(--color-icon-patch);
+}
+
 /* -- Application ---------------------------------------------------------- */
 
 #app {
@@ -393,6 +426,7 @@ button {
   font-size: var(--font-size-medium);
   font-weight: normal;
   color: var(--color-sidebar-subtle-fg);
+  margin-bottom: 0.125rem;
 }
 
 .namespace-tree {
@@ -405,6 +439,8 @@ button {
   align-items: center;
   border-radius: 4px;
   padding-left: 0.5rem;
+  margin-bottom: 0.125rem;
+  height: 1.75rem;
 }
 
 .namespace-tree .node:hover {
@@ -413,14 +449,16 @@ button {
 }
 
 .namespace-tree .node .icon {
-  color: var(--color-sidebar-subtle-fg);
-  width: 1rem;
+  width: 0.875rem;
+  height: 0.875rem;
   text-align: center;
-  margin-left: -0.275rem;
-  margin-right: 0.25rem;
+  margin-right: 0.5rem;
+}
+.namespace-tree .node .icon:is(.caret-right, .caret-down) {
+  color: var(--color-sidebar-subtle-fg);
 }
 
-.namespace-tree .node:hover .icon {
+.namespace-tree .node:hover .icon:is(.caret-right, .caret-down) {
   color: var(--color-sidebar-highlight-fg);
 }
 
@@ -428,6 +466,13 @@ button {
   color: var(--color-sidebar-fg);
   transition: all 0.2s;
   cursor: pointer;
+}
+
+.namespace-tree .node .definition-type {
+  font-family: var(--font-monospace);
+  color: var(--color-sidebar-subtle-fg);
+  margin-left: 0.375rem;
+  font-size: 0.75rem;
 }
 
 .namespace-tree .node:hover label {

--- a/src/App.elm
+++ b/src/App.elm
@@ -18,6 +18,7 @@ import Html
         , header
         , label
         , section
+        , span
         , text
         )
 import Html.Attributes exposing (class, id)
@@ -35,7 +36,6 @@ import RemoteData exposing (RemoteData(..), WebData)
 import Task
 import UI
 import UI.Icon as Icon
-import Util
 
 
 
@@ -271,18 +271,21 @@ viewDefinitionListing listing =
             a [ class "node type", onClick (OpenDefinition hash) ]
                 [ Icon.view Icon.Type
                 , label [] [ text (unqualifiedName fqn) ]
+                , span [ class "definition-type" ] [ text "type" ]
                 ]
 
         TermListing hash fqn ->
             a [ class "node term", onClick (OpenDefinition hash) ]
                 [ Icon.view Icon.Term
                 , label [] [ text (unqualifiedName fqn) ]
+                , span [ class "definition-type" ] [ text "term" ]
                 ]
 
         PatchListing _ ->
             a [ class "node patch" ]
                 [ Icon.view Icon.Patch
                 , label [] [ text "Patch" ]
+                , span [ class "definition-type" ] [ text "patch" ]
                 ]
 
 
@@ -400,7 +403,7 @@ viewOpenDefinitions openDefinitions =
 viewWorkspace : Model -> Html Msg
 viewWorkspace model =
     article [ id "workspace" ]
-        [ header [ id "workspace-toolbar" ] []
+        [ header [ id "workspace-toolbar" ] [ UI.button "Open" NoOp ]
         , section [ id "workspace-content" ]
             [ section
                 [ class "definitions-pane" ]

--- a/src/UI.elm
+++ b/src/UI.elm
@@ -2,6 +2,12 @@ module UI exposing (..)
 
 import Html exposing (Html, code, div, pre, text)
 import Html.Attributes exposing (class)
+import Html.Events exposing (onClick)
+
+
+button : String -> msg -> Html msg
+button label clickMsg =
+    Html.button [ onClick clickMsg ] [ text label ]
 
 
 nothing : Html msg

--- a/src/UI/Icon.elm
+++ b/src/UI/Icon.elm
@@ -32,11 +32,17 @@ type Icon
 view : Icon -> Html msg
 view icon =
     let
+        iconName =
+            toIdString icon
+
         ref =
-            spritePath ++ "#icon-" ++ toIdString icon
+            spritePath ++ "#icon-" ++ iconName
+
+        className =
+            "icon " ++ iconName
     in
     -- Random, its not possible to dynamically set classNames on svg elements
-    div [ class "icon" ]
+    div [ class className ]
         [ svg [ width "100%", height "100%" ] [ use [ xlinkHref ref ] [] ]
         ]
 


### PR DESCRIPTION
## Overview
Update the sidebar to include colored icons for each definition type
along with a qualifier label.

Additionally improve the spacing in the namespace listing tree and add a
placeholder button to the workspace toolbar.

https://user-images.githubusercontent.com/2371/109064420-6413a080-76b8-11eb-8a36-9061e20c76d9.mp4

## Loose ends
Buttons needs a more directed effort to ensure consistency, but thats out of scope of this PR.
