### PR TITLE
Show namespace and other names of definitions

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -18,7 +18,9 @@
             "elm-community/json-extra": "4.3.0",
             "elm-community/list-extra": "8.2.4",
             "elm-community/maybe-extra": "5.2.0",
+            "elm-community/string-extra": "4.0.1",
             "krisajenkins/remotedata": "6.0.1",
+            "lukewestby/elm-string-interpolate": "1.0.4",
             "mgold/elm-nonempty-list": "4.1.0",
             "stoeffel/set-extra": "1.2.3",
             "wernerdegroot/listzipper": "4.0.0"
@@ -28,6 +30,7 @@
             "elm/file": "1.0.5",
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3"

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -43,6 +43,7 @@ table {
 
   --font-size-base: 1rem;
   --font-size-medium: 0.875rem;
+  --font-size-small: 0.75rem;
 
   /* -- All colors --------------------------------------------------------- */
 
@@ -105,11 +106,11 @@ table {
   --color-workspace-item-mg: var(--color-gray-lighten-60);
   --color-workspace-item-bg: var(--color-gray-lighten-100);
   --color-workspace-item-subtle-fg: var(--color-main-subtle-fg);
+  --color-workspace-item-subtle-fg-em: var(--color-gray-lighten-20);
   --color-workspace-item-subtle-bg: var(--color-main-subtle-bg);
   --color-workspace-item-border: var(--color-gray-lighten-50);
 
   --color-workspace-item-focus-fg: var(--color-blue-darken-20);
-  --color-workspace-item-focus-fg-em: var(--color-blue-darken-20);
   --color-workspace-item-focus-subtle-fg: var(--color-gray-lighten-20);
   --color-workspace-item-focus-mg: var(--color-gray-lighten-50);
   --color-workspace-item-focus-bg: var(--color-gray-lighten-55);
@@ -130,6 +131,7 @@ table {
   --color-modal-focus-subtle-fg: var(--color-gray-base);
   --color-modal-focus-subtle-bg: var(--color-gray-lighten-50);
 
+  /* Icons */
   --color-icon-type: var(--color-brand-orange);
   --color-icon-test: var(--color-green-base);
   --color-icon-term: var(--color-purple-base);
@@ -148,8 +150,11 @@ table {
   --color-button-secondary-hover-fg: var(--color-main-fg);
   --color-button-secondary-hover-bg: var(--color-gray-lighten-40);
 
-  /* -- Default Syntax Theme ------------------------------------------------*/
+  /* Tooltips */
+  --color-tooltip-fg: var(--color-gray-lighten-60);
+  --color-tooltip-bg: var(--color-gray-darken-30);
 
+  /* Syntax */
   --color-syntax-plain: var(--color-main-fg);
   --color-syntax-subtle: var(--color-main-subtle-fg);
   --color-syntax-keyword: #225ebe;
@@ -186,6 +191,17 @@ table {
   0% {
     opacity: 0;
     transform: translateY(1rem);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slide-down {
+  0% {
+    opacity: 0;
+    transform: translateY(-1rem);
   }
   100% {
     opacity: 1;
@@ -527,7 +543,47 @@ button.secondary:hover {
   color: var(--color-icon-patch);
 }
 
-/* Keyboard shortcut indicators */
+/* Tooltips */
+
+.tooltip {
+  position: absolute;
+  top: 1.75rem;
+  left: -0.8rem;
+  font-size: var(--font-size-medium);
+  color: var(--color-tooltip-fg);
+  background: var(--color-tooltip-bg);
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--border-radius-base);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.tooltip:after {
+  bottom: 100%;
+  left: 1rem;
+  border: solid transparent;
+  content: "";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+  border-color: rgba(0, 0, 0, 0);
+  border-bottom-color: #000000;
+  border-width: 0.375rem;
+  margin-left: -0.375rem;
+}
+
+.with-tooltip {
+  display: inline-block;
+  position: relative;
+}
+
+.with-tooltip:hover .tooltip {
+  animation: fade-in 0.2s;
+  opacity: 1;
+}
+
+/* Keyboard shortcuts */
 
 .keyboard-shortcut .key {
   height: 1.5rem;
@@ -717,10 +773,16 @@ button.secondary:hover {
 }
 
 .definition-row header {
+  position: relative;
   display: flex;
   flex-direction: row;
   flex: 1;
-  justify-content: space-between;
+  align-items: center;
+  height: 1rem;
+}
+
+.definition-row .close {
+  margin-left: auto;
 }
 
 .definition-row .close .icon {
@@ -728,19 +790,10 @@ button.secondary:hover {
 }
 
 .definition-row .close:hover .icon {
-  color: var(--color-item-workspace-fg);
-}
-
-.definition-row header {
-  position: relative;
-  display: flex;
-  flex-direction: row;
+  color: var(--color-workspace-item-fg);
 }
 
 .definition-row header .focus-indicator {
-  position: absolute;
-  top: 0.2rem;
-  content: "";
   background: var(--color-blue-base);
   border-radius: var(--border-radius-base);
   width: 0.375rem;
@@ -748,15 +801,50 @@ button.secondary:hover {
   will-change: transform;
   transform: translate(-2rem, 0);
   transition: transform 0.2s ease-out;
+  margin-top: -2px;
 }
 
-.definition-row header h3 {
-  color: var(--color-workspace-item-fg);
-  font-size: var(--font-size-base);
-  font-weight: bold;
+.definition-row header .names {
+  display: flex;
+  flex-direction: row;
   will-change: transform;
   transition: color 0.2s, transform 0.3s var(--anim-elastic);
   transform: translate(0, 0);
+  margin-left: -0.375rem; /* countering the focus-indicator width */
+}
+
+.definition-row header .names .name {
+  color: var(--color-workspace-item-fg);
+  font-size: var(--font-size-base);
+  font-weight: bold;
+}
+
+.definition-row header .names .separator {
+  color: var(--color-workspace-item-subtle-fg);
+  margin: 0 0.375rem;
+  cursor: default;
+}
+
+.definition-row header .names .info {
+  margin-top: 0.1rem;
+  font-size: var(--font-size-small);
+  display: flex;
+  flex-direction: row;
+}
+
+.definition-row header .names .namespace .in {
+  color: var(--color-workspace-item-subtle-fg-em);
+}
+
+.definition-row header .names .other-names {
+  height: 1rem;
+  color: var(--color-workspace-item-subtle-fg-em);
+  transition: all 0.2s;
+  cursor: help;
+}
+
+.definition-row header .names .other-names:hover {
+  color: var(--color-workspace-item-fg);
 }
 
 .definition-row .content {
@@ -792,6 +880,7 @@ button.secondary:hover {
 }
 
 /* Definition Row: Focused */
+
 .definition-row.focused {
   background: var(--color-workspace-item-focus-bg);
 }
@@ -800,9 +889,12 @@ button.secondary:hover {
   background: var(--color-workspace-item-focus-mg);
 }
 
-.definition-row.focused header h3 {
-  color: var(--color-blue-darken-20);
+.definition-row.focused header .names {
   transform: translate(1.125rem, 0);
+}
+
+.definition-row.focused header .name {
+  color: var(--color-blue-darken-20);
 }
 
 .definition-row.focused header .focus-indicator {

--- a/src/Finder.elm
+++ b/src/Finder.elm
@@ -38,25 +38,29 @@ init =
         mockedResults =
             SearchResults.fromList
                 [ Definition.Type (Hash.fromString "#base.List")
-                    { fqns = NEL.fromElement (FQN.fromString "base.List")
-                    , name = "List"
-                    , source = BuiltinType
-                    }
+                    (Definition.makeTypeDefinitionInfo
+                        "List"
+                        (NEL.fromElement (FQN.fromString "base.List"))
+                        BuiltinType
+                    )
                 , Definition.Type (Hash.fromString "#base.Map")
-                    { fqns = NEL.fromElement (FQN.fromString "base.Map")
-                    , name = "Map"
-                    , source = BuiltinType
-                    }
+                    (Definition.makeTypeDefinitionInfo
+                        "Map"
+                        (NEL.fromElement (FQN.fromString "base.Map"))
+                        BuiltinType
+                    )
                 , Definition.Type (Hash.fromString "#base.Set")
-                    { fqns = NEL.fromElement (FQN.fromString "base.Set")
-                    , name = "Set"
-                    , source = BuiltinType
-                    }
+                    (Definition.makeTypeDefinitionInfo
+                        "Set"
+                        (NEL.fromElement (FQN.fromString "base.Set"))
+                        BuiltinType
+                    )
                 , Definition.Type (Hash.fromString "#base.List.Nonempty")
-                    { fqns = NEL.fromElement (FQN.fromString "base.List.Nonempty")
-                    , name = "List.Nonempty"
-                    , source = BuiltinType
-                    }
+                    (Definition.makeTypeDefinitionInfo
+                        "List.Nonempty"
+                        (NEL.fromElement (FQN.fromString "base.List.Nonempty"))
+                        BuiltinType
+                    )
                 ]
     in
     ( { query = "", results = Success mockedResults }, focusSearchInput )

--- a/src/FullyQualifiedName.elm
+++ b/src/FullyQualifiedName.elm
@@ -5,12 +5,15 @@ module FullyQualifiedName exposing
     , equals
     , fromParent
     , fromString
+    , isSuffixOf
+    , namespaceOf
     , toString
     , unqualifiedName
     )
 
 import Json.Decode as Decode
 import List.Nonempty as NEL
+import String.Extra as StringE
 
 
 type FQN
@@ -75,6 +78,39 @@ unqualifiedName (FQN nameParts) =
 equals : FQN -> FQN -> Bool
 equals a b =
     toString a == toString b
+
+
+{-| This is passed through a string as a suffix name can include
+namespaces like List.map (where the FQN would be
+base.List.map)
+-}
+isSuffixOf : String -> FQN -> Bool
+isSuffixOf suffixName fqn =
+    String.endsWith suffixName (toString fqn)
+
+
+{-| TODO: We should distinquish between FQN, Namespace and SuffixName on a type
+level, or rename the FQN type to Name
+-}
+namespaceOf : String -> FQN -> Maybe String
+namespaceOf suffixName fqn =
+    let
+        dropLastDot s =
+            if String.endsWith "." s then
+                String.dropRight 1 s
+
+            else
+                s
+    in
+    if isSuffixOf suffixName fqn then
+        fqn
+            |> toString
+            |> String.replace suffixName ""
+            |> StringE.nonEmpty
+            |> Maybe.map dropLastDot
+
+    else
+        Nothing
 
 
 

--- a/src/UI.elm
+++ b/src/UI.elm
@@ -1,6 +1,6 @@
 module UI exposing (..)
 
-import Html exposing (Html, code, div, pre, text)
+import Html exposing (Html, code, div, pre, span, text)
 import Html.Attributes exposing (class)
 
 
@@ -42,3 +42,13 @@ codeBlock content =
 charWidth : Int -> String
 charWidth numChars =
     String.fromInt numChars ++ "ch"
+
+
+tooltip : Html msg -> Html msg
+tooltip content =
+    div [ class "tooltip" ] [ content ]
+
+
+withTooltip : Html msg -> Html msg -> Html msg
+withTooltip content triggerContent =
+    span [ class "with-tooltip" ] [ tooltip content, triggerContent ]

--- a/src/Util.elm
+++ b/src/Util.elm
@@ -1,6 +1,5 @@
 module Util exposing (..)
 
-import Html
 import Json.Decode as Decode
 import List.Nonempty as NEL
 

--- a/tests/FullyQualifiedNameTests.elm
+++ b/tests/FullyQualifiedNameTests.elm
@@ -53,3 +53,65 @@ unqualifiedName =
             \_ ->
                 Expect.equal "List" (FQN.unqualifiedName (FQN.fromString "base.List"))
         ]
+
+
+isSuffixOf : Test
+isSuffixOf =
+    describe "FullyQualifiedName.isSuffixOf"
+        [ test "Returns True when an FQN ends in the provided suffix" <|
+            \_ ->
+                let
+                    suffix =
+                        "List.map"
+
+                    fqn =
+                        FQN.fromString "base.List.map"
+                in
+                Expect.true "is correctly a suffix of" (FQN.isSuffixOf suffix fqn)
+        , test "Returns False when an FQN does not end in the provided suffix" <|
+            \_ ->
+                let
+                    suffix =
+                        "List.foldl"
+
+                    fqn =
+                        FQN.fromString "base.List.map"
+                in
+                Expect.false "is correctly *not* a suffix of" (FQN.isSuffixOf suffix fqn)
+        ]
+
+
+namespaceOf : Test
+namespaceOf =
+    describe "FullyQualifiedName.namespaceOf"
+        [ test "With an FQN including the suffix, it returns the non suffix part" <|
+            \_ ->
+                let
+                    suffix =
+                        "List.map"
+
+                    fqn =
+                        FQN.fromString "base.List.map"
+                in
+                Expect.equal (Just "base") (FQN.namespaceOf suffix fqn)
+        , test "When the suffix and FQN are exactly the same, it returns Nothing" <|
+            \_ ->
+                let
+                    suffix =
+                        "base.List.map"
+
+                    fqn =
+                        FQN.fromString "base.List.map"
+                in
+                Expect.equal Nothing (FQN.namespaceOf suffix fqn)
+        , test "When the suffix is not included at all in the FQN, it returns Nothing" <|
+            \_ ->
+                let
+                    suffix =
+                        "List.map.foldl"
+
+                    fqn =
+                        FQN.fromString "base.List.map"
+                in
+                Expect.equal Nothing (FQN.namespaceOf suffix fqn)
+        ]


### PR DESCRIPTION
## Overview
Add the namespace of a definition along with a list of other names when
they exist. Construct these values from the list of names when decoding
the Definition JSON response.

<img width="1115" alt="Screen Shot 2021-03-17 at 13 52 01" src="https://user-images.githubusercontent.com/2371/111522255-79687180-8730-11eb-98d6-e1368dacf3e1.png">

## Implementation notes / Loose ends

* Currently definitions are always fetched by hash which in the screenshot resulted in the weird difference between clicking on `+` and getting `plus`, there's a separate effort to fetch definitions by name when possible.
* Slightly related to the above; @runarorama could the backend use the `bestName` as the name of the term/type in its source instead of an FQN?
* To select the namespace, I pick the first name one that includes the suffix name, and chop off the suffix.
This doesn't seem like the best way to do this and perhaps this is something we can do on the backend instead to have a complete alignment of bestName and the associated namespace. What do you think @runarorama ?
* I think my FQN module should likely be changed to a more general `Names` module that deals with FQNs, suffix names and namespaces in a more structured way; I could definitely benefit some pairing on a design for that.

(All of the items below should be handled separately from this PR)