### PR TITLE
Add a SearchResults data type that wraps a Zipper

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "direct": {
             "Gizra/elm-keyboard-event": "1.0.1",
+            "SwiftsNamesake/proper-keyboard": "4.0.0",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
@@ -16,10 +17,11 @@
             "elm/url": "1.0.0",
             "elm-community/json-extra": "4.3.0",
             "elm-community/list-extra": "8.2.4",
+            "elm-community/maybe-extra": "5.2.0",
             "krisajenkins/remotedata": "6.0.1",
             "mgold/elm-nonempty-list": "4.1.0",
-            "SwiftsNamesake/proper-keyboard": "4.0.0",
-            "stoeffel/set-extra": "1.2.3"
+            "stoeffel/set-extra": "1.2.3",
+            "wernerdegroot/listzipper": "4.0.0"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/src/Finder.elm
+++ b/src/Finder.elm
@@ -1,12 +1,15 @@
 module Finder exposing (Model, Msg, OutMsg(..), init, update, view)
 
 import Browser.Dom as Dom
+import Definition exposing (Definition)
 import Html exposing (Html, a, header, input)
 import Html.Attributes exposing (autocomplete, class, id, placeholder, type_, value)
-import Html.Events exposing (on, onClick, onInput)
+import Html.Events exposing (onClick, onInput)
 import Json.Decode as Decode
 import Keyboard.Event exposing (KeyboardEvent, decodeKeyboardEvent)
 import Keyboard.Key exposing (Key(..))
+import RemoteData exposing (WebData)
+import SearchResults exposing (SearchResults)
 import Task
 import UI.Icon as Icon
 import UI.Modal as Modal
@@ -16,13 +19,17 @@ import UI.Modal as Modal
 -- MODEL
 
 
+type alias FinderSearchResults =
+    SearchResults Definition
+
+
 type alias Model =
-    { query : String }
+    { query : String, results : WebData FinderSearchResults }
 
 
 init : ( Model, Cmd Msg )
 init =
-    ( { query = "" }, focusSearchInput )
+    ( { query = "", results = RemoteData.NotAsked }, focusSearchInput )
 
 
 

--- a/src/SearchResults.elm
+++ b/src/SearchResults.elm
@@ -1,0 +1,148 @@
+module SearchResults exposing
+    ( Matches
+    , SearchResults(..)
+    , focus
+    , focusOn
+    , from
+    , fromList
+    , isEmpty
+    , length
+    , map
+    , mapMatchesToList
+    , mapToList
+    , next
+    , prev
+    , toList
+    , toMaybe
+    )
+
+import List.Zipper as Zipper exposing (Zipper)
+import Maybe.Extra exposing (unwrap)
+
+
+
+-- SEARCH RESULT
+
+
+type SearchResults a
+    = Empty
+    | SearchResults (Matches a)
+
+
+isEmpty : SearchResults a -> Bool
+isEmpty results =
+    case results of
+        Empty ->
+            True
+
+        SearchResults _ ->
+            False
+
+
+fromList : List a -> SearchResults a
+fromList data =
+    unwrap Empty (Matches >> SearchResults) (Zipper.fromList data)
+
+
+from : List a -> a -> List a -> SearchResults a
+from before focus_ after =
+    SearchResults (Matches (Zipper.from before focus_ after))
+
+
+length : SearchResults a -> Int
+length results =
+    case results of
+        Empty ->
+            0
+
+        SearchResults (Matches data) ->
+            data
+                |> Zipper.toList
+                |> List.length
+
+
+map : (Matches a -> Matches a) -> SearchResults a -> SearchResults a
+map f results =
+    case results of
+        Empty ->
+            Empty
+
+        SearchResults matches ->
+            SearchResults (f matches)
+
+
+mapToList : (a -> Bool -> b) -> SearchResults a -> List b
+mapToList f results =
+    case results of
+        Empty ->
+            []
+
+        SearchResults matches ->
+            mapMatchesToList f matches
+
+
+toMaybe : SearchResults a -> Maybe (Matches a)
+toMaybe results =
+    case results of
+        Empty ->
+            Nothing
+
+        SearchResults matches ->
+            Just matches
+
+
+toList : SearchResults a -> List a
+toList results =
+    case results of
+        Empty ->
+            []
+
+        SearchResults (Matches data) ->
+            Zipper.toList data
+
+
+
+-- MATCHES
+
+
+type Matches a
+    = Matches (Zipper a)
+
+
+next : Matches a -> Matches a
+next ((Matches data) as matches) =
+    unwrap matches Matches (Zipper.next data)
+
+
+prev : Matches a -> Matches a
+prev ((Matches data) as matches) =
+    unwrap matches Matches (Zipper.previous data)
+
+
+focus : Matches a -> a
+focus (Matches data) =
+    Zipper.current data
+
+
+focusOn : (a -> Bool) -> Matches a -> Matches a
+focusOn pred ((Matches data) as matches) =
+    unwrap matches Matches (Zipper.findFirst pred data)
+
+
+mapMatchesToList : (a -> Bool -> b) -> Matches a -> List b
+mapMatchesToList f (Matches data) =
+    let
+        before =
+            data
+                |> Zipper.before
+                |> List.map (\a -> f a False)
+
+        focus_ =
+            f (Zipper.current data) True
+
+        after =
+            data
+                |> Zipper.after
+                |> List.map (\a -> f a False)
+    in
+    before ++ (focus_ :: after)

--- a/tests/OpenDefinitionsTests.elm
+++ b/tests/OpenDefinitionsTests.elm
@@ -262,7 +262,7 @@ next =
 prev : Test
 prev =
     describe "OpenDefinitions.prev"
-        [ test "moves focus to the next element" <|
+        [ test "moves focus to the prev element" <|
             \_ ->
                 let
                     result =

--- a/tests/SearchResultsTests.elm
+++ b/tests/SearchResultsTests.elm
@@ -1,0 +1,99 @@
+module SearchResultsTests exposing (..)
+
+import Expect
+import SearchResults exposing (..)
+import Test exposing (..)
+
+
+fromList : Test
+fromList =
+    describe "SearchResults.fromList"
+        [ test "Returns Empty for empty list" <|
+            \_ ->
+                let
+                    result =
+                        SearchResults.fromList []
+                in
+                Expect.equal SearchResults.Empty result
+        , test "Includes all matches" <|
+            \_ ->
+                let
+                    result =
+                        SearchResults.fromList [ "a", "b", "c" ]
+                            |> SearchResults.toList
+                in
+                Expect.equal [ "a", "b", "c" ] result
+        ]
+
+
+next : Test
+next =
+    describe "SearchResults.next"
+        [ test "moves focus to the next element" <|
+            \_ ->
+                let
+                    result =
+                        SearchResults.from [ "a" ] "b" [ "c" ]
+                            |> SearchResults.map SearchResults.next
+                            |> SearchResults.toMaybe
+                            |> Maybe.map SearchResults.focus
+                in
+                Expect.equal (Just "c") result
+        , test "keeps focus if no elements after" <|
+            \_ ->
+                let
+                    result =
+                        SearchResults.from [ "a", "b" ] "c" []
+                            |> SearchResults.map SearchResults.next
+                            |> SearchResults.toMaybe
+                            |> Maybe.map SearchResults.focus
+                in
+                Expect.equal (Just "c") result
+        ]
+
+
+prev : Test
+prev =
+    describe "SearchResults.prev"
+        [ test "moves focus to the prev element" <|
+            \_ ->
+                let
+                    result =
+                        SearchResults.from [ "a" ] "b" [ "c" ]
+                            |> SearchResults.map SearchResults.prev
+                            |> SearchResults.toMaybe
+                            |> Maybe.map SearchResults.focus
+                in
+                Expect.equal (Just "a") result
+        , test "keeps focus if no elements before" <|
+            \_ ->
+                let
+                    result =
+                        SearchResults.from [] "a" [ "b", "c" ]
+                            |> SearchResults.map SearchResults.prev
+                            |> SearchResults.toMaybe
+                            |> Maybe.map SearchResults.focus
+                in
+                Expect.equal (Just "a") result
+        ]
+
+
+
+-- MAP
+
+
+mapToList : Test
+mapToList =
+    describe "SearchResults.mapToList"
+        [ test "Maps definitions" <|
+            \_ ->
+                let
+                    result =
+                        SearchResults.from [ "a" ] "b" [ "c" ]
+                            |> SearchResults.mapToList (\x isFocused -> ( x ++ "mapped", isFocused ))
+
+                    expected =
+                        [ ( "amapped", False ), ( "bmapped", True ), ( "cmapped", False ) ]
+                in
+                Expect.equal expected result
+        ]


### PR DESCRIPTION
## Overview
SearchResults are much like a Zipper, but with a few key difference:

* They can be empty
* Only their focus can be modified
* Construction is limited

## Implementation notes
More Zippers :)

I imagine that this SearchResults data type might be used for driving the Autocomplete UI
when we do editing. 

## Loose ends
At some point `OpenDefinitions` should be changed to wrap the Zipper library this PR pulls in.
