### PR TITLE
Add base Finder modal

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -22,10 +22,6 @@ li {
   --main-sidebar-width: 16rem;
   --border-radius-base: 0.25rem;
 
-  /* -- Animations --------------------------------------------------------- */
-
-  --anim-elastic: cubic-bezier(0.68, -0.4, 0.32, 1.4);
-
   /* -- Font --------------------------------------------------------------- */
 
   --font-sans-serif: "Inter", sans-serif;
@@ -130,7 +126,34 @@ li {
   }
 }
 
+/* -- Animations ----------------------------------------------------------- */
+
+:root {
+  --anim-elastic: cubic-bezier(0.68, -0.4, 0.32, 1.4);
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes slide-up {
+  0% {
+    opacity: 0;
+    transform: translateY(1rem);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* -- Global --------------------------------------------------------------- */
+
 html {
   font-size: var(--base-size);
   font-family: var(--font-sans-serif);
@@ -153,6 +176,17 @@ a:visited {
 
 a:hover {
   text-decoration: underline;
+}
+
+input {
+  border: 0;
+  border-radius: 0;
+  font-family: var(--font-sans-serif);
+  caret-color: var(--color-main-focus-fg);
+}
+
+::placeholder {
+  color: var(--color-main-subtle-fg);
 }
 
 /* -- Syntax --------------------------------------------------------------- */
@@ -352,6 +386,35 @@ button {
   font-weight: bold;
   height: 2rem;
   padding: 0 0.75rem;
+  cursor: pointer;
+  transition: all 0.1s ease-in;
+}
+
+button:focus {
+  outline: none;
+}
+
+button:hover {
+  box-shadow: inset 0 0 0 1px var(--color-gray-lighten-40);
+}
+
+button:active {
+  background: var(--color-blue-base);
+  box-shadow: none;
+}
+
+#modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex: 1;
+  flex-shrink: 3;
+  justify-content: center;
+  animation: fade-in 0.2s ease-out;
 }
 
 /* -- Icon ----------------------------------------------------------------- */
@@ -519,17 +582,20 @@ button {
   height: calc(100vh - 3.5rem);
   scroll-behavior: smooth;
   scrollbar-width: auto;
-  scrollbar-color: var(--color-workspace-subtle-fg)
+  scrollbar-color: var(--color-workspace-item-subtle-fg)
     var(--color-workspace-item-bg);
 }
+
 #workspace-content::-webkit-scrollbar {
   width: 0.5rem;
 }
+
 #workspace-content::-webkit-scrollbar-track {
-  background: var(--color-workspace-mg);
+  background: var(--color-workspace-item-bg);
 }
+
 #workspace-content::-webkit-scrollbar-thumb {
-  background-color: var(--color-workspace-subtle-fg);
+  background-color: var(--color-workspace-item-subtle-fg);
   border-radius: var(--border-radius-base);
 }
 
@@ -646,4 +712,65 @@ button {
 
 .definition-row.focused .close .icon {
   color: var(--color-workspace-item-focus-subtle-fg);
+}
+
+/* -- Finder --------------------------------------------------------------- */
+
+#finder {
+  background: var(--color-gray-lighten-100);
+  width: 40rem;
+  margin-top: 4rem;
+  border-radius: var(--border-radius-base);
+  overflow: hidden;
+  height: fit-content;
+  animation: slide-up 0.2s var(--anim-elastic);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+}
+
+#finder:focus {
+  outline: none;
+}
+
+#finder header {
+  background: var(--color-gray-lighten-60);
+  border-bottom: 1px solid var(--color-gray-lighten-50);
+  display: flex;
+  align-items: center;
+}
+
+#finder header .icon.search {
+  width: 1.125rem;
+  height: 1.125rem;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  color: var(--color-main-subtle-fg);
+}
+
+#finder input {
+  height: 3rem;
+  background: transparent;
+  width: 100%;
+  border-radius: 0;
+  font-size: 1rem;
+  line-height: 3rem;
+}
+
+#finder input:focus {
+  outline: none;
+}
+
+#finder .reset {
+  height: 3rem;
+  padding: 0 1rem;
+  justify-content: center;
+  align-items: center;
+  display: flex;
+}
+
+#finder .reset .icon {
+  color: var(--color-main-subtle-fg);
+}
+
+#finder .reset .icon:hover {
+  color: var(--color-main-fg);
 }

