### PR TITLE
Add definition category

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -469,7 +469,7 @@ button {
   cursor: pointer;
 }
 
-.namespace-tree .node .definition-type {
+.namespace-tree .node .definition-category {
   font-family: var(--font-monospace);
   color: var(--color-sidebar-subtle-fg);
   margin-left: 0.375rem;

--- a/public/img/icons.svg
+++ b/public/img/icons.svg
@@ -17,6 +17,9 @@
   <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" id="icon-checkmark">
     <path d="M2.345 7.406l3.381 3.361 6.205-6.185-.776-.775-5.429 5.409L3.101 6.63l-.756.775z" fill="currentColor"></path>
   </symbol>
+  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" id="icon-test">
+    <path d="M2.345 7.406l3.381 3.361 6.205-6.185-.776-.775-5.429 5.409L3.101 6.63l-.756.775z" fill="currentColor"></path>
+  </symbol>
   <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" id="icon-chevron-down">
     <path d="M10.324 5.449l-3.32 3.31-3.322-3.31-.756.756 4.077 4.076 4.077-4.076-.756-.756z" fill="currentColor"></path>
   </symbol>
@@ -26,7 +29,7 @@
   <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" id="icon-folder">
     <path d="M.5 3V2a.5.5 0 01.5-.5h4a.5.5 0 01.4.2l.9 1.2.4-.3-.4.3a1.5 1.5 0 001.2.6H13a.5.5 0 01.5.5v8a.5.5 0 01-.5.5H1a.5.5 0 01-.5-.5V3z" stroke="currentColor"></path>
   </symbol>
-  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" id="icon-document">
+  <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" id="icon-doc">
     <path d="M2 4h2a1 1 0 001-1V1m5.842 1v10a1 1 0 01-1 1H3a1 1 0 01-1-1V3.914a1 1 0 01.293-.707l1.914-1.914A1 1 0 014.914 1h4.928a1 1 0 011 1z" stroke="currentColor"></path>
   </symbol>
   <symbol fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 14" id="icon-term">

--- a/src/App.elm
+++ b/src/App.elm
@@ -31,6 +31,8 @@ import NamespaceListing
         ( DefinitionListing(..)
         , NamespaceListing(..)
         , NamespaceListingContent
+        , TermCategory(..)
+        , TypeCategory(..)
         )
 import OpenDefinitions exposing (HashIndexedDefinition, OpenDefinitions)
 import RemoteData exposing (RemoteData(..), WebData)
@@ -271,29 +273,52 @@ scrollToDefinition hash =
 -- VIEW
 
 
+viewListingRow : Maybe msg -> String -> String -> Icon.Icon -> Html msg
+viewListingRow clickMsg label_ category icon =
+    let
+        containerClass =
+            class ("node " ++ category)
+
+        container =
+            clickMsg
+                |> Maybe.map (\msg -> a [ containerClass, onClick msg ])
+                |> Maybe.withDefault (span [ containerClass ])
+    in
+    container
+        [ Icon.view icon
+        , label [] [ text label_ ]
+        , span [ class "definition-category" ] [ text category ]
+        ]
+
+
 viewDefinitionListing : DefinitionListing -> Html Msg
 viewDefinitionListing listing =
+    let
+        viewDefRow hash fqn =
+            viewListingRow (Just (OpenDefinition hash)) (unqualifiedName fqn)
+    in
     case listing of
-        TypeListing hash fqn ->
-            a [ class "node type", onClick (OpenDefinition hash) ]
-                [ Icon.view Icon.Type
-                , label [] [ text (unqualifiedName fqn) ]
-                , span [ class "definition-type" ] [ text "type" ]
-                ]
+        TypeListing hash fqn category ->
+            case category of
+                DataType ->
+                    viewDefRow hash fqn "type" Icon.Type
 
-        TermListing hash fqn ->
-            a [ class "node term", onClick (OpenDefinition hash) ]
-                [ Icon.view Icon.Term
-                , label [] [ text (unqualifiedName fqn) ]
-                , span [ class "definition-type" ] [ text "term" ]
-                ]
+                AbilityType ->
+                    viewDefRow hash fqn "ability" Icon.Ability
+
+        TermListing hash fqn category ->
+            case category of
+                PlainTerm ->
+                    viewDefRow hash fqn "term" Icon.Term
+
+                TestTerm ->
+                    viewDefRow hash fqn "test" Icon.Test
+
+                DocTerm ->
+                    viewDefRow hash fqn "doc" Icon.Doc
 
         PatchListing _ ->
-            a [ class "node patch" ]
-                [ Icon.view Icon.Patch
-                , label [] [ text "Patch" ]
-                , span [ class "definition-type" ] [ text "patch" ]
-                ]
+            viewListingRow Nothing "Patch" "patch" Icon.Patch
 
 
 viewLoadedNamespaceListingContent : FQNSet -> NamespaceListingContent -> Html Msg

--- a/src/UI/Icon.elm
+++ b/src/UI/Icon.elm
@@ -16,8 +16,9 @@ type Icon
     | Patch
     | Term
     | Ability
+    | Test
     | Type
-    | Document
+    | Doc
     | Folder
     | Plus
     | Hash
@@ -89,8 +90,11 @@ toIdString icon =
         Type ->
             "type"
 
-        Document ->
-            "document"
+        Test ->
+            "test"
+
+        Doc ->
+            "doc"
 
         Folder ->
             "folder"


### PR DESCRIPTION
## Overview
* Add support for a definition category to support icons for abilities,
  tests, and docs (in addition to type and terms).
* Parse `typeTag` and `termTag` from the server listings into definition
  categories