### PR TITLE
Add Env file and update syntax tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 15.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -23,5 +23,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
+    - run: API_TOKEN=ci npm run makeElmEnv
     - run: npm run build --if-present
     - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ elm-stuff
 .DS_Store
 public/bundle.js
 node_modules
+src/Env.elm

--- a/README.md
+++ b/README.md
@@ -6,8 +6,17 @@ Unison Codebase UI
 Running
 -------
 
-With a `ucm` running, run `npm start` in the `codebase-browser` directory to start the development server
+Start `ucm` and copy the API URL and API Token (this URL is uniquely generated
+by `ucm` at start-up) from the `ucm` start-up output (It's formatted as
+a single URL with a query string. Get the token by from the query string).
 
+Then start the development server, run:
+
+```sh
+API_URL="<API URL FROM UCM>" API_TOKEN="<API TOKEN FROM UCM>" npm start
+```
+
+Then visit `http://localhost:8000` to use the UI.
 
 Generating Icon Sprite
 ----------------------

--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
-  "name": "codebase-browser",
+  "name": "codebase-ui",
   "version": "1.0.0",
-  "description": "Unison Codebase Browser",
+  "description": "Unison Codebase UI",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/unisonweb/codebase-browser.git"
+    "url": "git+https://github.com/unisonweb/codebase-ui.git"
   },
   "scripts": {
     "build": "elm make src/Main.elm --output public/bundle.js",
-    "start": "elm-live src/Main.elm --path-to-elm=node_modules/.bin/elm --dir=public --pushstate --verbose --proxy-prefix=/api --proxy-host=http://localhost:8081 -- --output public/bundle.js",
-    "test": "elm-test"
+    "start": "npm run makeElmEnv; elm-live src/Main.elm --path-to-elm=node_modules/.bin/elm --dir=public --pushstate --verbose --proxy-prefix=/api --proxy-host=${API_URL} -- --output public/bundle.js",
+    "test": "elm-test",
+    "makeElmEnv": "node ./scripts/makeElmEnv.mjs"
   },
   "bugs": {
-    "url": "https://github.com/unisonweb/codebase-browser/issues"
+    "url": "https://github.com/unisonweb/codebase-ui/issues"
   },
-  "homepage": "https://github.com/unisonweb/codebase-browser#readme",
+  "homepage": "https://github.com/unisonweb/codebase-ui#readme",
   "devDependencies": {
     "elm": "^0.19.1-5",
     "elm-format": "^0.8.5",

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -207,11 +207,11 @@ code a:active {
   color: var(--color-syntax-base);
 }
 
-.reference {
+.type-reference {
   color: var(--color-syntax-name);
 }
 
-.referent {
+.term-reference {
   color: var(--color-syntax-name);
 }
 

--- a/scripts/makeElmEnv.mjs
+++ b/scripts/makeElmEnv.mjs
@@ -1,0 +1,33 @@
+// Generate src/Env.elm based on a API_TOKEN environment variable.
+
+import { writeFile } from "fs";
+
+const ENV_FILE_PATH = "src/Env.elm";
+const API_TOKEN = process.env.API_TOKEN;
+
+function generateContent(apiToken) {
+  return `module Env exposing (..)
+
+-- DO NOT MODIFY This is an auto-generated environment file
+
+
+apiToken : String
+apiToken =
+    "${apiToken}"
+`;
+}
+
+function saveEnvFile(envFilePath, content) {
+  const data = new Uint8Array(Buffer.from(content));
+  writeFile(envFilePath, data, (err) => {
+    if (err) console.error(`Could not save file: ${err}`);
+  });
+}
+
+if (API_TOKEN) {
+  saveEnvFile(ENV_FILE_PATH, generateContent(API_TOKEN));
+} else {
+  console.error(
+    "Please provide an API_TOKEN environment variable. Grab it from the `ucm` startup output"
+  );
+}

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -1,30 +1,22 @@
-module Api exposing (..)
+module Api exposing (definitions, errorToString, list)
 
+import Env
 import Http
 import Url.Builder exposing (QueryParameter, absolute, string)
 
 
-
--- URL HELPERS
-
-
-serverUrl : List String -> List QueryParameter -> String
-serverUrl path queryParams =
-    absolute ("api" :: path) queryParams
-
-
 {-| TODO: Be more explicit about Root |
 -}
-listUrl : Maybe String -> String
-listUrl rawFQN =
+list : Maybe String -> String
+list rawFQN =
     rawFQN
         |> Maybe.map (\n -> [ string "namespace" n ])
         |> Maybe.withDefault []
         |> serverUrl [ "list" ]
 
 
-definitionUrl : List String -> String
-definitionUrl hashes =
+definitions : List String -> String
+definitions hashes =
     hashes
         |> List.map (string "names")
         |> serverUrl [ "getDefinition" ]
@@ -51,3 +43,20 @@ errorToString err =
 
         Http.BadUrl url ->
             "Malformed url: " ++ url
+
+
+
+-- PRIVATE URL HELPERS
+
+
+serverUrl : List String -> List QueryParameter -> String
+serverUrl path queryParams =
+    let
+        url =
+            absolute ("api" :: path) queryParams
+    in
+    if String.contains "?" url then
+        url ++ "&" ++ Env.apiToken
+
+    else
+        url ++ "?" ++ Env.apiToken

--- a/src/App.elm
+++ b/src/App.elm
@@ -215,7 +215,7 @@ fetchRootNamespaceListing =
             FQN.fromString "."
     in
     Http.get
-        { url = Api.listUrl Nothing
+        { url = Api.list Nothing
         , expect = Http.expectJson FetchRootNamespaceListingFinished (NamespaceListing.decode rootFqn)
         }
 
@@ -223,7 +223,7 @@ fetchRootNamespaceListing =
 fetchSubNamespaceListing : FQN -> Cmd Msg
 fetchSubNamespaceListing fqn =
     Http.get
-        { url = Api.listUrl (Just (FQN.toString fqn))
+        { url = Api.list (Just (FQN.toString fqn))
         , expect = Http.expectJson (FetchSubNamespaceListingFinished fqn) (NamespaceListing.decode fqn)
         }
 
@@ -231,7 +231,7 @@ fetchSubNamespaceListing fqn =
 fetchDefinitions : List Hash -> Cmd Msg
 fetchDefinitions hashes =
     Http.get
-        { url = Api.definitionUrl (List.map Hash.toString hashes)
+        { url = Api.definitions (List.map Hash.toString hashes)
         , expect = Http.expectJson (FetchOpenDefinitionsFinished hashes) Definition.decodeList
         }
 


### PR DESCRIPTION
## Overview
The backend changed to be on a random port and to generate a token at
start-up. Add a new build step to generate an `Env.elm` file based on a
token passed into the `npm start` script, which also now requires an API
url. The full start command is now:

```sh
API_URL=<API URL FROM UCM> API_TOKEN=<API TOKEN FROM UCM> npm start
```

## Implementation notes
This `Env.elm` is generated with a small node script - The intent is
that it will eventually support environment settings from something like [`dotenv`](https://github.com/motdotla/dotenv).
A generated file is chosen instead of `flags` to the `init` function to make it
easier to deal with these static settings without having to pass them around as state in Elm.

Additionally update the Syntax module to support a few backend renames
around references and hash qualifiers.

## Interesting/controversial decisions
At some point we'll likely end up with a more involved build system like webpack or parcel, 
but for the time being I'm opting for a simple approach.