### PR TITLE
Add focus to OpenDefinitions

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -17,8 +17,7 @@
             "elm-community/list-extra": "8.2.4",
             "krisajenkins/remotedata": "6.0.1",
             "mgold/elm-nonempty-list": "4.1.0",
-            "stoeffel/set-extra": "1.2.3",
-            "y0hy0h/ordered-containers": "2.0.1"
+            "stoeffel/set-extra": "1.2.3"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/src/Definition.elm
+++ b/src/Definition.elm
@@ -183,3 +183,12 @@ decodeList =
     Decode.map2 List.append
         (field "termDefinitions" decodeTerms)
         (field "typeDefinitions" decodeTypes)
+
+
+decodeHead : Decode.Decoder Definition
+decodeHead =
+    Decode.map List.head decodeList
+        |> Decode.andThen
+            (Maybe.map Decode.succeed
+                >> Maybe.withDefault (Decode.fail "Empty list")
+            )

--- a/src/OpenDefinitions.elm
+++ b/src/OpenDefinitions.elm
@@ -1,131 +1,247 @@
+{-
+   OpenDefinitions is the main data structure for working with definitions in
+   the Workspace area. It supports holding Loading definitions and inserting
+   definitions after another.
+
+   It features a `focus` indicator and a before and after just like a Zipper,
+   but is based on OrderedDicts. `focus` can be changed with `next` and `prev`.
+
+   Invariants:
+     It structurally can't hold the invariant that it should not contain
+     duplicates, so this is instead enforced via the API; uniqueness is
+     determined by Hash.
+-}
+
+
 module OpenDefinitions exposing
