### PR TITLE
Fuzzy Finder: Render definition matches

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -12,15 +12,29 @@ h5,
 ul,
 p,
 ol,
+table,
+tr,
+td,
 li {
   margin: 0;
   padding: 0;
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 :root {
   --size-base: 16px;
   --main-sidebar-width: 16rem;
   --border-radius-base: 0.25rem;
+
+  /* -- Layers ------------------------------------------------------------- */
+  --layer-base: 1;
+  --layer-modal-overlay: 99;
+  --layer-modal: 100;
+  --layer-modal-above: 110;
 
   /* -- Font --------------------------------------------------------------- */
 
@@ -99,6 +113,22 @@ li {
   --color-workspace-item-focus-subtle-fg: var(--color-gray-lighten-20);
   --color-workspace-item-focus-mg: var(--color-gray-lighten-50);
   --color-workspace-item-focus-bg: var(--color-gray-lighten-55);
+
+  --color-modal-fg: var(--color-main-fg);
+  --color-modal-mg: var(--color-gray-lighten-60);
+  --color-modal-bg: var(--color-gray-lighten-100);
+  --color-modal-inner-border: var(--color-gray-lighten-50);
+  --color-modal-separator: var(--color-gray-lighten-55);
+  --color-modal-shadow: rgba(24, 24, 28, 0.2); /* 20% gray-darken-30 */
+  --color-modal-overlay: rgba(24, 24, 28, 0.5); /* 50% gray-darken-30 */
+  --color-modal-border: transparent;
+  --color-modal-subtle-fg: var(--color-main-subtle-fg);
+  --color-modal-subtle-fg-em: var(--color-gray-lighten-20);
+  --color-modal-subtle-bg: var(--color-gray-lighten-60);
+  --color-modal-focus-fg: var(--color-main-fg);
+  --color-modal-focus-bg: var(--color-gray-lighten-55);
+  --color-modal-focus-subtle-fg: var(--color-gray-base);
+  --color-modal-focus-subtle-bg: var(--color-gray-lighten-50);
 
   --color-icon-type: var(--color-brand-orange);
   --color-icon-test: var(--color-green-base);
@@ -394,15 +424,34 @@ code a:active {
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--color-modal-overlay);
   display: flex;
   flex: 1;
   flex-shrink: 3;
   justify-content: center;
   animation: fade-in 0.2s ease-out;
+  z-index: (--layer-modal-overlay);
 }
 
-/* -- Buttons -------------------------------------------------------------- */
+.modal {
+  position: relative;
+  background: var(--color-modal-bg);
+  border-radius: var(--border-radius-base);
+  border: 1px solid var(--color-modal-border);
+  width: 50rem;
+  margin-top: 4rem;
+  overflow: hidden;
+  height: fit-content;
+  animation: slide-up 0.2s var(--anim-elastic);
+  box-shadow: 0 6px 16px var(--color-modal-shadow);
+  z-index: (--layer-modal);
+}
+
+.modal:focus {
+  outline: none;
+}
+
+/* Buttons */
 
 button {
   border: 0;
@@ -443,7 +492,7 @@ button.secondary:hover {
   background: var(--color-button-secondary-hover-bg);
 }
 
-/* -- Icon ----------------------------------------------------------------- */
+/* Icons */
 
 .icon {
   display: inline-block;
@@ -475,6 +524,30 @@ button.secondary:hover {
 
 .icon.patch {
   color: var(--color-icon-patch);
+}
+
+/* Keyboard shortcut indicators */
+
+.keyboard-shortcut .key {
+  height: 1.5rem;
+  width: 1.5rem;
+  font-size: 0.75rem;
+  border-radius: var(--border-radius-base);
+  text-align: center;
+  display: inline-flex;
+  justify-content: center;
+  align-content: center;
+  align-items: center;
+  background: var(--color-main-subtle-bg);
+  color: var(--color-main-subtle-fg);
+}
+
+.keyboard-shortcut .instruction {
+  display: inline-flex;
+  width: 2rem;
+  font-size: 0.625rem;
+  justify-content: center;
+  color: var(--color-main-subtle-fg);
 }
 
 /* -- Application ---------------------------------------------------------- */
@@ -742,24 +815,13 @@ button.secondary:hover {
 
 /* -- Finder --------------------------------------------------------------- */
 
-#finder {
-  background: var(--color-gray-lighten-100);
-  width: 40rem;
-  margin-top: 4rem;
-  border-radius: var(--border-radius-base);
-  overflow: hidden;
-  height: fit-content;
-  animation: slide-up 0.2s var(--anim-elastic);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
-}
-
 #finder:focus {
   outline: none;
 }
 
 #finder header {
-  background: var(--color-gray-lighten-60);
-  border-bottom: 1px solid var(--color-gray-lighten-50);
+  background: var(--color-modal-mg);
+  border-bottom: 1px solid var(--color-modal-inner-border);
   display: flex;
   align-items: center;
 }
@@ -769,16 +831,21 @@ button.secondary:hover {
   height: 1.125rem;
   margin-left: 1rem;
   margin-right: 1rem;
-  color: var(--color-main-subtle-fg);
+  color: var(--color-modal-subtle-fg);
 }
 
 #finder input {
-  height: 3rem;
+  height: 2rem;
   background: transparent;
   width: 100%;
   border-radius: 0;
   font-size: 1rem;
-  line-height: 3rem;
+  font-weight: bold;
+  line-height: 2rem;
+}
+
+#finder input::placeholder {
+  font-weight: normal;
 }
 
 #finder input:focus {
@@ -794,9 +861,78 @@ button.secondary:hover {
 }
 
 #finder .reset .icon {
-  color: var(--color-main-subtle-fg);
+  color: var(--color-modal-subtle-fg);
 }
 
 #finder .reset:hover .icon {
