### PR TITLE
Polish interaction for definition linkings

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -19,8 +19,8 @@ li {
 
 :root {
   --size-base: 16px;
-
-  --main-sidebar-width: 14rem;
+  --main-sidebar-width: 16rem;
+  --border-radius-base: 0.25rem;
 
   /* -- Font --------------------------------------------------------------- */
 
@@ -129,8 +129,10 @@ a:visited {
 }
 
 a:hover {
-  color: var(--color-main-highlight-fg);
+  text-decoration: underline;
 }
+
+/* -- Syntax --------------------------------------------------------------- */
 
 pre {
   margin: 0;
@@ -139,13 +141,25 @@ pre {
 code {
   display: inline-block;
   font-family: var(--font-monospace);
+  line-height: 1.6rem;
+}
+
+code a {
+  display: inline-block;
+  padding: 0 0.375rem;
+  margin: 0 -0.25rem;
+  border-radius: var(--border-radius-base);
+  line-height: 1.4rem;
 }
 
 code a:hover {
-  text-decoration: underline;
+  background: var(--color-gray-lighten-50);
+  text-decoration: none;
 }
 
-/* -- Syntax --------------------------------------------------------------- */
+code a:active {
+  transform: translate(0, 0.125rem);
+}
 
 .builtin {
   color: var(--color-syntax-base);
@@ -305,6 +319,19 @@ code a:hover {
   min-width: calc(var(--font-size-base) * 3);
 }
 
+button {
+  border: 0;
+  border-radius: var(--border-radius-base);
+  /* TODO: Colors should be theme based */
+  background: var(--color-gray-lighten-50);
+  color: var(--color-main-fg);
+  font-weight: bold;
+  height: 2rem;
+  padding: 0 0.75rem;
+}
+
+/* -- Icon ----------------------------------------------------------------- */
+
 .icon {
   display: inline-block;
   width: 0.875rem;
@@ -382,6 +409,7 @@ code a:hover {
 
 .namespace-tree .node:hover {
   background: var(--color-sidebar-highlight-bg);
+  text-decoration: none;
 }
 
 .namespace-tree .node .icon {
@@ -441,7 +469,7 @@ code a:hover {
 }
 #workspace-content::-webkit-scrollbar-thumb {
   background-color: var(--color-workspace-subtle-fg);
-  border-radius: 0.25rem;
+  border-radius: var(--border-radius-base);
 }
 
 /* -- Definitions ---------------------------------------------------------- */
@@ -488,7 +516,7 @@ code a:hover {
 .definition-row .content code {
   display: block;
   padding: 1rem 1.25rem;
-  border-radius: 0.25rem;
+  border-radius: var(--border-radius-base);
   background: var(--color-workspace-subtle-bg);
 }
 


### PR DESCRIPTION
## Overview
Add more polished hover and active states for reference links in
definitions.

![codehover](https://user-images.githubusercontent.com/2371/109178238-a4296080-7756-11eb-96a8-fe96a2c43145.gif)


## Loose ends
This can definitely be improved further over time, but this treatment seems ok for now.