### PR TITLE
Add linking to definitions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,7 @@
   </head>
   <body>
     <main></main>
-    <script src="bundle.js"></script>
+    <script src="/bundle.js"></script>
     <script>
       var app = Elm.Main.init({
         node: document.querySelector("main")

--- a/src/Finder.elm
+++ b/src/Finder.elm
@@ -5,6 +5,7 @@ import Browser.Dom as Dom
 import Definition
 import DefinitionMatch exposing (DefinitionMatch)
 import Hash exposing (Hash)
+import HashQualified exposing (HashQualified(..))
 import Html exposing (Html, a, div, header, input, label, li, ol, section, text)
 import Html.Attributes exposing (autocomplete, class, classList, id, placeholder, style, type_, value)
 import Html.Events exposing (onClick, onInput)
@@ -55,7 +56,7 @@ type Msg
 type OutMsg
     = Remain
     | Exit
-    | OpenDefinition Hash
+    | OpenDefinition HashQualified
 
 
 update : Msg -> Model -> ( Model, Cmd Msg, OutMsg )
@@ -103,7 +104,7 @@ update msg model =
             resetOrClose
 
         Select hash ->
-            ( model, Cmd.none, OpenDefinition hash )
+            ( model, Cmd.none, OpenDefinition (HashOnly hash) )
 
         Keydown event ->
             case event.keyCode of
@@ -132,7 +133,7 @@ update msg model =
                                     Remain
 
                                 SearchResults matches ->
-                                    OpenDefinition ((SearchResults.focus >> .definition >> Definition.hash) matches)
+                                    OpenDefinition ((SearchResults.focus >> .definition >> Definition.hash >> HashOnly) matches)
 
                         out =
                             model.results

--- a/src/FullyQualifiedName.elm
+++ b/src/FullyQualifiedName.elm
@@ -5,15 +5,20 @@ module FullyQualifiedName exposing
     , equals
     , fromParent
     , fromString
+    , fromUrlString
     , isSuffixOf
     , namespaceOf
+    , segments
     , toString
+    , toUrlString
     , unqualifiedName
+    , urlParser
     )
 
 import Json.Decode as Decode
 import List.Nonempty as NEL
 import String.Extra as StringE
+import Url.Parser
 
 
 type FQN
@@ -46,6 +51,13 @@ fromString rawFqn =
         |> FQN
 
 
+fromUrlString : String -> FQN
+fromUrlString str =
+    str
+        |> String.replace "/" "."
+        |> fromString
+
+
 toString : FQN -> String
 toString (FQN nameParts) =
     let
@@ -63,6 +75,18 @@ toString (FQN nameParts) =
         |> NEL.toList
         |> String.join "."
         |> trimLeadingDot
+
+
+toUrlString : FQN -> String
+toUrlString fqn =
+    fqn
+        |> toString
+        |> String.replace "." "/"
+
+
+segments : FQN -> NEL.Nonempty String
+segments (FQN segments_) =
+    segments_
 
 
 fromParent : FQN -> String -> FQN
@@ -114,7 +138,12 @@ namespaceOf suffixName fqn =
 
 
 
--- JSON DECODE
+-- PARSERS
+
+
+urlParser : Url.Parser.Parser (FQN -> a) a
+urlParser =
+    Url.Parser.custom "FQN" (fromUrlString >> Just)
 
 
 decodeFromParent : FQN -> Decode.Decoder FQN

--- a/src/Hash.elm
+++ b/src/Hash.elm
@@ -1,6 +1,17 @@
-module Hash exposing (Hash, decode, equals, fromString, toString)
+module Hash exposing
+    ( Hash
+    , decode
+    , equals
+    , fromString
+    , fromUrlString
+    , isRawHash
+    , toString
+    , toUrlString
+    , urlParser
+    )
 
 import Json.Decode as Decode
+import Url.Parser
 
 
 type Hash
@@ -22,10 +33,53 @@ fromString raw =
     Hash raw
 
 
+isRawHash : String -> Bool
+isRawHash str =
+    String.startsWith prefix str || String.startsWith urlPrefix str
 
--- JSON Decode
+
+fromUrlString : String -> Maybe Hash
+fromUrlString str =
+    if String.startsWith urlPrefix str then
+        str
+            |> String.replace urlPrefix prefix
+            |> fromString
+            |> Just
+
+    else
+        Nothing
+
+
+toUrlString : Hash -> String
+toUrlString hash =
+    hash
+        |> toString
+        |> String.replace prefix urlPrefix
+
+
+
+-- PARSERS
+
+
+urlParser : Url.Parser.Parser (Hash -> a) a
+urlParser =
+    Url.Parser.custom "HASH" fromUrlString
 
 
 decode : Decode.Decoder Hash
 decode =
     Decode.map fromString Decode.string
+
+
+
+-- INTERNAL
+
+
+prefix : String
+prefix =
+    "#"
+
+
+urlPrefix : String
+urlPrefix =
+    "@"

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -1,0 +1,210 @@
+module Route exposing
+    ( Route(..)
+    , fromUrl
+    , navigate
+    , navigateToLatest
+    , navigateToTerm
+    , navigateToType
+    , toTerm
+    , toType
+    , toUrlString
+    )
+
+import Browser.Navigation as Nav
+import FullyQualifiedName as FQN exposing (FQN)
+import Hash exposing (Hash)
+import HashQualified as HQ exposing (HashQualified(..))
+import List.Nonempty as NEL
+import Url exposing (Url)
+import Url.Builder exposing (absolute)
+import Url.Parser as Parser exposing ((</>), Parser, oneOf, s)
+
+
+
+{-
+
+   Routing
+   =======
+
+   URL Scheme
+   ----------
+
+   /[latest|:namespace-hash]/[namespaces|types|terms]/[:definition-name|:definition-hash]
+
+
+   Relative examples
+   -----------------
+
+   Top level of a Codebase:          /
+   Top level of a Codebase:          /latest
+   Namespace as Workspace:           /latest/namespaces/base/List
+   Definitions:                      /latest/[types|terms]/base/List
+   Ambiguous definitions:            /latest/[types|terms]/base/List@je2wR6
+
+
+   Absolute examples
+   -----------------
+
+   Namespace as Workspace:           /latest/namespaces/@785shikvuihsdfd
+   Namespace as Workspace:           /@785shikvuihsdfd
+   Definitions:                      /@785shikvuihsdfd/[types|terms]/base/List
+   Ambiguous definitions:            /@785shikvuihsdfd/[types|terms]/Nonempty/map@dkqA42
+   Definitions outside of Workspace: /@785shikvuihsdfd/[types|terms]/@jf615sgdkvuihskrt
+
+-}
+
+
+type NamespaceReference
+    = Latest
+    | NameReference FQN
+    | HashReference Hash
+
+
+type WithinNamespace
+    = WithinLatest
+    | WithinHash Hash
+
+
+type Route
+    = Namespace NamespaceReference
+    | Type WithinNamespace HashQualified
+    | Term WithinNamespace HashQualified
+
+
+
+-- CREATE
+
+
+urlParser : Parser (Route -> a) a
+urlParser =
+    oneOf
+        [ Parser.map (Namespace Latest) Parser.top
+        , Parser.map (Namespace Latest) (s "latest")
+        , Parser.map Namespace (s "latest" </> s "namespaces" </> Hash.urlParser |> Parser.map HashReference)
+        , Parser.map Namespace (s "latest" </> s "namespaces" </> FQN.urlParser |> Parser.map NameReference)
+        , Parser.map (Type WithinLatest) (s "latest" </> s "types" </> HQ.urlParser)
+        , Parser.map (Term WithinLatest) (s "latest" </> s "terms" </> HQ.urlParser)
+        ]
+
+
+fromUrl : Url -> Route
+fromUrl url =
+    url
+        |> Parser.parse urlParser
+        |> Maybe.withDefault (Namespace Latest)
+
+
+
+-- TRANSFORM
+
+
+toType : Route -> HashQualified -> Route
+toType oldRoute hq =
+    case oldRoute of
+        Namespace ref ->
+            case ref of
+                Latest ->
+                    Type WithinLatest hq
+
+                NameReference _ ->
+                    Type WithinLatest hq
+
+                HashReference hash ->
+                    Type (WithinHash hash) hq
+
+        Type within _ ->
+            Type within hq
+
+        Term within _ ->
+            Type within hq
+
+
+toTerm : Route -> HashQualified -> Route
+toTerm oldRoute hq =
+    case oldRoute of
+        Namespace ref ->
+            case ref of
+                Latest ->
+                    Term WithinLatest hq
+
+                NameReference _ ->
+                    Term WithinLatest hq
+
+                HashReference hash ->
+                    Term (WithinHash hash) hq
+
+        Type within _ ->
+            Term within hq
+
+        Term within _ ->
+            Term within hq
+
+
+toUrlString : Route -> String
+toUrlString route =
+    let
+        withinToPath within =
+            case within of
+                WithinLatest ->
+                    "latest"
+
+                WithinHash h ->
+                    Hash.toUrlString h
+
+        hqToPath hq =
+            case hq of
+                NameOnly fqn ->
+                    NEL.toList (FQN.segments fqn)
+
+                HashOnly h ->
+                    [ Hash.toUrlString h ]
+
+                HashQualified fqn h ->
+                    String.split "/" (FQN.toUrlString fqn ++ Hash.toUrlString h)
+
+        path =
+            case route of
+                Namespace ref ->
+                    case ref of
+                        Latest ->
+                            [ "latest" ]
+
+                        NameReference fqn ->
+                            "latest" :: NEL.toList (FQN.segments fqn)
+
+                        HashReference hash ->
+                            [ "@" ++ Hash.toString hash ]
+
+                Type within hq ->
+                    [ withinToPath within, "types" ] ++ hqToPath hq
+
+                Term within hq ->
+                    [ withinToPath within, "terms" ] ++ hqToPath hq
+    in
+    absolute path []
+
+
+
+-- EFFECTS
+
+
+navigate : Nav.Key -> Route -> Cmd msg
+navigate navKey route =
+    route
+        |> toUrlString
+        |> Nav.pushUrl navKey
+
+
+navigateToLatest : Nav.Key -> Cmd msg
+navigateToLatest navKey =
+    navigate navKey (Namespace Latest)
+
+
+navigateToType : Nav.Key -> Route -> HashQualified -> Cmd msg
+navigateToType navKey currentRoute hq =
+    navigate navKey (toType currentRoute hq)
+
+
+navigateToTerm : Nav.Key -> Route -> HashQualified -> Cmd msg
+navigateToTerm navKey currentRoute hq =
+    navigate navKey (toTerm currentRoute hq)

--- a/tests/FullyQualifiedNameTests.elm
+++ b/tests/FullyQualifiedNameTests.elm
@@ -25,15 +25,47 @@ fromString =
         ]
 
 
