### PR TITLE
Fix a visual glitch in definition linking

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -159,6 +159,7 @@ code a {
   margin: 0 -0.25rem;
   border-radius: var(--border-radius-base);
   line-height: 1.4rem;
+  will-change: transform;
 }
 
 code a:hover {


### PR DESCRIPTION
## Overview
When clicking to view a definition from another definition, the
animation would glitch and move the link slightly (1 or 2 pixels) to one side. 
Fix this with the [`will-change`](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) css property.

Before:
![glitch](https://user-images.githubusercontent.com/2371/109223892-39dde380-7789-11eb-8d98-73f95f6b97f4.gif)

After:
![glitch-fix](https://user-images.githubusercontent.com/2371/109223900-3d716a80-7789-11eb-8776-61e5dca6b7bb.gif)
