### PR TITLE
Update the Workspace with new gutter

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -99,21 +99,22 @@ table {
   --color-sidebar-focus-bg: var(--color-gray-darken-5);
 
   --color-workspace-fg: var(--color-main-fg);
-  --color-workspace-bg: var(--color-gray-lighten-50);
-  --color-workspace-border: var(--color-main-border);
+  --color-workspace-bg: var(--color-main-bg);
+  --color-workspace-subtle-bg: var(--color-gray-lighten-60);
+  --color-workspace-border: var(--color-gray-lighten-50);
 
   --color-workspace-item-fg: var(--color-gray-darken-30);
-  --color-workspace-item-mg: var(--color-gray-lighten-60);
-  --color-workspace-item-bg: var(--color-gray-lighten-100);
-  --color-workspace-item-subtle-fg: var(--color-main-subtle-fg);
+  --color-workspace-item-mg: transparent;
+  --color-workspace-item-bg: transparent;
+  --color-workspace-item-subtle-fg: var(--color-gray-lighten-40);
   --color-workspace-item-subtle-fg-em: var(--color-gray-lighten-20);
   --color-workspace-item-subtle-bg: var(--color-main-subtle-bg);
-  --color-workspace-item-border: var(--color-gray-lighten-50);
+  --color-workspace-item-border: transparent;
 
-  --color-workspace-item-focus-fg: var(--color-blue-darken-20);
+  --color-workspace-item-focus-fg: var(--color-blue-base);
   --color-workspace-item-focus-subtle-fg: var(--color-gray-lighten-20);
-  --color-workspace-item-focus-mg: var(--color-gray-lighten-50);
-  --color-workspace-item-focus-bg: var(--color-gray-lighten-55);
+  --color-workspace-item-focus-mg: transparent;
+  --color-workspace-item-focus-bg: transparent;
 
   --color-modal-fg: var(--color-main-fg);
   --color-modal-mg: var(--color-gray-lighten-60);
@@ -465,13 +466,25 @@ code a:active {
   overflow: hidden;
   height: fit-content;
   animation: slide-up 0.2s var(--anim-elastic);
-  box-shadow: 0 6px 16px var(--color-modal-shadow),
+  box-shadow: 0 0.375rem 1rem var(--color-modal-shadow),
     0 0 0 1px var(--color-modal-border);
   z-index: (--layer-modal);
 }
 
 .modal:focus {
   outline: none;
+}
+
+.badge {
+  color: var(--color-gray-base);
+  background: var(--color-gray-lighten-60);
+  border: 1px solid var(--color-gray-lighten-50);
+  font-size: 0.75rem;
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  padding: 0 0.5rem;
+  border-radius: var(--border-radius-base);
 }
 
 /* Buttons */
@@ -720,6 +733,10 @@ button.secondary:hover {
   color: var(--color-sidebar-focus-fg);
 }
 
+.namespace-tree .node.open label {
+  font-weight: bold;
+}
+
 .namespace-tree .namespace-content {
   margin-left: 1rem;
 }
@@ -743,10 +760,12 @@ button.secondary:hover {
 #workspace-content {
   overflow: auto;
   height: calc(100vh - 3.5rem);
+  padding-top: 2rem;
   scroll-behavior: smooth;
   scrollbar-width: auto;
   scrollbar-color: var(--color-workspace-item-subtle-fg)
     var(--color-workspace-item-bg);
+  box-shadow: inset 2rem 0 0 var(--color-workspace-subtle-bg);
 }
 
 #workspace-content::-webkit-scrollbar {
@@ -765,14 +784,30 @@ button.secondary:hover {
 /* -- Definitions ---------------------------------------------------------- */
 
 .definition-row {
+  position: relative;
   color: var(--color-workspace-item-fg);
   background: var(--color-workspace-item-bg);
-  padding: 1rem;
+  padding: 1rem 0;
   border-bottom: 1px solid var(--color-workspace-item-border);
+  margin-bottom: 1.5rem;
 }
 
-.definition-row:last-child {
-  border-bottom: 1px solid var(--color-workspace-border);
+.definition-row .inner-row {
+  display: flex;
+  flex-direction: row;
+}
+
+.definition-row .icon.caret-right,
+.definition-row .icon.caret-down {
+  color: var(--color-workspace-item-subtle-fg);
+}
+
+.definition-row .gutter {
+  display: flex;
+  justify-content: center;
+  width: 2rem;
+  margin-right: 0.375rem;
+  color: var(--color-workspace-item-subtle-fg);
 }
 
 .definition-row .loading-placeholder {
@@ -786,43 +821,45 @@ button.secondary:hover {
   flex: 1;
   align-items: center;
   height: 1rem;
+  margin-bottom: 1.5rem;
 }
 
 .definition-row .close {
-  margin-left: auto;
+  width: 2rem;
+  height: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .definition-row .close .icon {
-  color: var(--color-workspace-item-subtle-fg);
+  color: var(--color-workspace-item-subtle-fg-em);
+  width: 0.5rem;
+  height: 0.5rem;
 }
 
 .definition-row .close:hover .icon {
   color: var(--color-workspace-item-fg);
 }
 
-.definition-row header .focus-indicator {
-  background: var(--color-blue-base);
-  border-radius: var(--border-radius-base);
-  width: 0.375rem;
-  height: 1rem;
-  will-change: transform;
-  transform: translate(-2rem, 0);
-  transition: transform 0.2s ease-out;
-  margin-top: -2px;
-}
-
 .definition-row header .names {
   display: flex;
   flex-direction: row;
-  will-change: transform;
-  transition: color 0.2s, transform 0.3s var(--anim-elastic);
-  transform: translate(0, 0);
-  margin-left: -0.375rem; /* countering the focus-indicator width */
+  align-items: center;
+}
+
+.definition-row header .names .icon {
+  margin-right: 0.375rem;
+}
+.definition-row header .names .icon.caret-right,
+.definition-row header .names .icon.caret-down {
+  margin-right: 0.25rem;
 }
 
 .definition-row header .names .name {
   color: var(--color-workspace-item-fg);
   font-size: var(--font-size-base);
+  transition: color 0.2s;
   font-weight: bold;
 }
 
@@ -847,7 +884,7 @@ button.secondary:hover {
 .definition-row header .names .other-names {
   height: 1rem;
   color: var(--color-workspace-item-subtle-fg-em);
-  transition: all 0.2s;
+  transition: color 0.2s;
   cursor: help;
 }
 
@@ -855,19 +892,35 @@ button.secondary:hover {
   color: var(--color-workspace-item-fg);
 }
 
-.definition-row .content {
-  margin: 2rem 1rem 1rem;
+.definition-row .content .gutter {
+  margin-right: 1.5rem;
 }
 
 .definition-row .content .docs {
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 }
 
-.definition-row .content code {
-  display: block;
-  padding: 1rem 1.25rem;
-  border-radius: var(--border-radius-base);
+.definition-row .content .built-in {
+  margin-bottom: 1.5rem;
+  margin-left: 1.25rem;
+}
+
+.definition-row .content .source {
+  display: flex;
+  flex-direction: row;
   background: var(--color-workspace-item-mg);
+}
+
+.definition-row .content .source .source-toggle {
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  margin-right: 0.375rem;
+  padding-top: 0.2rem;
+}
+
+.definition-row .content .source .source-toggle.disabled {
+  opacity: 0.5;
 }
 
 /* Definition Row: Loading */
@@ -893,25 +946,27 @@ button.secondary:hover {
   background: var(--color-workspace-item-focus-bg);
 }
 
+.definition-row.focused:before {
+  position: absolute;
+  top: 0;
+  left: 2rem;
+  bottom: 0;
+  content: "";
+  background: var(--color-workspace-item-focus-fg);
+  width: 0.15rem;
+  transform: translateX(-50%);
+}
+
 .definition-row.focused .content code {
   background: var(--color-workspace-item-focus-mg);
 }
 
-.definition-row.focused header .names {
-  transform: translate(1.125rem, 0);
-}
-
 .definition-row.focused header .name {
-  color: var(--color-blue-darken-20);
+  color: var(--color-workspace-item-focus-fg);
 }
 
-.definition-row.focused header .focus-indicator {
-  transform: translate(0, 0);
-  transition: transform 0.2s ease-in;
-}
-
-.definition-row.focused .close .icon {
-  color: var(--color-workspace-item-focus-subtle-fg);
+.definition-row.focused header .icon {
+  color: var(--color-workspace-item-focus-fg);
 }
 
 /* -- Finder --------------------------------------------------------------- */

--- a/src/App.elm
+++ b/src/App.elm
@@ -5,6 +5,7 @@ import Browser
 import Browser.Events
 import Browser.Navigation as Nav
 import Definition exposing (Definition(..))
+import Definition.Category
 import Finder
 import FullyQualifiedName as FQN exposing (FQN, unqualifiedName)
 import FullyQualifiedNameSet as FQNSet exposing (FQNSet)
@@ -33,8 +34,6 @@ import NamespaceListing
         ( DefinitionListing(..)
         , NamespaceListing(..)
         , NamespaceListingContent
-        , TermCategory(..)
-        , TypeCategory(..)
         )
 import RemoteData exposing (RemoteData(..), WebData)
 import UI
@@ -306,23 +305,10 @@ viewDefinitionListing listing =
     in
     case listing of
         TypeListing hash fqn category ->
-            case category of
-                DataType ->
-                    viewDefRow hash fqn "type" Icon.Type
-
-                AbilityType ->
-                    viewDefRow hash fqn "ability" Icon.Ability
+            viewDefRow hash fqn (Definition.Category.name category) (Definition.Category.icon category)
 
         TermListing hash fqn category ->
-            case category of
-                PlainTerm ->
-                    viewDefRow hash fqn "term" Icon.Term
-
-                TestTerm ->
-                    viewDefRow hash fqn "test" Icon.Test
-
-                DocTerm ->
-                    viewDefRow hash fqn "doc" Icon.Doc
+            viewDefRow hash fqn (Definition.Category.name category) (Definition.Category.icon category)
 
         PatchListing _ ->
             viewListingRow Nothing "Patch" "patch" Icon.Patch

--- a/src/Definition/Category.elm
+++ b/src/Definition/Category.elm
@@ -1,0 +1,65 @@
+module Definition.Category exposing (..)
+
+import UI.Icon as Icon exposing (Icon)
+
+
+type TypeCategory
+    = DataType
+    | AbilityType
+
+
+type TermCategory
+    = PlainTerm
+    | TestTerm
+    | DocTerm
+
+
+type Category
+    = Type TypeCategory
+    | Term TermCategory
+
+
+name : Category -> String
+name category =
+    case category of
+        Type c ->
+            case c of
+                DataType ->
+                    "type"
+
+                AbilityType ->
+                    "ability"
+
+        Term c ->
+            case c of
+                PlainTerm ->
+                    "term"
+
+                TestTerm ->
+                    "test"
+
+                DocTerm ->
+                    "doc"
+
+
+icon : Category -> Icon
+icon category =
+    case category of
+        Type c ->
+            case c of
+                DataType ->
+                    Icon.Type
+
+                AbilityType ->
+                    Icon.Ability
+
+        Term c ->
+            case c of
+                PlainTerm ->
+                    Icon.Term
+
+                TestTerm ->
+                    Icon.Test
+
+                DocTerm ->
+                    Icon.Doc

--- a/src/NamespaceListing.elm
+++ b/src/NamespaceListing.elm
@@ -2,12 +2,11 @@ module NamespaceListing exposing
     ( DefinitionListing(..)
     , NamespaceListing(..)
     , NamespaceListingContent
-    , TermCategory(..)
-    , TypeCategory(..)
     , decode
     , map
     )
 
+import Definition.Category as Category exposing (Category, TermCategory(..), TypeCategory(..))
 import FullyQualifiedName as FQN exposing (FQN)
 import Hash exposing (Hash)
 import Json.Decode as Decode exposing (andThen, field)
@@ -15,20 +14,9 @@ import Json.Decode.Extra exposing (when)
 import RemoteData exposing (RemoteData(..), WebData)
 
 
-type TypeCategory
-    = DataType
-    | AbilityType
-
-
-type TermCategory
-    = PlainTerm
-    | TestTerm
-    | DocTerm
-
-
 type DefinitionListing
-    = TypeListing Hash FQN TypeCategory
-    | TermListing Hash FQN TermCategory
+    = TypeListing Hash FQN Category
+    | TermListing Hash FQN Category
     | PatchListing String
 
 
@@ -103,8 +91,8 @@ decodeContent parentFqn =
 
         decodeTypeTag =
             Decode.oneOf
-                [ when (field "typeTag" Decode.string) ((==) "Data") (Decode.succeed DataType)
-                , when (field "typeTag" Decode.string) ((==) "Ability") (Decode.succeed AbilityType)
+                [ when (field "typeTag" Decode.string) ((==) "Data") (Decode.succeed (Category.Type DataType))
+                , when (field "typeTag" Decode.string) ((==) "Ability") (Decode.succeed (Category.Type AbilityType))
                 ]
 
         decodeTypeListing =
@@ -117,9 +105,9 @@ decodeContent parentFqn =
 
         decodeTermTag =
             Decode.oneOf
-                [ when (field "termTag" Decode.string) ((==) "Test") (Decode.succeed TestTerm)
-                , when (field "termTag" Decode.string) ((==) "Doc") (Decode.succeed DocTerm)
-                , Decode.succeed PlainTerm
+                [ when (field "termTag" Decode.string) ((==) "Test") (Decode.succeed (Category.Term TestTerm))
+                , when (field "termTag" Decode.string) ((==) "Doc") (Decode.succeed (Category.Term DocTerm))
+                , Decode.succeed (Category.Term PlainTerm)
                 ]
 
         decodeTermListing =

--- a/src/Source.elm
+++ b/src/Source.elm
@@ -3,13 +3,15 @@ module Source exposing
     , TypeSignature(..)
     , TypeSource(..)
     , ViewConfig(..)
+    , numTermLines
+    , numTypeLines
     , viewTermSignature
     , viewTermSource
     , viewTypeSource
     )
 
 import Hash exposing (Hash)
-import Html exposing (Html, code, pre, span, text)
+import Html exposing (Html, span, text)
 import Html.Attributes exposing (class)
 import Syntax exposing (Syntax)
 import UI
@@ -35,6 +37,34 @@ type ViewConfig msg
     | Plain
 
 
+
+-- HELPERS
+
+
+numTypeLines : TypeSource -> Int
+numTypeLines source =
+    case source of
+        TypeSource syntax ->
+            Syntax.numLines syntax
+
+        BuiltinType ->
+            1
+
+
+numTermLines : TermSource -> Int
+numTermLines source =
+    case source of
+        TermSource _ syntax ->
+            Syntax.numLines syntax
+
+        BuiltinTerm (TypeSignature syntax) ->
+            Syntax.numLines syntax
+
+
+
+-- VIEW
+
+
 viewTypeSource : ViewConfig msg -> TypeSource -> Html msg
 viewTypeSource viewConfig source =
     let
@@ -46,7 +76,7 @@ viewTypeSource viewConfig source =
                 BuiltinType ->
                     span
                         []
-                        [ span [ class "builtin" ] [ text "builtin " ]
+                        [ span [] [ text "builtin " ]
                         , span [ class "data-type-keyword" ] [ text "type" ]
                         ]
     in
@@ -77,10 +107,6 @@ viewTermSource viewConfig termName source =
                         [ span [ class "hash-qualifier" ] [ text termName ]
                         , span [ class "type-ascription-colon" ] [ text " : " ]
                         , viewSyntax viewConfig syntax
-                        , span [ class "blank" ] [ text "\n" ]
-                        , span [ class "hash-qualifier" ] [ text termName ]
-                        , span [ class "binding-equals" ] [ text " = " ]
-                        , span [ class "builtin" ] [ text "builtin" ]
                         ]
     in
     viewCode viewConfig content
@@ -92,7 +118,9 @@ viewTermSource viewConfig termName source =
 
 viewCode : ViewConfig msg -> Html msg -> Html msg
 viewCode viewConfig content =
-    pre [ class (viewConfigToClassName viewConfig) ] [ code [] [ content ] ]
+    UI.codeBlock
+        [ class (viewConfigToClassName viewConfig) ]
+        content
 
 
 viewConfigToClassName : ViewConfig msg -> String

--- a/src/Syntax.elm
+++ b/src/Syntax.elm
@@ -4,6 +4,7 @@ module Syntax exposing
     , SyntaxSegment(..)
     , SyntaxType(..)
     , decode
+    , numLines
     , view
     )
 
@@ -82,6 +83,25 @@ type SyntaxType
 type Linked msg
     = Linked (Hash -> msg)
     | NotLinked
+
+
+
+-- HELPERS
+
+
+{-| TODO: Parse Syntax into a list of lines and this function can be removed
+-}
+numLines : Syntax -> Int
+numLines (Syntax segments) =
+    let
+        count (SyntaxSegment _ segment) acc =
+            if String.contains "\n" segment then
+                acc + 1
+
+            else
+                acc
+    in
+    NEL.foldl count 1 segments
 
 
 

--- a/src/UI.elm
+++ b/src/UI.elm
@@ -1,12 +1,22 @@
 module UI exposing (..)
 
-import Html exposing (Html, div, span, text)
+import Html exposing (Attribute, Html, code, div, pre, span, text)
 import Html.Attributes exposing (class)
+
+
+codeBlock : List (Attribute msg) -> Html msg -> Html msg
+codeBlock attrs code_ =
+    pre attrs [ code [] [ code_ ] ]
 
 
 nothing : Html msg
 nothing =
     text ""
+
+
+badge : Html msg -> Html msg
+badge content =
+    span [ class "badge" ] [ content ]
 
 
 spinner : Html msg


### PR DESCRIPTION
## Overview
* Update the workspace to support a less row like view with a new gutter
* Improve built-in rendering with a badge
* Add Definition.Category and move associated types out of
  NamespaceListing (this needs further building out in the future)
* Add placeholder expansion toggles
* Add source line numbers in gutter

<img width="1263" alt="Screen Shot 2021-03-26 at 16 55 34" src="https://user-images.githubusercontent.com/2371/112692771-d7decf80-8e55-11eb-9c58-5c0c48a64201.png">

## Loose ends
This depends on https://github.com/unisonweb/codebase-ui/pull/34 (which depends on a backend branch)

This effort revealed a lot of ergonomic problems with the 2 kinds of Definition, the sources of definitions and syntax. I worked a little on category refactoring, but generally tried to avoid the distraction to focus on a single thing.
This also revealed that we're pretty much at the diminishing returns point of using a single css file, it's getting really hard to keep in check and avoid having unused css etc.