+fromUrlString : Test
+fromUrlString =
+    describe "FullyQualifiedName.fromUrlString"
+        [ test "Creates an FQN from a URL string (segments separate by /)" <|
+            \_ ->
+                Expect.equal "a.b.c" (FQN.toString (FQN.fromUrlString "a/b/c"))
+        , describe "Root"
+            [ test "Creates a root FQN from \"\"" <|
+                \_ ->
+                    Expect.equal "." (FQN.toString (FQN.fromUrlString ""))
+            , test "Creates a root FQN from \" \"" <|
+                \_ ->
+                    Expect.equal "." (FQN.toString (FQN.fromUrlString " "))
+            , test "Creates a root FQN from \"/\"" <|
+                \_ ->
+                    Expect.equal "." (FQN.toString (FQN.fromUrlString "/"))
+            ]
+        ]
+
+
 toString : Test
 toString =
-    describe "FullyQualifiedName.toString"
+    describe "FullyQualifiedName.toString with segments separate by ."
         [ test "serializes the FQN" <|
             \_ ->
                 Expect.equal "foo.bar" (FQN.toString (FQN.fromString "foo.bar"))
         , test "includes root dot when an absolute fqn" <|
             \_ ->
                 Expect.equal ".foo.bar" (FQN.toString (FQN.fromString ".foo.bar"))
+        ]
+
+
+toUrlString : Test
+toUrlString =
+    describe "FullyQualifiedName.toUrlString"
+        [ test "serializes the FQN with segments separate by /" <|
+            \_ ->
+                Expect.equal "foo/bar" (FQN.toUrlString (FQN.fromString "foo.bar"))
+        , test "includes root dot when an absolute fqn" <|
+            \_ ->
+                Expect.equal "/foo/bar" (FQN.toUrlString (FQN.fromString ".foo.bar"))
         ]
 
 

