### PR TITLE
Fetch definitions from sidebar using name

### DIFF
--- a/src/Api.elm
+++ b/src/Api.elm
@@ -16,8 +16,8 @@ list rawFQN =
 
 
 definitions : List String -> String
-definitions hashes =
-    hashes
+definitions fqnsOrHashes =
+    fqnsOrHashes
         |> List.map (string "names")
         |> serverUrl [ "getDefinition" ]
 

--- a/src/FullyQualifiedName.elm
+++ b/src/FullyQualifiedName.elm
@@ -21,13 +21,22 @@ type FQN
 -- HELPERS
 
 
-{-| Turn a string, like "base.List.map" into FQN ["base", "List", "map"] |
+{-| Turn a string, like "base.List.map" into FQN ["base", "List", "map"]
 -}
 fromString : String -> FQN
 fromString rawFqn =
+    let
+        rootEmptyToDot i s =
+            if i == 0 && String.isEmpty s then
+                "."
+
+            else
+                s
+    in
     rawFqn
         |> String.split "."
         |> List.map String.trim
+        |> List.indexedMap rootEmptyToDot
         |> List.filter (\s -> String.length s > 0)
         |> NEL.fromList
         |> Maybe.withDefault (NEL.fromElement ".")
@@ -36,9 +45,21 @@ fromString rawFqn =
 
 toString : FQN -> String
 toString (FQN nameParts) =
+    let
+        -- Absolute FQNs start with a dot, so when also
+        -- joining parts using a dot, we get dot dot (..),
+        -- which we don't want.
+        trimLeadingDot str =
+            if String.startsWith ".." str then
+                String.dropLeft 1 str
+
+            else
+                str
+    in
     nameParts
         |> NEL.toList
         |> String.join "."
+        |> trimLeadingDot
 
 
 fromParent : FQN -> String -> FQN

--- a/src/HashQualified.elm
+++ b/src/HashQualified.elm
@@ -1,0 +1,49 @@
+module HashQualified exposing (..)
+
+import FullyQualifiedName as FQN exposing (FQN)
+import Hash exposing (Hash)
+
+
+type HashQualified
+    = HashOnly Hash
+    | HashQualified FQN Hash
+
+
+type ToStringPrefererence
+    = PreferName
+    | PreferHash
+
+
+toString : ToStringPrefererence -> HashQualified -> String
+toString preference hq =
+    case hq of
+        HashOnly hash_ ->
+            Hash.toString hash_
+
+        HashQualified fqn hash_ ->
+            case preference of
+                PreferName ->
+                    FQN.toString fqn
+
+                PreferHash ->
+                    Hash.toString hash_
+
+
+name : HashQualified -> Maybe FQN
+name hq =
+    case hq of
+        HashOnly _ ->
+            Nothing
+
+        HashQualified fqn _ ->
+            Just fqn
+
+
+hash : HashQualified -> Hash
+hash hq =
+    case hq of
+        HashOnly h ->
+            h
+
+        HashQualified _ h ->
+            h

--- a/src/Syntax.elm
+++ b/src/Syntax.elm
@@ -56,7 +56,7 @@ type SyntaxType
     | UseKeyword
     | UsePrefix
     | UseSuffix
-      -- TODO: Should this be NameOnly Name | HashOnly Hash | HashQualified Name Hash
+      -- TODO: This should be a HashQualified
     | HashQualifier String
       -- ! '
     | DelayForceChar

--- a/tests/FullyQualifiedNameTests.elm
+++ b/tests/FullyQualifiedNameTests.elm
@@ -11,7 +11,7 @@ fromString =
         [ test "Creates an FQN from a string" <|
             \_ ->
                 Expect.equal "a.b.c" (FQN.toString (FQN.fromString "a.b.c"))
-        , describe "With an empty raw path"
+        , describe "Root"
             [ test "Creates a root FQN from \"\"" <|
                 \_ ->
                     Expect.equal "." (FQN.toString (FQN.fromString ""))
@@ -22,6 +22,18 @@ fromString =
                 \_ ->
                     Expect.equal "." (FQN.toString (FQN.fromString "."))
             ]
+        ]
+
+
+toString : Test
+toString =
+    describe "FullyQualifiedName.toString"
+        [ test "serializes the FQN" <|
+            \_ ->
+                Expect.equal "foo.bar" (FQN.toString (FQN.fromString "foo.bar"))
+        , test "includes root dot when an absolute fqn" <|
+            \_ ->
+                Expect.equal ".foo.bar" (FQN.toString (FQN.fromString ".foo.bar"))
         ]
 
 


### PR DESCRIPTION
## Overview
Add a new `HashQualified` type supporting `FQN` and `Hash` alike and using
it to fetch a definition by `FQN` whenever an `FQN` exists.

## Implementation notes
The `HashQualified` type is similar to the one in the backend (except without the `NameOnly` variant)
and used for determining the amount of data thats available and how to use it to fetch via
the `ToStringPreference` type.

## Interesting/controversial decisions
This revealed a bug with absolute `FQN` that start with `.`. Fixed it in not the most elegant way, but it seems fine.