### PR TITLE
Add API integration for Fuzzy Finder

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -155,7 +155,7 @@ table {
   --color-tooltip-bg: var(--color-gray-darken-30);
 
   /* Syntax */
-  --color-syntax-plain: var(--color-main-fg);
+  --color-syntax-base: var(--color-main-fg);
   --color-syntax-subtle: var(--color-main-subtle-fg);
   --color-syntax-keyword: #225ebe;
   --color-syntax-operator: #c7474e;
@@ -163,6 +163,12 @@ table {
   --color-syntax-type: #225ebe;
   --color-syntax-variant: #438443;
   --color-syntax-text: #438443;
+
+  --color-syntax-monochrome-subtle: var(--color-main-subtle-fg);
+  --color-syntax-monochrome-base: var(--color-gray-base);
+  --color-syntax-monochrome-em: var(--color-main-fg);
+
+  --color-syntax-plain: var(--color-main-fg);
 }
 
 @supports (font-variation-settings: normal) {
@@ -276,146 +282,147 @@ code a:active {
   transform: translate(0, 0.1rem);
 }
 
-.builtin {
-  color: var(--color-syntax-base);
-  font-style: italic;
-}
-
-.comment {
-  color: var(--color-syntax-subtle);
-}
-
-.numberic-literal {
-  color: var(--color-syntax-name);
-}
-
-.text-literal {
+.rich .text-literal,
+.rich .bytes-literal,
+.rich .char-literal {
   color: var(--color-syntax-text);
 }
 
-.bytes-literal {
-  color: var(--color-syntax-text);
-}
-
-.char-literal {
-  color: var(--color-syntax-text);
-}
-
-.boolean-literal {
+.rich .boolean-literal,
+.rich .constructor {
   color: var(--color-syntax-variant);
 }
 
-.blank {
+.rich .blank,
+.rich .var,
+.rich .data-type-params {
   color: var(--color-syntax-base);
 }
 
-.var {
-  color: var(--color-syntax-base);
-}
-
-.type-reference {
+.rich .numberic-literal,
+.rich .term-reference,
+.rich .type-reference,
+.rich .data-type-modifier,
+.rich .hash-qualifier,
+.rich .request {
   color: var(--color-syntax-name);
 }
 
-.term-reference {
-  color: var(--color-syntax-name);
-}
-
-.op.cons {
+.rich .op.cons,
+.rich .op.snoc,
+.rich .op.concat,
+.rich .type-operator,
+.rich .type-ascription-colon {
   color: var(--color-syntax-operator);
 }
 
-.op.snoc {
-  color: var(--color-syntax-operator);
-}
-
-.op.concat {
-  color: var(--color-syntax-operator);
-}
-
-.constructor {
-  color: var(--color-syntax-variant);
-}
-
-.request {
-  color: var(--color-syntax-name);
-}
-
-.ability-braces {
-  color: var(--color-syntax-subtle);
-}
-
-.control-keyword {
-  color: var(--color-syntax-keyword);
-}
-
-.type-operator {
-  color: var(--color-syntax-operator);
-}
-
-.binding-equals {
-  color: var(--color-syntax-subtle);
-}
-
-.type-ascription-colon {
-  color: var(--color-syntax-operator);
-}
-
-.data-type-keyword {
-  color: var(--color-syntax-keyword);
-}
-
-.data-type-params {
-  color: var(--color-syntax-plain);
-}
-
-.unit {
-  color: var(--color-syntax-subtle);
-}
-
-.data-type-modifier {
-  color: var(--color-syntax-name);
-}
-
-.use-keyword {
-  color: var(--color-syntax-keyword);
-}
-
-.use-prefix {
-  color: var(--color-syntax-name);
-}
-
-.use-suffix {
-  color: var(--color-syntax-variant);
-}
-
-.hash-qualifier {
-  color: var(--color-syntax-name);
-}
-
-.delay-force-char {
+.rich .delay-force-char {
   color: var(--color-syntax-operator);
   font-weight: bold;
 }
 
-.delimeter-char {
-  color: var(--color-syntax-subtle);
-}
-
-.parenthesis {
-  color: var(--color-syntax-subtle);
-}
-
-.link-keyword {
+.rich .control-keyword,
+.rich .data-type-keyword,
+.rich .link-keyword,
+.rich .doc-keyword {
   color: var(--color-syntax-keyword);
 }
 
-.doc-delimeter {
+.rich .comment,
+.rich .ability-braces,
+.rich .binding-equals,
+.rich .unit,
+.rich .use-keyword,
+.rich .use-prefix,
+.rich .use-suffix,
+.rich .delimeter-char,
+.rich .parenthesis,
+.rich .doc-delimeter {
   color: var(--color-syntax-subtle);
 }
 
-.doc-keyword {
-  color: var(--color-syntax-keyword);
+.monochrome .text-literal,
+.monochrome .bytes-literal,
+.monochrome .char-literal,
+.monochrome .blank,
+.monochrome .var,
+.monochrome .data-type-params {
+  color: var(--color-syntax-monochrome-base);
+}
+
+.monochrome .type-reference,
+.monochrome .boolean-literal,
+.monochrome .constructor,
+.monochrome .numberic-literal,
+.monochrome .term-reference,
+.monochrome .data-type-modifier,
+.monochrome .hash-qualifier,
+.monochrome .request {
+  color: var(--color-syntax-monochrome-em);
+}
+
+.monochrome .delay-force-char {
+  color: var(--color-syntax-monochrome-em);
+  font-weight: bold;
+}
+
+.monochrome .op.cons,
+.monochrome .op.snoc,
+.monochrome .op.concat,
+.monochrome .type-operator,
+.monochrome .type-ascription-colon,
+.monochrome .control-keyword,
+.monochrome .data-type-keyword,
+.monochrome .link-keyword,
+.monochrome .doc-keyword,
+.monochrome .comment,
+.monochrome .ability-braces,
+.monochrome .binding-equals,
+.monochrome .unit,
+.monochrome .use-keyword,
+.monochrome .use-prefix,
+.monochrome .use-suffix,
+.monochrome .delimeter-char,
+.monochrome .parenthesis,
+.monochrome .doc-delimeter {
+  color: var(--color-syntax-monochrome-subtle);
+}
+
+.plain .text-literal,
+.plain .bytes-literal,
+.plain .char-literal,
+.plain .boolean-literal,
+.plain .constructor,
+.plain .blank,
+.plain .var,
+.plain .data-type-params,
+.plain .numberic-literal,
+.plain .term-reference,
+.plain .data-type-modifier,
+.plain .hash-qualifier,
+.plain .request,
+.plain .type-reference,
+.plain .op.cons,
+.plain .op.snoc,
+.plain .op.concat,
+.plain .type-operator,
+.plain .type-ascription-colon,
+.plain .delay-force-char,
+.plain .control-keyword,
+.plain .data-type-keyword,
+.plain .link-keyword,
+.plain .doc-keyword,
+.plain .comment,
+.plain .ability-braces,
+.plain .binding-equals,
+.plain .unit,
+.plain .use-keyword,
+.plain .use-prefix,
+.plain .use-suffix,
+.plain .delimeter-char,
+.plain .parenthesis,
+.plain .doc-delimeter {
+  color: var(--color-syntax-plain);
 }
 
 /* -- UI ------------------------------------------------------------------- */
@@ -453,13 +460,13 @@ code a:active {
   position: relative;
   background: var(--color-modal-bg);
   border-radius: var(--border-radius-base);
-  border: 1px solid var(--color-modal-border);
   width: 50rem;
   margin-top: 4rem;
   overflow: hidden;
   height: fit-content;
   animation: slide-up 0.2s var(--anim-elastic);
-  box-shadow: 0 6px 16px var(--color-modal-shadow);
+  box-shadow: 0 6px 16px var(--color-modal-shadow),
+    0 0 0 1px var(--color-modal-border);
   z-index: (--layer-modal);
 }
 
@@ -915,7 +922,6 @@ button.secondary:hover {
 
 #finder header {
   background: var(--color-modal-mg);
-  border-bottom: 1px solid var(--color-modal-inner-border);
   display: flex;
   align-items: center;
 }
@@ -965,15 +971,14 @@ button.secondary:hover {
 #finder .results {
   position: relative;
   padding: 0.75rem;
+  border-top: 1px solid var(--color-modal-inner-border);
 }
 
-#finder .results .column-line {
-  position: absolute;
-  top: 0.75rem;
-  bottom: 0.75rem;
-  width: 1px;
-  background: var(--color-modal-separator);
-  margin-left: calc(2rem + 0.75rem + 0.875rem);
+#finder .empty-state {
+  padding: 2rem;
+  text-align: center;
+  border-top: 1px solid var(--color-modal-inner-border);
+  color: var(--color-modal-subtle-fg);
 }
 
 #finder .definition-match {
@@ -981,11 +986,16 @@ button.secondary:hover {
   z-index: var(--layer-modal-above);
   height: 3rem;
   padding: 0 0.75rem;
-  font-size: 0.875rem;
   line-height: 1.5rem;
   display: flex;
   flex-direction: row;
   align-items: center;
+  cursor: pointer;
+  border-radius: var(--border-radius-base);
+}
+
+#finder .definition-match:hover {
+  background: var(--color-modal-mg);
 }
 
 #finder .definition-match .icon {
@@ -1001,9 +1011,24 @@ button.secondary:hover {
 }
 
 #finder .definition-match .name {
+  cursor: pointer;
   font-weight: bold;
-  max-width: 10rem;
-  margin-right: 2rem;
+  max-width: 14rem;
+  font-size: 0.875rem;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+#finder .definition-match .source {
+  height: 3rem;
+  display: flex;
+  padding: 0 1rem;
+  align-items: center;
+  border-left: 1px solid var(--color-modal-separator);
+}
+#finder .definition-match.focused .source {
+  border-color: var(--color-modal-focus-bg);
 }
 
 #finder .definition-match .keyboard-shortcut {
@@ -1022,8 +1047,27 @@ button.secondary:hover {
 
 #finder .definition-match.focused {
   background: var(--color-modal-focus-bg);
-  border-radius: var(--border-radius-base);
   box-shadow: 0 0 0 0.25rem var(--color-modal-bg);
+}
+
+#finder .definition-match.focused:before {
+  position: absolute;
+  top: -0.25rem;
+  left: 0;
+  right: 0;
+  height: 0.25rem;
+  content: "";
+  background: var(--color-modal-bg);
+}
+
+#finder .definition-match.focused + .definition-match:before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 0.25rem;
+  content: "";
+  background: var(--color-modal-bg);
 }
 
 #finder .definition-match.focused .keyboard-shortcut .key {

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -1,8 +1,8 @@
-module Api exposing (definitions, errorToString, list)
+module Api exposing (errorToString, find, getDefinition, list)
 
 import Env
 import Http
-import Url.Builder exposing (QueryParameter, absolute, string)
+import Url.Builder exposing (QueryParameter, absolute, int, string)
 
 
 {-| TODO: Be more explicit about Root |
@@ -15,11 +15,21 @@ list rawFQN =
         |> serverUrl [ "list" ]
 
 
-definitions : List String -> String
-definitions fqnsOrHashes =
+getDefinition : List String -> String
+getDefinition fqnsOrHashes =
     fqnsOrHashes
         |> List.map (string "names")
         |> serverUrl [ "getDefinition" ]
+
+
+find : Int -> Int -> String -> String
+find limit sourceWidth query =
+    serverUrl
+        [ "find" ]
+        [ int "limit" limit
+        , int "renderWidth" sourceWidth
+        , string "query" query
+        ]
 
 
 

--- a/src/Definition.elm
+++ b/src/Definition.elm
@@ -171,9 +171,7 @@ viewNames info =
                         div [] (List.map (\n -> div [] [ text (FQN.toString n) ]) info.otherNames)
 
                     otherNamesLabel =
-                        [ String.fromInt numOtherNames, pluralize "name" "names" numOtherNames ]
-                            |> interpolate "{0} other {1}..."
-                            |> text
+                        text (pluralize "other name..." "other names..." numOtherNames)
                 in
                 div []
                     [ span [ class "separator" ] [ text "•" ]
@@ -207,12 +205,12 @@ view closeMsg toOpenReferenceMsg definition isFocused =
         Term h info ->
             viewDefinitionInfo h
                 info
-                (viewTermSource toOpenReferenceMsg info.name info.source)
+                (viewTermSource (Source.Rich toOpenReferenceMsg) info.name info.source)
 
         Type h info ->
             viewDefinitionInfo h
                 info
-                (viewTypeSource toOpenReferenceMsg info.source)
+                (viewTypeSource (Source.Rich toOpenReferenceMsg) info.source)
 
 
 
@@ -283,7 +281,9 @@ decodeTermDefInfo =
             at [ "termDefinition", "tag" ] Decode.string
 
         decodeUserObject =
-            Decode.map TermSource (at [ "termDefinition", "contents" ] Syntax.decode)
+            Decode.map2 TermSource
+                (Decode.map TypeSignature (field "signature" Syntax.decode))
+                (at [ "termDefinition", "contents" ] Syntax.decode)
 
         decodeBuiltin =
             Decode.map (TypeSignature >> BuiltinTerm) (field "signature" Syntax.decode)

--- a/src/DefinitionMatch.elm
+++ b/src/DefinitionMatch.elm
@@ -1,0 +1,45 @@
+module DefinitionMatch exposing (..)
+
+import Definition exposing (Definition)
+import Json.Decode as Decode exposing (field)
+import Maybe.Extra as MaybeE
+
+
+type alias DefinitionMatch =
+    { score : Int
+    , definition : Definition
+    }
+
+
+
+-- JSON DECODERS
+
+
+decodeScore : Decode.Decoder Int
+decodeScore =
+    field "score" Decode.int
+
+
+{-| Missing definitions result in decode failure, but we don't want a single
+failure to break the entire result.
+
+TODO: Is there some better combinators that work directly with Decode instead
+of awkwardly going through Maybe?
+
+-}
+decodeMatch : Decode.Decoder (Maybe DefinitionMatch)
+decodeMatch =
+    Decode.oneOf
+        [ Decode.map Just
+            (Decode.map2
+                DefinitionMatch
+                (Decode.index 0 decodeScore)
+                (Decode.index 1 Definition.decodeHead)
+            )
+        , Decode.succeed Nothing
+        ]
+
+
+decodeMatches : Decode.Decoder (List DefinitionMatch)
+decodeMatches =
+    Decode.map MaybeE.values (Decode.list decodeMatch)

--- a/src/KeyboardShortcuts.elm
+++ b/src/KeyboardShortcuts.elm
@@ -43,7 +43,7 @@ viewShortcut : Shortcut -> Html msg
 viewShortcut shortcut =
     let
         instruction text_ =
-            span [ class "shortcut-instruction" ] [ text text_ ]
+            span [ class "instruction" ] [ text text_ ]
 
         content =
             case shortcut of

--- a/src/Source.elm
+++ b/src/Source.elm
@@ -2,12 +2,14 @@ module Source exposing
     ( TermSource(..)
     , TypeSignature(..)
     , TypeSource(..)
+    , ViewConfig(..)
+    , viewTermSignature
     , viewTermSource
     , viewTypeSource
     )
 
 import Hash exposing (Hash)
-import Html exposing (Html, span, text)
+import Html exposing (Html, code, pre, span, text)
 import Html.Attributes exposing (class)
 import Syntax exposing (Syntax)
 import UI
@@ -23,17 +25,23 @@ type TypeSignature
 
 
 type TermSource
-    = TermSource Syntax
+    = TermSource TypeSignature Syntax
     | BuiltinTerm TypeSignature
 
 
-viewTypeSource : (Hash -> msg) -> TypeSource -> Html msg
-viewTypeSource toReferenceClickMsg source =
+type ViewConfig msg
+    = Rich (Hash -> msg)
+    | Monochrome
+    | Plain
+
+
+viewTypeSource : ViewConfig msg -> TypeSource -> Html msg
+viewTypeSource viewConfig source =
     let
         content =
             case source of
                 TypeSource syntax ->
-                    Syntax.view toReferenceClickMsg syntax
+                    viewSyntax viewConfig syntax
 
                 BuiltinType ->
                     span
@@ -42,27 +50,74 @@ viewTypeSource toReferenceClickMsg source =
                         , span [ class "data-type-keyword" ] [ text "type" ]
                         ]
     in
-    UI.codeBlock content
+    viewCode viewConfig content
 
 
-viewTermSource : (Hash -> msg) -> String -> TermSource -> Html msg
-viewTermSource toReferenceClickMsg termName source =
+viewTermSignature : ViewConfig msg -> String -> TermSource -> Html msg
+viewTermSignature viewConfig _ source =
+    case source of
+        TermSource (TypeSignature signature) _ ->
+            viewCode viewConfig (viewSyntax viewConfig signature)
+
+        BuiltinTerm (TypeSignature signature) ->
+            viewCode viewConfig (viewSyntax viewConfig signature)
+
+
+viewTermSource : ViewConfig msg -> String -> TermSource -> Html msg
+viewTermSource viewConfig termName source =
     let
         content =
             case source of
-                TermSource syntax ->
-                    Syntax.view toReferenceClickMsg syntax
+                TermSource _ syntax ->
+                    viewSyntax viewConfig syntax
 
                 BuiltinTerm (TypeSignature syntax) ->
                     span
                         []
                         [ span [ class "hash-qualifier" ] [ text termName ]
                         , span [ class "type-ascription-colon" ] [ text " : " ]
-                        , Syntax.view toReferenceClickMsg syntax
+                        , viewSyntax viewConfig syntax
                         , span [ class "blank" ] [ text "\n" ]
                         , span [ class "hash-qualifier" ] [ text termName ]
                         , span [ class "binding-equals" ] [ text " = " ]
                         , span [ class "builtin" ] [ text "builtin" ]
                         ]
     in
-    UI.codeBlock content
+    viewCode viewConfig content
+
+
+
+-- VIEW HELPERS
+
+
+viewCode : ViewConfig msg -> Html msg -> Html msg
+viewCode viewConfig content =
+    pre [ class (viewConfigToClassName viewConfig) ] [ code [] [ content ] ]
+
+
+viewConfigToClassName : ViewConfig msg -> String
+viewConfigToClassName viewConfig =
+    case viewConfig of
+        Rich _ ->
+            "rich"
+
+        Monochrome ->
+            "monochrome"
+
+        Plain ->
+            "plain"
+
+
+viewSyntax : ViewConfig msg -> (Syntax.Syntax -> Html msg)
+viewSyntax viewConfig =
+    Syntax.view (viewConfigToSyntaxLinked viewConfig)
+
+
+viewConfigToSyntaxLinked : ViewConfig msg -> Syntax.Linked msg
+viewConfigToSyntaxLinked viewConfig =
+    case viewConfig of
+        Rich toReferenceClickMsg ->
+            Syntax.Linked toReferenceClickMsg
+
+        _ ->
+            Syntax.NotLinked

--- a/src/UI.elm
+++ b/src/UI.elm
@@ -1,6 +1,6 @@
 module UI exposing (..)
 
-import Html exposing (Html, code, div, pre, span, text)
+import Html exposing (Html, div, span, text)
 import Html.Attributes exposing (class)
 
 
@@ -27,16 +27,6 @@ errorMessage message =
 emptyStateMessage : String -> Html msg
 emptyStateMessage message =
     div [ class "empty-state" ] [ text message ]
-
-
-codeInline : Html msg -> Html msg
-codeInline content =
-    code [] [ content ]
-
-
-codeBlock : Html msg -> Html msg
-codeBlock content =
-    pre [] [ code [] [ content ] ]
 
 
 charWidth : Int -> String

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -199,7 +199,7 @@ handleKeyboardEvent model keyboardEvent =
 fetchDefinition : HashQualified -> Cmd Msg
 fetchDefinition hq =
     Http.get
-        { url = Api.definitions [ HashQualified.toString HashQualified.PreferName hq ]
+        { url = Api.getDefinition [ HashQualified.toString HashQualified.PreferName hq ]
         , expect =
             Http.expectJson
                 (RemoteData.fromResult


### PR DESCRIPTION
## Overview
Integrate with the new `/find` endpoint and adjust decoding, rendering,
and styling to `DefinitionMatch` —  a new type added in this that
combines `Definition` and scoring.

https://user-images.githubusercontent.com/2371/112357431-e8e8de80-8ca5-11eb-837c-80b4c1a70547.mp4

## Implementation notes
* Add a new type for `Finder` called `DefinitionMatch` that includes a `Definition` and it's scoring
* Setup API integration for the `/find` endpoint to return a list `DefinitionMatch`
* Fix issue with parse errors for a single definition breaking all parsing for a list of definitions
* Add `Source.ViewConfig` providing: `Rich`, `Monochrome`, and `Plain` styling of syntax
* Add `Syntax.Linked` for configuration if a rendered syntax should include links to other definitions or not
* Use `Monochrome` for source rendering in `Finder` (which excludes definition links)

## Loose ends
This right now depends on the unmerged `topic/fzf-endpoint` backend branch.