-  color: var(--color-main-fg);
+  color: var(--color-modal-fg);
+}
+
+#finder .results {
+  position: relative;
+  padding: 0.75rem;
+}
+
+#finder .results .column-line {
+  position: absolute;
+  top: 0.75rem;
+  bottom: 0.75rem;
+  width: 1px;
+  background: var(--color-modal-separator);
+  margin-left: calc(2rem + 0.75rem + 0.875rem);
+}
+
+#finder .definition-match {
+  position: relative;
+  z-index: var(--layer-modal-above);
+  height: 3rem;
+  padding: 0 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+#finder .definition-match .icon {
+  margin-right: 0.5rem;
+}
+
+#finder .definition-match code {
+  line-height: inherit;
+}
+
+#finder .definition-match pre {
+  font-size: 0.75rem;
+}
+
+#finder .definition-match .name {
+  font-weight: bold;
+  max-width: 10rem;
+  margin-right: 2rem;
+}
+
+#finder .definition-match .keyboard-shortcut {
+  margin-left: auto;
+  font-size: 0.75rem;
+}
+
+#finder .definition-match .keyboard-shortcut .key {
+  color: var(--color-modal-subtle-fg-em);
+  background: var(--color-modal-subtle-bg);
+}
+
+#finder .definition-match .keyboard-shortcut .instruction {
+  color: var(--color-modal-subtle-fg);
+}
+
+#finder .definition-match.focused {
+  background: var(--color-modal-focus-bg);
+  border-radius: var(--border-radius-base);
+  box-shadow: 0 0 0 0.25rem var(--color-modal-bg);
+}
+
+#finder .definition-match.focused .keyboard-shortcut .key {
+  color: var(--color-modal-focus-subtle-fg);
+  background: var(--color-modal-focus-subtle-bg);
 }

--- a/src/App.elm
+++ b/src/App.elm
@@ -211,6 +211,9 @@ update msg model =
                         Finder.Exit ->
                             ( { model | modal = NoModal }, Cmd.none )
 
+                        Finder.OpenDefinition hash ->
+                            openDefinition { model | modal = NoModal } Nothing hash
+
 
 
 -- UPDATE HELPERS

--- a/src/Definition.elm
+++ b/src/Definition.elm
@@ -61,6 +61,21 @@ hash definition =
             h
 
 
+name : Definition -> String
+name definition =
+    case definition of
+        Type _ info ->
+            info.name
+
+        Term _ info ->
+            info.name
+
+
+equals : Definition -> Definition -> Bool
+equals a b =
+    Hash.equals (hash a) (hash b)
+
+
 
 -- VIEW
 