-    ( OpenDefinitions
-    , definitions
+    ( HashIndexedDefinition
+    , OpenDefinitions
     , empty
-    , fromList
-    , get
+    , focus
+    , fromDefinitions
     , hashes
-    , insert
-    , insertAfter
-    , loading
+    , init
+    , insertWithFocus
+    , insertWithFocusAfter
+    , isEmpty
+    , isFocused
+    , map
+    , mapToList
     , member
+    , next
+    , prev
     , remove
     , replace
-    , replaceItems
+    , singleton
     , toList
-    , update
     )
 
 import Definition exposing (Definition)
 import Hash exposing (Hash)
+import List
+import List.Extra as ListE
 import OrderedDict exposing (OrderedDict)
 import RemoteData exposing (WebData)
 
 
+type alias DefinitionDict =
+    OrderedDict String (WebData Definition)
 
-{-
-   OpenDefinitions is the main data structure for working with definitions in
-   the Workspace area. It wraps an OrderedDirect (Hash to Definition), but is
-   opaque to that underlying data structure and only exposes a few key APIs,
-   including a few convenience functions for working with, loading and opening
-   Definitions.
+
+type alias HashIndexedDefinition =
+    { hash : Hash
+    , definition : WebData Definition
+    }
+
+
+{-| This technically allows multiple of the same definition across the 3 fields.
+This is conceptionally not allowed and is enforced by the helper functions.
 -}
-
-
 type OpenDefinitions
-    = OpenDefinitions (OrderedDict String (WebData Definition))
+    = Empty
+    | OpenDefinitions
+        { before : DefinitionDict
+        , focus : HashIndexedDefinition
+        , after : DefinitionDict
+        }
 
 
+init : Maybe Hash -> OpenDefinitions
+init focused =
+    case focused of
+        Nothing ->
+            Empty
 
--- BUILD
+        Just h ->
+            singleton { hash = h, definition = RemoteData.NotAsked }
+
+
+fromDefinitions :
+    List HashIndexedDefinition
+    -> HashIndexedDefinition
+    -> List HashIndexedDefinition
+    -> OpenDefinitions
+fromDefinitions before focus_ after =
+    OpenDefinitions
+        { before = defDictFromList before
+        , focus = focus_
+        , after = defDictFromList after
+        }
 
 
 empty : OpenDefinitions
 empty =
-    OpenDefinitions OrderedDict.empty
+    Empty
 
 
-loading : List Hash -> OpenDefinitions
-loading list =
-    list
-        |> List.map (\h -> ( h, RemoteData.Loading ))
-        |> fromList
+isEmpty : OpenDefinitions -> Bool
+isEmpty openDefinitions =
+    case openDefinitions of
+        Empty ->
+            True
+
+        OpenDefinitions _ ->
+            False
 
 
-fromList : List ( Hash, WebData Definition ) -> OpenDefinitions
-fromList list =
-    list
-        |> List.map (Tuple.mapFirst Hash.toString)
-        |> OrderedDict.fromList
-        |> OpenDefinitions
+singleton : HashIndexedDefinition -> OpenDefinitions
+singleton hashIndexedDefinition =
+    OpenDefinitions
+        { before = OrderedDict.empty
+        , focus = hashIndexedDefinition
+        , after = OrderedDict.empty
+        }
 
 
-update :
-    Hash
-    -> (Maybe (WebData Definition) -> Maybe (WebData Definition))
-    -> OpenDefinitions
-    -> OpenDefinitions
-update h f (OpenDefinitions dict) =
-    OpenDefinitions (OrderedDict.update (Hash.toString h) f dict)
+
+-- MODIFY
 
 
-{-| Replace existing item |
--}
-replace : Hash -> WebData Definition -> OpenDefinitions -> OpenDefinitions
-replace h def openDefinition =
-    update h (Maybe.map (always def)) openDefinition
+insertWithFocus : HashIndexedDefinition -> OpenDefinitions -> OpenDefinitions
+insertWithFocus hashIndexedDefinition od =
+    case od of
+        Empty ->
+            singleton hashIndexedDefinition
 
-
-{-| Replace existing items in OpenDefinitions |
--}
-replaceItems :
-    List ( Hash, WebData Definition )
-    -> OpenDefinitions
-    -> OpenDefinitions
-replaceItems items openDefinitions =
-    let
-        replacer ( h, d ) acc =
-            replace h d acc
-    in
-    List.foldl replacer openDefinitions items
-
-
-remove : Hash -> OpenDefinitions -> OpenDefinitions
-remove h (OpenDefinitions dict) =
-    OpenDefinitions (OrderedDict.remove (Hash.toString h) dict)
-
-
-insert : ( Hash, WebData Definition ) -> OpenDefinitions -> OpenDefinitions
-insert ( h, definition ) (OpenDefinitions dict) =
-    OpenDefinitions (OrderedDict.insert (Hash.toString h) definition dict)
+        OpenDefinitions _ ->
+            let
+                newBefore =
+                    od
+                        |> toList
+                        |> List.map hashIndexedDefinitionToRawPair
+                        |> OrderedDict.fromList
+            in
+            OpenDefinitions
+                { before = newBefore
+                , focus = hashIndexedDefinition
+                , after = OrderedDict.empty
+                }
 
 
 {-| Insert after a Hash. If the Hash is not in OpenDefinitions, insert at the
 end. If the element to insert already exists in OpenDefinitions, move it to
-after the provided Hash |
+after the provided Hash
 -}
-insertAfter : Hash -> ( Hash, WebData Definition ) -> OpenDefinitions -> OpenDefinitions
-insertAfter afterHash (( hashToInsert, _ ) as definitionRow) openDefinitions =
-    let
-        after (( h, _ ) as elem) =
-            if Hash.equals afterHash h then
-                [ elem, definitionRow ]
+insertWithFocusAfter :
+    Hash
+    -> HashIndexedDefinition
+    -> OpenDefinitions
+    -> OpenDefinitions
+insertWithFocusAfter afterHash toInsert openDefinitions =
+    case openDefinitions of
+        Empty ->
+            singleton toInsert
+
+        OpenDefinitions _ ->
+            if member afterHash openDefinitions then
+                let
+                    insertAfter def =
+                        if Hash.equals def.hash afterHash then
+                            [ def, toInsert ]
+
+                        else
+                            [ def ]
+
+                    make ( before, afterInclusive ) =
+                        OpenDefinitions
+                            { before = defDictFromList before
+                            , focus = toInsert
+                            , after = defDictFromList (List.drop 1 afterInclusive)
+                            }
+                in
+                openDefinitions
+                    |> toList
+                    |> List.concatMap insertAfter
+                    |> ListE.splitWhen (\d -> Hash.equals toInsert.hash d.hash)
+                    |> Maybe.map make
+                    |> Maybe.withDefault (singleton toInsert)
 
             else
-                [ elem ]
+                insertWithFocus toInsert openDefinitions
 
-        insertAfter_ defs =
-            defs
-                |> toList
-                |> List.filter (\( h, _ ) -> not (Hash.equals h hashToInsert))
-                |> List.concatMap after
-                |> fromList
+
+replace : Hash -> WebData Definition -> OpenDefinitions -> OpenDefinitions
+replace hash newDef ods =
+    let
+        replaceMatching d =
+            if Hash.equals d.hash hash then
+                newDef
+
+            else
+                d.definition
     in
-    if member afterHash openDefinitions then
-        insertAfter_ openDefinitions
+    map replaceMatching ods
 
-    else
-        insert definitionRow openDefinitions
+
+remove : Hash -> OpenDefinitions -> OpenDefinitions
+remove hash od =
+    case od of
+        Empty ->
+            Empty
+
+        OpenDefinitions data ->
+            if Hash.equals hash data.focus.hash then
+                let
+                    rightBeforeFocus =
+                        data.before
+                            |> OrderedDict.toList
+                            |> ListE.last
+
+                    rightAfterFocus =
+                        data.after
+                            |> OrderedDict.toList
+                            |> List.head
+                in
+                case rightAfterFocus of
+                    Just ( rawHash, d ) ->
+                        OpenDefinitions
+                            { before = data.before
+                            , focus = HashIndexedDefinition (Hash.fromString rawHash) d
+                            , after = OrderedDict.remove rawHash data.after
+                            }
+
+                    Nothing ->
+                        case rightBeforeFocus of
+                            Just ( rawHash, d ) ->
+                                OpenDefinitions
+                                    { before = OrderedDict.remove rawHash data.before
+                                    , focus = HashIndexedDefinition (Hash.fromString rawHash) d
+                                    , after = data.after
+                                    }
+
+                            Nothing ->
+                                Empty
+
+            else
+                let
+                    rawHash =
+                        Hash.toString hash
+                in
+                OpenDefinitions
+                    { before = OrderedDict.remove rawHash data.before
+                    , focus = data.focus
+                    , after = OrderedDict.remove rawHash data.after
+                    }
 
 
 
@@ -133,33 +249,187 @@ insertAfter afterHash (( hashToInsert, _ ) as definitionRow) openDefinitions =
 
 
 member : Hash -> OpenDefinitions -> Bool
-member hash (OpenDefinitions dict) =
-    OrderedDict.member (Hash.toString hash) dict
+member hash od =
+    case od of
+        Empty ->
+            False
 
-
-get : Hash -> OpenDefinitions -> Maybe (WebData Definition)
-get h (OpenDefinitions dict) =
-    OrderedDict.get (Hash.toString h) dict
-
-
-
--- CONVERSIONS
+        OpenDefinitions data ->
+            let
+                rawHash =
+                    Hash.toString hash
+            in
+            Hash.equals data.focus.hash hash || OrderedDict.member rawHash data.before || OrderedDict.member rawHash data.after
 
 
 hashes : OpenDefinitions -> List Hash
-hashes (OpenDefinitions dict) =
-    dict
-        |> OrderedDict.keys
-        |> List.map Hash.fromString
+hashes =
+    toList >> List.map .hash
 
 
-definitions : OpenDefinitions -> List (WebData Definition)
-definitions (OpenDefinitions dict) =
-    OrderedDict.values dict
+
+-- Focus
 
 
-toList : OpenDefinitions -> List ( Hash, WebData Definition )
-toList (OpenDefinitions dict) =
-    dict
-        |> OrderedDict.toList
-        |> List.map (Tuple.mapFirst Hash.fromString)
+focus : OpenDefinitions -> Maybe HashIndexedDefinition
+focus openDefinitions =
+    case openDefinitions of
+        Empty ->
+            Nothing
+
+        OpenDefinitions data ->
+            Just data.focus
+
+
+isFocused : Hash -> OpenDefinitions -> Bool
+isFocused hash openDefinitions =
+    openDefinitions
+        |> focus
+        |> Maybe.map (.hash >> Hash.equals hash)
+        |> Maybe.withDefault False
+
+
+next : OpenDefinitions -> OpenDefinitions
+next openDefinitions =
+    case openDefinitions of
+        Empty ->
+            Empty
+
+        OpenDefinitions data ->
+            case OrderedDict.toList data.after of
+                [] ->
+                    openDefinitions
+
+                newFocus :: rest ->
+                    OpenDefinitions
+                        { before = OrderedDict.insert (Hash.toString data.focus.hash) data.focus.definition data.before
+                        , focus = hashIndexedDefinitionFromRawPair newFocus
+                        , after = OrderedDict.fromList rest
+                        }
+
+
+prev : OpenDefinitions -> OpenDefinitions
+prev openDefinitions =
+    case openDefinitions of
+        Empty ->
+            Empty
+
+        OpenDefinitions data ->
+            let
+                after =
+                    data.after
+                        |> OrderedDict.toList
+                        |> (\l -> hashIndexedDefinitionToRawPair data.focus :: l)
+                        |> OrderedDict.fromList
+
+                before =
+                    data.before
+                        |> OrderedDict.toList
+                        |> ListE.unconsLast
+            in
+            case before of
+                Nothing ->
+                    openDefinitions
+
+                Just ( newFocus, newBefore ) ->
+                    OpenDefinitions
+                        { before = OrderedDict.fromList newBefore
+                        , focus = hashIndexedDefinitionFromRawPair newFocus
+                        , after = after
+                        }
+
+
+
+-- TRANFORM
+
+
+map :
+    (HashIndexedDefinition -> WebData Definition)
+    -> OpenDefinitions
+    -> OpenDefinitions
+map f openDefinitions =
+    case openDefinitions of
+        Empty ->
+            Empty
+
+        OpenDefinitions data ->
+            let
+                mapper rawHash d =
+                    f (hashIndexedDefinitionFromRawHash rawHash d)
+
+                newFocus =
+                    { hash = data.focus.hash
+                    , definition = f data.focus
+                    }
+            in
+            OpenDefinitions
+                { before = OrderedDict.map mapper data.before
+                , focus = newFocus
+                , after = OrderedDict.map mapper data.after
+                }
+
+
+mapToList : (HashIndexedDefinition -> Bool -> a) -> OpenDefinitions -> List a
+mapToList f openDefinitions =
+    case openDefinitions of
+        Empty ->
+            []
+
+        OpenDefinitions data ->
+            let
+                before =
+                    data.before
+                        |> OrderedDict.toList
+                        |> List.map (\pair -> f (hashIndexedDefinitionFromRawPair pair) False)
+
+                after =
+                    data.after
+                        |> OrderedDict.toList
+                        |> List.map (\pair -> f (hashIndexedDefinitionFromRawPair pair) False)
+            in
+            before ++ (f data.focus True :: after)
+
+
+toList : OpenDefinitions -> List HashIndexedDefinition
+toList openDefinitions =
+    case openDefinitions of
+        Empty ->
+            []
+
+        OpenDefinitions data ->
+            let
+                toList_ =
+                    OrderedDict.toList >> List.map hashIndexedDefinitionFromRawPair
+            in
+            toList_ data.before ++ (data.focus :: toList_ data.after)
+
+
+
+-- INTERNAL HELPERS
+
+
+hashIndexedDefinitionFromRawPair :
+    ( String, WebData Definition )
+    -> HashIndexedDefinition
+hashIndexedDefinitionFromRawPair ( rawHash, def ) =
+    hashIndexedDefinitionFromRawHash rawHash def
+
+
+hashIndexedDefinitionFromRawHash :
+    String
+    -> WebData Definition
+    -> HashIndexedDefinition
+hashIndexedDefinitionFromRawHash rawHash def =
+    HashIndexedDefinition (Hash.fromString rawHash) def
+
+
+hashIndexedDefinitionToRawPair :
+    HashIndexedDefinition
+    -> ( String, WebData Definition )
+hashIndexedDefinitionToRawPair hashIndexedDefinition =
+    ( Hash.toString hashIndexedDefinition.hash, hashIndexedDefinition.definition )
+
+
+defDictFromList : List HashIndexedDefinition -> DefinitionDict
+defDictFromList =
+    List.map hashIndexedDefinitionToRawPair >> OrderedDict.fromList

--- a/tests/OpenDefinitionsTests.elm
+++ b/tests/OpenDefinitionsTests.elm
@@ -1,154 +1,379 @@
 module OpenDefinitionsTests exposing (..)
 
+import Definition exposing (Definition)
 import Expect
-import Hash
+import Hash exposing (Hash)
 import OpenDefinitions exposing (..)
-import RemoteData exposing (RemoteData(..))
+import RemoteData exposing (RemoteData(..), WebData)
 import Test exposing (..)
 
 
-equalKeys : OpenDefinitions -> OpenDefinitions -> Bool
-equalKeys a b =
+
+-- MODIFY
+
+
+insertWithFocus : Test
+insertWithFocus =
     let
-        keys =
-            OpenDefinitions.toList >> List.map (Tuple.first >> Hash.toString)
+        result =
+            OpenDefinitions.insertWithFocus (HashIndexedDefinition hash definitionData) OpenDefinitions.empty
+
+        currentFocusedHash =
+            getFocusedHash result
     in
-    keys a == keys b
+    describe "OpenDefinitions.insertWithFocus"
+        [ test "Inserts the definition" <|
+            \_ ->
+                Expect.true "Definition is a member" (OpenDefinitions.member hash result)
+        , test "Sets focus" <|
+            \_ ->
+                Expect.true "Has focus" (Maybe.withDefault False <| Maybe.map (Hash.equals hash) currentFocusedHash)
+        ]
 
 
-insertAfter : Test
-insertAfter =
+insertWithFocusAfter : Test
+insertWithFocusAfter =
     let
         afterHash =
-            Hash.fromString "#afterHash"
+            Hash.fromString "#a"
 
-        insertHash =
-            Hash.fromString "#insertHash"
+        toInsert =
+            HashIndexedDefinition hash definitionData
+
+        expected =
+            [ ( "#a", NotAsked )
+            , ( Hash.toString hash, NotAsked )
+            , ( "#b", NotAsked )
+            , ( "#focus", NotAsked )
+            , ( "#c", NotAsked )
+            , ( "#d", NotAsked )
+            ]
+
+        inserted =
+            OpenDefinitions.insertWithFocusAfter afterHash toInsert openDefinitions
+
+        currentFocusedHash =
+            getFocusedHash inserted
     in
-    describe "OpenDefinitions.insertAfter"
-        [ test "Inserts a definition after a Hash" <|
+    describe "OpenDefinitions.insertWithFocusAfter"
+        [ test "Inserts after the the 'after hash'" <|
+            \_ ->
+                Expect.equal expected (toComparableList inserted)
+        , test "When inserted, the new element has focus" <|
+            \_ ->
+                Expect.true "Has focus" (Maybe.withDefault False <| Maybe.map (Hash.equals toInsert.hash) currentFocusedHash)
+        , test "When the 'after hash' is not present, insert at the end" <|
             \_ ->
                 let
-                    original =
-                        OpenDefinitions.fromList
-                            [ ( Hash.fromString "#foo", NotAsked )
-                            , ( afterHash, NotAsked )
-                            , ( Hash.fromString "#bar", NotAsked )
-                            ]
-
-                    expected =
-                        OpenDefinitions.fromList
-                            [ ( Hash.fromString "#foo", NotAsked )
-                            , ( afterHash, NotAsked )
-                            , ( insertHash, NotAsked )
-                            , ( Hash.fromString "#bar", NotAsked )
-                            ]
+                    atEnd =
+                        [ ( "#a", NotAsked )
+                        , ( "#b", NotAsked )
+                        , ( "#focus", NotAsked )
+                        , ( "#c", NotAsked )
+                        , ( "#d", NotAsked )
+                        , ( Hash.toString toInsert.hash, NotAsked )
+                        ]
 
                     result =
-                        OpenDefinitions.insertAfter afterHash ( insertHash, NotAsked ) original
+                        openDefinitions
+                            |> OpenDefinitions.insertWithFocusAfter (Hash.fromString "#notfound") toInsert
+                            |> toComparableList
                 in
-                Expect.true "keys are equal" (equalKeys expected result)
-        , test "When the Hash is missing from OpenDefinitions, insert at the end" <|
-            \_ ->
-                let
-                    original =
-                        OpenDefinitions.fromList
-                            [ ( Hash.fromString "#foo", NotAsked )
-                            , ( Hash.fromString "#bar", NotAsked )
-                            ]
-
-                    expected =
-                        OpenDefinitions.fromList
-                            [ ( Hash.fromString "#foo", NotAsked )
-                            , ( Hash.fromString "#bar", NotAsked )
-                            , ( insertHash, NotAsked )
-                            ]
-
-                    result =
-                        OpenDefinitions.insertAfter afterHash ( insertHash, NotAsked ) original
-                in
-                Expect.true "keys are equals" (equalKeys expected result)
-        , test "When the definition already exists in OpenDefinitions, replace after the Hash" <|
-            \_ ->
-                let
-                    original =
-                        OpenDefinitions.fromList
-                            [ ( insertHash, NotAsked )
-                            , ( Hash.fromString "#foo", NotAsked )
-                            , ( afterHash, NotAsked )
-                            , ( Hash.fromString "#bar", NotAsked )
-                            ]
-
-                    expected =
-                        OpenDefinitions.fromList
-                            [ ( Hash.fromString "#foo", NotAsked )
-                            , ( afterHash, NotAsked )
-                            , ( insertHash, NotAsked )
-                            , ( Hash.fromString "#bar", NotAsked )
-                            ]
-
-                    result =
-                        OpenDefinitions.insertAfter afterHash ( insertHash, NotAsked ) original
-                in
-                Expect.true "keys equals" (equalKeys expected result)
-        , test "When the Hash is missing and the Definition already exists in OpenDefinitions, replace at the end" <|
-            \_ ->
-                let
-                    original =
-                        OpenDefinitions.fromList
-                            [ ( Hash.fromString "#foo", NotAsked )
-                            , ( insertHash, NotAsked )
-                            , ( Hash.fromString "#bar", NotAsked )
-                            ]
-
-                    expected =
-                        OpenDefinitions.fromList
-                            [ ( Hash.fromString "#foo", NotAsked )
-                            , ( Hash.fromString "#bar", NotAsked )
-                            , ( insertHash, NotAsked )
-                            ]
-
-                    result =
-                        OpenDefinitions.insertAfter afterHash ( insertHash, NotAsked ) original
-                in
-                Expect.true "keys equals" (equalKeys expected result)
+                Expect.equal atEnd result
         ]
 
 
 replace : Test
 replace =
-    let
-        replaceHash =
-            Hash.fromString "#replaceHash"
-    in
     describe "OpenDefinitions.replace"
-        [ test "Replace an existing definition by Hash" <|
+        [ test "Can replace element in 'before' focus" <|
             \_ ->
                 let
-                    openDefs =
-                        OpenDefinitions.fromList
-                            [ ( Hash.fromString "#foo", NotAsked )
-                            , ( Hash.fromString "#replaceHash", NotAsked )
-                            , ( Hash.fromString "#bar", NotAsked )
-                            ]
+                    expected =
+                        [ ( "#a", NotAsked )
+                        , ( "#b", Loading )
+                        , ( "#focus", NotAsked )
+                        , ( "#c", NotAsked )
+                        , ( "#d", NotAsked )
+                        ]
 
                     result =
-                        OpenDefinitions.replace replaceHash Loading openDefs
+                        openDefinitions
+                            |> OpenDefinitions.replace (Hash.fromString "#b") Loading
+                            |> toComparableList
                 in
-                Expect.equal (Just Loading) (OpenDefinitions.get replaceHash result)
-        , test "Do nothing if the Hash is not found" <|
+                Expect.equal expected result
+        , test "Can replace element in focus" <|
             \_ ->
                 let
-                    openDefs =
-                        OpenDefinitions.fromList
-                            [ ( Hash.fromString "#foo", NotAsked )
-                            , ( Hash.fromString "#bar", NotAsked )
-                            ]
+                    expected =
+                        [ ( "#a", NotAsked )
+                        , ( "#b", NotAsked )
+                        , ( "#focus", Loading )
+                        , ( "#c", NotAsked )
+                        , ( "#d", NotAsked )
+                        ]
 
                     result =
-                        OpenDefinitions.replace replaceHash Loading openDefs
+                        openDefinitions
+                            |> OpenDefinitions.replace (Hash.fromString "#focus") Loading
+                            |> toComparableList
                 in
-                Expect.false
-                    "The element is not part of OpenDefinitions"
-                    (OpenDefinitions.member replaceHash openDefs)
+                Expect.equal expected result
+        , test "Can replace element in 'after' focus" <|
+            \_ ->
+                let
+                    expected =
+                        [ ( "#a", NotAsked )
+                        , ( "#b", NotAsked )
+                        , ( "#focus", NotAsked )
+                        , ( "#c", NotAsked )
+                        , ( "#d", Loading )
+                        ]
+
+                    result =
+                        openDefinitions
+                            |> OpenDefinitions.replace (Hash.fromString "#d") Loading
+                            |> toComparableList
+                in
+                Expect.equal expected result
         ]
+
+
+remove : Test
+remove =
+    describe "OpenDefinitions.remove"
+        [ test "Returns original when trying to remove a missing Hash" <|
+            \_ ->
+                let
+                    expected =
+                        toComparableList openDefinitions
+
+                    result =
+                        openDefinitions
+                            |> OpenDefinitions.remove (Hash.fromString "#notfound")
+                            |> toComparableList
+                in
+                Expect.equal expected result
+        , test "Removes the element" <|
+            \_ ->
+                let
+                    toRemove =
+                        Hash.fromString "#a"
+
+                    result =
+                        OpenDefinitions.remove toRemove openDefinitions
+                in
+                Expect.false "#a is removed" (OpenDefinitions.member toRemove result)
+        , test "When the element to remove is focused, remove the element and change focus to right after it" <|
+            \_ ->
+                let
+                    toRemove =
+                        Hash.fromString "#focus"
+
+                    expectedNewFocus =
+                        Hash.fromString "#c"
+
+                    result =
+                        OpenDefinitions.remove toRemove openDefinitions
+                in
+                Expect.true "#focus is removed and #c has focus" (not (OpenDefinitions.member toRemove result) && OpenDefinitions.isFocused expectedNewFocus result)
+        , test "When the element to remove is focused and there are no elements after, remove the element and change focus to right before it" <|
+            \_ ->
+                let
+                    toRemove =
+                        Hash.fromString "#focus"
+
+                    expectedNewFocus =
+                        Hash.fromString "#b"
+
+                    result =
+                        OpenDefinitions.remove toRemove (OpenDefinitions.fromDefinitions before focused [])
+                in
+                Expect.true "#focus is removed and #b has focus" (not (OpenDefinitions.member toRemove result) && OpenDefinitions.isFocused expectedNewFocus result)
+        , test "When the element to remove is focused there are no other elements, it returns Empty" <|
+            \_ ->
+                let
+                    result =
+                        HashIndexedDefinition hash definitionData
+                            |> OpenDefinitions.singleton
+                            |> OpenDefinitions.remove hash
+                in
+                Expect.true "Definition is empty" (OpenDefinitions.isEmpty result)
+        ]
+
+
+
+-- QUERY
+
+
+member : Test
+member =
+    let
+        definition =
+            HashIndexedDefinition hash definitionData
+
+        openDefs =
+            OpenDefinitions.singleton definition
+
+        notFoundHash =
+            Hash.fromString "#notfound"
+    in
+    describe "OpenDefinitions.member"
+        [ test "Returns true for a hash housed within" <|
+            \_ ->
+                Expect.true "Definition is a member" (OpenDefinitions.member hash openDefs)
+        , test "Returns false for a hash *not* housed within" <|
+            \_ ->
+                Expect.false "Definition is *not* a member" (OpenDefinitions.member notFoundHash openDefs)
+        ]
+
+
+
+-- FOCUS
+
+
+next : Test
+next =
+    describe "OpenDefinitions.next"
+        [ test "moves focus to the next element" <|
+            \_ ->
+                let
+                    result =
+                        openDefinitions
+                            |> OpenDefinitions.next
+                            |> getFocusedHash
+                            |> Maybe.map Hash.toString
+                in
+                Expect.equal (Just "#c") result
+        , test "keeps focus if no elements after" <|
+            \_ ->
+                let
+                    result =
+                        OpenDefinitions.fromDefinitions before focused []
+                            |> OpenDefinitions.next
+                            |> getFocusedHash
+                            |> Maybe.map Hash.toString
+                in
+                Expect.equal (Just "#focus") result
+        ]
+
+
+prev : Test
+prev =
+    describe "OpenDefinitions.prev"
+        [ test "moves focus to the next element" <|
+            \_ ->
+                let
+                    result =
+                        openDefinitions
+                            |> OpenDefinitions.prev
+                            |> getFocusedHash
+                            |> Maybe.map Hash.toString
+                in
+                Expect.equal (Just "#b") result
+        , test "keeps focus if no elements before" <|
+            \_ ->
+                let
+                    result =
+                        OpenDefinitions.fromDefinitions [] focused after
+                            |> OpenDefinitions.prev
+                            |> getFocusedHash
+                            |> Maybe.map Hash.toString
+                in
+                Expect.equal (Just "#focus") result
+        ]
+
+
+
+-- MAP
+
+
+map : Test
+map =
+    describe "OpenDefinitions.map"
+        [ test "Maps definitions" <|
+            \_ ->
+                let
+                    result =
+                        openDefinitions
+                            |> OpenDefinitions.map (\_ -> Loading)
+                            |> toComparableList
+
+                    expected =
+                        [ ( "#a", Loading )
+                        , ( "#b", Loading )
+                        , ( "#focus", Loading )
+                        , ( "#c", Loading )
+                        , ( "#d", Loading )
+                        ]
+                in
+                Expect.equal expected result
+        ]
+
+
+mapToList : Test
+mapToList =
+    describe "OpenDefinitions.mapToList"
+        [ test "Maps definitions" <|
+            \_ ->
+                let
+                    result =
+                        openDefinitions
+                            |> OpenDefinitions.mapToList (\hid _ -> Hash.toString hid.hash)
+
+                    expected =
+                        [ "#a", "#b", "#focus", "#c", "#d" ]
+                in
+                Expect.equal expected result
+        ]
+
+
+
+-- TEST HELPERS
+
+
+hash : Hash
+hash =
+    Hash.fromString "#testhash"
+
+
+definitionData : WebData Definition
+definitionData =
+    -- The details of a definition doesn't really matter in a test setting
+    RemoteData.NotAsked
+
+
+before : List HashIndexedDefinition
+before =
+    [ HashIndexedDefinition (Hash.fromString "#a") NotAsked
+    , HashIndexedDefinition (Hash.fromString "#b") NotAsked
+    ]
+
+
+focused : HashIndexedDefinition
+focused =
+    HashIndexedDefinition (Hash.fromString "#focus") NotAsked
+
+
+after : List HashIndexedDefinition
+after =
+    [ HashIndexedDefinition (Hash.fromString "#c") NotAsked
+    , HashIndexedDefinition (Hash.fromString "#d") NotAsked
+    ]
+
+
+openDefinitions : OpenDefinitions
+openDefinitions =
+    OpenDefinitions.fromDefinitions before focused after
+
+
+toComparableList : OpenDefinitions -> List ( String, WebData Definition )
+toComparableList =
+    OpenDefinitions.toList
+        >> List.map (\d -> ( Hash.toString d.hash, d.definition ))
+
+
+getFocusedHash : OpenDefinitions -> Maybe Hash
+getFocusedHash =
+    OpenDefinitions.focus >> Maybe.map .hash


### PR DESCRIPTION
## Overview
Update OpenDefinitions to be Zipper like and support a focus that moves
when inserting, inserting after another definition and allows next/prev movement.

Also add a `mapToList` to help with rendering.

## Interesting/controversial decisions
~This implementation is basically a Zipper and I looked at using something like 
[List.Zipper](https://package.elm-lang.org/packages/wernerdegroot/listzipper/latest/List.Zipper),
but decided against it to be able to keep the inner structures as OrderedDicts
and there's some differences in how things work between `OpenDefinitions` and `List.Zipper`,
specifically around how focus is moved when inserting and removing.~

Edit: This is now `List` based instead of `OrderedDict` based which greatly simplified the implementation.

## Loose ends
* These functions are fairly well tested, but i'm sure they could be cleaned up a lot; some of them are a bit messy.
* The constant transform of hashes from and to strings are quite annoying and i'll need to find a better way to deal with that at some point
* I don't actually enforce the uniqueness invariant even though I mentioned it in the comments. Before this is merged, either the comment should be updated or the invariant enforced.