--- a/tests/HashQualifiedTests.elm
+++ b/tests/HashQualifiedTests.elm
@@ -1,0 +1,102 @@
+module HashQualifiedTests exposing (..)
+
+import Expect
+import FullyQualifiedName as FQN exposing (FQN)
+import Hash exposing (Hash)
+import HashQualified
+import Test exposing (..)
+
+
+name : Test
+name =
+    describe "HashQualified.name"
+        [ test "Returns Just name when NameOnly" <|
+            \_ ->
+                let
+                    hq =
+                        HashQualified.NameOnly name_
+                in
+                Expect.equal (Just "test.name") (Maybe.map FQN.toString (HashQualified.name hq))
+        , test "Returns Nothing when HashOnly" <|
+            \_ ->
+                let
+                    hq =
+                        HashQualified.HashOnly hash_
+                in
+                Expect.equal Nothing (HashQualified.name hq)
+        , test "Returns Just name when HashQualified" <|
+            \_ ->
+                let
+                    hq =
+                        HashQualified.HashQualified name_ hash_
+                in
+                Expect.equal (Just "test.name") (Maybe.map FQN.toString (HashQualified.name hq))
+        ]
+
+
+hash : Test
+hash =
+    describe "HashQualified.hash"
+        [ test "Returns Nothing when NameOnly" <|
+            \_ ->
+                let
+                    hq =
+                        HashQualified.NameOnly name_
+                in
+                Expect.equal Nothing (HashQualified.hash hq)
+        , test "Returns Just hash when HashOnly" <|
+            \_ ->
+                let
+                    hq =
+                        HashQualified.HashOnly hash_
+                in
+                Expect.equal (Just "#testhash") (Maybe.map Hash.toString (HashQualified.hash hq))
+        , test "Returns Just hash when HashQualified" <|
+            \_ ->
+                let
+                    hq =
+                        HashQualified.HashQualified name_ hash_
+                in
+                Expect.equal (Just "#testhash") (Maybe.map Hash.toString (HashQualified.hash hq))
+        ]
+
+
+fromUrlString : Test
+fromUrlString =
+    describe "HashQualified.fromUrlString"
+        [ test "HashOnly when called with a raw hash" <|
+            \_ ->
+                let
+                    expected =
+                        HashQualified.HashOnly hash_
+                in
+                Expect.equal expected (HashQualified.fromUrlString "@testhash")
+        , test "HashQualified when called with a string and name" <|
+            \_ ->
+                let
+                    expected =
+                        HashQualified.HashQualified name_ hash_
+                in
+                Expect.equal expected (HashQualified.fromUrlString "test.name@testhash")
+        , test "NameOnly when called with a name" <|
+            \_ ->
+                let
+                    expected =
+                        HashQualified.NameOnly name_
+                in
+                Expect.equal expected (HashQualified.fromUrlString "test.name")
+        ]
+
+
+
+-- TEST HELPERS
+
+
+name_ : FQN
+name_ =
+    FQN.fromString "test.name"
+
+
+hash_ : Hash
+hash_ =
+    Hash.fromString "#testhash"