--- a/src/KeyboardShortcuts.elm
+++ b/src/KeyboardShortcuts.elm
@@ -1,0 +1,108 @@
+module KeyboardShortcuts exposing (..)
+
+import Html exposing (Html, span, text)
+import Html.Attributes exposing (class)
+import Html.Events
+import Json.Decode as Decode
+import Keyboard.Event exposing (KeyboardEvent, decodeKeyboardEvent)
+
+
+type Shortcut
+    = Single String
+    | Sequence String String
+    | Combination String String
+
+
+
+-- HELPERS
+
+
+indexToShortcut : Int -> Maybe String
+indexToShortcut index =
+    let
+        n =
+            index + 1
+    in
+    if n > 9 then
+        Nothing
+
+    else
+        Just (String.fromInt n)
+
+
+
+-- VIEW
+
+
+viewKey : String -> Html msg
+viewKey key =
+    span [ class "key" ] [ text key ]
+
+
+viewShortcut : Shortcut -> Html msg
+viewShortcut shortcut =
+    let
+        instruction text_ =
+            span [ class "shortcut-instruction" ] [ text text_ ]
+
+        content =
+            case shortcut of
+                Single key ->
+                    [ viewKey key ]
+
+                Sequence keyA keyB ->
+                    [ viewKey keyA
+                    , instruction "then"
+                    , viewKey keyB
+                    ]
+
+                Combination mod key ->
+                    [ viewKey mod
+                    , instruction "plus"
+                    , viewKey key
+                    ]
+    in
+    span [ class "keyboard-shortcut" ] content
+
+
+
+-- EVENTS
+
+
+stopPropagationOnKeyup : (KeyboardEvent -> msg) -> Html.Attribute msg
+stopPropagationOnKeyup toMsg =
+    Html.Events.custom "keyup"
+        (decodeKey toMsg
+            |> Decode.andThen
+                (\msg ->
+                    Decode.succeed
+                        { message = msg
+                        , stopPropagation = True
+                        , preventDefault = False
+                        }
+                )
+        )
+
+
+stopPropagationOnKeydown : (KeyboardEvent -> msg) -> Html.Attribute msg
+stopPropagationOnKeydown toMsg =
+    Html.Events.custom "keydown"
+        (decodeKey toMsg
+            |> Decode.andThen
+                (\msg ->
+                    Decode.succeed
+                        { message = msg
+                        , stopPropagation = True
+                        , preventDefault = False
+                        }
+                )
+        )
+
+
+
+-- DECODE
+
+
+decodeKey : (KeyboardEvent -> msg) -> Decode.Decoder msg
+decodeKey toMsg =
+    Decode.map toMsg decodeKeyboardEvent

--- a/src/SearchResults.elm
+++ b/src/SearchResults.elm
@@ -10,6 +10,7 @@ module SearchResults exposing
     , map
     , mapMatchesToList
     , mapToList
+    , matchesToList
     , next
     , prev
     , toList
@@ -97,8 +98,28 @@ toList results =
         Empty ->
             []
 
-        SearchResults (Matches data) ->
-            Zipper.toList data
+        SearchResults matches ->
+            matchesToList matches
+
+
+next : SearchResults a -> SearchResults a
+next =
+    map nextMatch
+
+
+prev : SearchResults a -> SearchResults a
+prev =
+    map prevMatch
+
+
+focusOn : (a -> Bool) -> SearchResults a -> SearchResults a
+focusOn pred results =
+    case results of
+        Empty ->
+            Empty
+
+        SearchResults matches ->
+            SearchResults (focusOnMatch pred matches)
 
 
 
@@ -109,13 +130,13 @@ type Matches a
     = Matches (Zipper a)
 
 
-next : Matches a -> Matches a
-next ((Matches data) as matches) =
+nextMatch : Matches a -> Matches a
+nextMatch ((Matches data) as matches) =
     unwrap matches Matches (Zipper.next data)
 
 
-prev : Matches a -> Matches a
-prev ((Matches data) as matches) =
+prevMatch : Matches a -> Matches a
+prevMatch ((Matches data) as matches) =
     unwrap matches Matches (Zipper.previous data)
 
 
@@ -124,9 +145,16 @@ focus (Matches data) =
     Zipper.current data
 
 
-focusOn : (a -> Bool) -> Matches a -> Matches a
-focusOn pred ((Matches data) as matches) =
+focusOnMatch : (a -> Bool) -> Matches a -> Matches a
+focusOnMatch pred ((Matches data) as matches) =
     unwrap matches Matches (Zipper.findFirst pred data)