--- a/src/Finder.elm
+++ b/src/Finder.elm
@@ -1,0 +1,135 @@
+module Finder exposing (Model, Msg, OutMsg(..), init, update, view)
+
+import Browser.Dom as Dom
+import Html exposing (Html, a, header, input)
+import Html.Attributes exposing (autocomplete, class, id, placeholder, type_, value)
+import Html.Events exposing (on, onClick, onInput)
+import Json.Decode as Decode
+import Keyboard.Event exposing (KeyboardEvent, decodeKeyboardEvent)
+import Keyboard.Key exposing (Key(..))
+import Task
+import UI.Icon as Icon
+import UI.Modal as Modal
+
+
+
+-- MODEL
+
+
+type alias Model =
+    { query : String }
+
+
+init : ( Model, Cmd Msg )
+init =
+    ( { query = "" }, focusSearchInput )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = NoOp
+    | UpdateQuery String
+    | ResetOrClose
+    | Close
+    | HandleKeyboardEvent KeyboardEvent
+
+
+type OutMsg
+    = Remain
+    | Exit
+
+
+update : Msg -> Model -> ( Model, Cmd Msg, OutMsg )
+update msg model =
+    let
+        exit =
+            ( model, Cmd.none, Exit )
+
+        reset =
+            ( { model | query = "" }, focusSearchInput, Remain )
+
+        resetOrClose =
+            if model.query == "" then
+                exit
+
+            else
+                reset
+    in
+    case msg of
+        UpdateQuery query ->
+            ( { model | query = query }, Cmd.none, Remain )
+
+        Close ->
+            exit
+
+        ResetOrClose ->
+            resetOrClose
+
+        HandleKeyboardEvent event ->
+            case event.keyCode of
+                Escape ->
+                    resetOrClose
+
+                _ ->
+                    ( model, Cmd.none, Remain )
+
+        _ ->
+            ( model, Cmd.none, Remain )
+
+
+
+-- EFFECTS
+
+
+focusSearchInput : Cmd Msg
+focusSearchInput =
+    Task.attempt (\_ -> NoOp) (Dom.focus "search")
+
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model =
+    Modal.view
+        Close
+        [ id "finder"
+        , onKeydown
+        ]
+        [ header []
+            [ Icon.view Icon.Search
+            , input
+                [ type_ "text"
+                , id "search"
+                , autocomplete False
+                , placeholder "Search by name, namespace, and/or type"
+                , onInput UpdateQuery
+                , value model.query
+                ]
+                []
+            , a [ class "reset", onClick ResetOrClose ] [ Icon.view Icon.X ]
+            ]
+        ]
+
+
+onKeydown : Html.Attribute Msg
+onKeydown =
+    let
+        decodeKey =
+            Decode.map HandleKeyboardEvent decodeKeyboardEvent
+    in
+    Html.Events.custom "keydown"
+        (decodeKey
+            |> Decode.andThen
+                (\msg ->
+                    Decode.succeed
+                        { message = msg
+                        , stopPropagation = True
+                        , preventDefault = False
+                        }
+                )
+        )

--- a/src/UI/Modal.elm
+++ b/src/UI/Modal.elm
@@ -1,0 +1,35 @@
+module UI.Modal exposing (view)
+
+import Html exposing (Attribute, Html, div)
+import Html.Attributes exposing (id, tabindex)
+import Html.Events exposing (on)
+import Json.Decode as Decode
+
+
+view : msg -> List (Attribute msg) -> List (Html msg) -> Html msg
+view closeMsg attrs content =
+    div [ id overlayId, on "click" (decodeOverlayClick closeMsg) ]
+        [ div (tabindex 0 :: attrs) content
+        ]
+
+
+
+-- INTERNAL
+
+
+overlayId : String
+overlayId =
+    "modal-overlay"
+
+
+decodeOverlayClick : msg -> Decode.Decoder msg
+decodeOverlayClick closeMsg =
+    Decode.at [ "target", "id" ] Decode.string
+        |> Decode.andThen
+            (\c ->
+                if String.contains overlayId c then
+                    Decode.succeed closeMsg
+
+                else
+                    Decode.fail "ignoring"
+            )

--- a/src/Util.elm
+++ b/src/Util.elm
@@ -1,5 +1,6 @@
 module Util exposing (..)
 
+import Html
 import Json.Decode as Decode
 import List.Nonempty as NEL
 


### PR DESCRIPTION
## Overview
Add a new Finder module with very basic UI for showing a modal and an
input field. The Modal module that drives this supports clicking outside
to close and the Finder module supports keyboard shortcuts and is hooked
up to the "Open" button in the workspace toolbar.

https://user-images.githubusercontent.com/2371/110646996-7516e400-8185-11eb-8de7-b09a185e2b2f.mp4

## Loose ends
This isn't connected to any backend and currently only covers the query state.