--- a/tests/HashTests.elm
+++ b/tests/HashTests.elm
@@ -1,7 +1,7 @@
 module HashTests exposing (..)
 
 import Expect
-import Hash exposing (..)
+import Hash
 import Test exposing (..)
 
 
@@ -31,4 +31,56 @@ toString =
                         Hash.fromString "#foo"
                 in
                 Expect.equal "#foo" (Hash.toString hash)
+        ]
+
+
+toUrlString : Test
+toUrlString =
+    describe "Hash.toUrlString"
+        [ test "Extracts the raw hash value in a URL format" <|
+            \_ ->
+                let
+                    hash =
+                        Hash.fromString "#foo"
+                in
+                Expect.equal "@foo" (Hash.toUrlString hash)
+        ]
+
+
+fromUrlString : Test
+fromUrlString =
+    describe "Hash.fromUrlString"
+        [ test "Creates a Hash with a valid URL prefixed raw hash" <|
+            \_ ->
+                let
+                    hash =
+                        Hash.fromUrlString "@foo"
+                in
+                Expect.equal (Just "#foo") (Maybe.map Hash.toString hash)
+        , test "Fails to create a hash with an incorrect prefix" <|
+            \_ ->
+                let
+                    hash =
+                        Hash.fromUrlString "$foo"
+                in
+                Expect.equal Nothing (Maybe.map Hash.toString hash)
+        , test "Fails to create a hash with an Hash symbol prefix" <|
+            \_ ->
+                let
+                    hash =
+                        Hash.fromUrlString "#foo"
+                in
+                Expect.equal Nothing (Maybe.map Hash.toString hash)
+        ]
+
+
+isRawHash : Test
+isRawHash =
+    describe "Hash.isRawHash"
+        [ test "True for strings prefixed with #" <|
+            \_ -> Expect.true "# is a raw hash" (Hash.isRawHash "#foo")
+        , test "True for strings prefixed with @" <|
+            \_ -> Expect.true "@ is a raw hash" (Hash.isRawHash "@foo")
+        , test "False for non prefixed strings" <|
+            \_ -> Expect.false "needs prefix" (Hash.isRawHash "foo")
         ]