+
+
+{-| TODO: Should this be List.Nonempty ? |
+-}
+matchesToList : Matches a -> List a
+matchesToList (Matches data) =
+    Zipper.toList data
 
 
 mapMatchesToList : (a -> Bool -> b) -> Matches a -> List b

--- a/src/UI.elm
+++ b/src/UI.elm
@@ -24,6 +24,11 @@ errorMessage message =
     div [ class "error-message" ] [ text message ]
 
 
+emptyStateMessage : String -> Html msg
+emptyStateMessage message =
+    div [ class "empty-state" ] [ text message ]
+
+
 codeInline : Html msg -> Html msg
 codeInline content =
     code [] [ content ]
@@ -32,3 +37,8 @@ codeInline content =
 codeBlock : Html msg -> Html msg
 codeBlock content =
     pre [] [ code [] [ content ] ]
+
+
+charWidth : Int -> String
+charWidth numChars =
+    String.fromInt numChars ++ "ch"

--- a/src/UI/Modal.elm
+++ b/src/UI/Modal.elm
@@ -1,7 +1,7 @@
 module UI.Modal exposing (view)
 
 import Html exposing (Attribute, Html, div)
-import Html.Attributes exposing (id, tabindex)
+import Html.Attributes exposing (class, id, tabindex)
 import Html.Events exposing (on)
 import Json.Decode as Decode
 
@@ -9,7 +9,7 @@ import Json.Decode as Decode
 view : msg -> List (Attribute msg) -> List (Html msg) -> Html msg
 view closeMsg attrs content =
     div [ id overlayId, on "click" (decodeOverlayClick closeMsg) ]
-        [ div (tabindex 0 :: attrs) content
+        [ div (tabindex 0 :: class "modal" :: attrs) content
         ]
 
 

--- a/tests/SearchResultsTests.elm
+++ b/tests/SearchResultsTests.elm
@@ -34,7 +34,7 @@ next =
                 let
                     result =
                         SearchResults.from [ "a" ] "b" [ "c" ]
-                            |> SearchResults.map SearchResults.next
+                            |> SearchResults.next
                             |> SearchResults.toMaybe
                             |> Maybe.map SearchResults.focus
                 in
@@ -44,7 +44,7 @@ next =
                 let
                     result =
                         SearchResults.from [ "a", "b" ] "c" []
-                            |> SearchResults.map SearchResults.next
+                            |> SearchResults.next
                             |> SearchResults.toMaybe
                             |> Maybe.map SearchResults.focus
                 in
@@ -60,7 +60,7 @@ prev =
                 let
                     result =
                         SearchResults.from [ "a" ] "b" [ "c" ]
-                            |> SearchResults.map SearchResults.prev
+                            |> SearchResults.prev
                             |> SearchResults.toMaybe
                             |> Maybe.map SearchResults.focus
                 in
@@ -70,7 +70,7 @@ prev =
                 let
                     result =
                         SearchResults.from [] "a" [ "b", "c" ]
-                            |> SearchResults.map SearchResults.prev
+                            |> SearchResults.prev
                             |> SearchResults.toMaybe
                             |> Maybe.map SearchResults.focus
                 in


### PR DESCRIPTION
## Overview
Render (mocked for now) definition matches based on the SearchResults
data structure, supporting navigation with arrow keys and mouse over and
selection with the enter key and mouse click, and indicating both focus
and keyboard shortcuts (the sequence shortcuts are not yet implemented).

https://user-images.githubusercontent.com/2371/111357747-f546b900-865f-11eb-934e-5c1e0a1240a2.mp4

## Implementation notes
The width of the definition name column name will vary depending on the
max character width of the names in the search result, resulting in the
signature being as close as possible to the left side while still being
aligned.

Introduce a new KeyboardShortcuts module for displaying shortcuts (and
eventually handling things like sequence and combos), setting up events
and decoding keyCodes into keys (using third-party libraries).

Also update the SearchResults data structure to be a little easier to
work with.

## Interesting/controversial decisions
The `KeyboardShortcuts` module might become a separate open source 
library for more generally dealing with sequence and combination shortcuts.

## Loose ends
I left the mocked data in here, it'll obviously be removed when integrating with the backend.
Perhaps stuff like this should be behind a feature flag in the future.