### PR DESCRIPTION
## Overview

Add routing support with a URL scheme for locating namespaces, terms and
types:

```
/[latest|:namespace-hash]/[namespaces|types|terms]/[:definition-name|:definition-hash]
```

Update the URL based on which definition is in focus (currently
exclusively hash based). When the app is initiated with a URL of a
definition, fetch that definition as the app starts.


https://user-images.githubusercontent.com/2371/113348052-1cf67c00-9304-11eb-9470-69375cf9a98e.mp4


## Implementation notes
How does it accomplish it, in broad strokes?

## Interesting/controversial decisions
There's some annoying `(Model, Cmd Msg)` compositional hurdles that could use some love. 

## Loose ends
There's a lot more to routing than this PR adds. Currently this is missing:

* Routing via FQN: The scheme and the routes support this, but currently the open definitions are exclusively indexed by Hash. I've avoided the temptation to refactor that in this initial routes effort and will be doing that as the next thing
* Top level redirect from `latest` to the hash of the codebase: We'd need a meta data API request to support this.
* Route first: We currently update the URL as a side thing to changing focus, but perhaps it should be the other way around, and have the URL be the source of truth.
* Terms vs Types: This work has once again shown ergonomic limitations of the `type Definition = Term | Type` datatype, and it would be cool to lean into types and terms being separate things more. We could for instance have improve the typing around the HashQualifiers such that we don't end up using a type hash for a term url. Figuring this out will also have an impact on the `OpenDefinitions` type.
* ~~This needs better test coverage~~

---

Tagging @pchiusano and @aryairani since you've both been very active and provided a lot of good feedback in this area 🙏 