### PR TITLE
Add RelativeTo and track it in the App model

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -35,6 +35,7 @@ import NamespaceListing
         , NamespaceListing(..)
         , NamespaceListingContent
         )
+import RelativeTo exposing (RelativeTo(..))
 import RemoteData exposing (RemoteData(..), WebData)
 import Route exposing (Route)
 import UI
@@ -55,6 +56,7 @@ type Modal
 type alias Model =
     { navKey : Nav.Key
     , route : Route
+    , relativeTo : RelativeTo
     , workspace : Workspace.Model
     , rootNamespaceListing : WebData NamespaceListing
     , expandedNamespaceListings : FQNSet
@@ -79,9 +81,15 @@ init _ url navKey =
                 _ ->
                     Workspace.init Nothing
 
+        {--| TODO: When we can't get a relative to, we need to resolve the name
+          in the url to a hash-}
+        relativeTo =
+            Maybe.withDefault Codebase (Route.relativeTo route)
+
         model =
             { navKey = navKey
             , route = route
+            , relativeTo = relativeTo
             , workspace = workspace
             , rootNamespaceListing = Loading
             , expandedNamespaceListings = FQNSet.empty

--- a/src/RelativeTo.elm
+++ b/src/RelativeTo.elm
@@ -1,0 +1,22 @@
+module RelativeTo exposing (..)
+
+import Hash exposing (Hash)
+
+
+type RelativeTo
+    = Codebase
+    | Namespace Hash
+
+
+
+-- HELPERS
+
+
+toUrlPath : RelativeTo -> String
+toUrlPath relTo =
+    case relTo of
+        Codebase ->
+            "latest"
+
+        Namespace h ->
+            Hash.toUrlString h


### PR DESCRIPTION
## Overview
Part of the work outlined in https://github.com/unisonweb/codebase-ui/pull/38.

Introduces a new `RelativeTo` type, tracks in the `App` model and use it in `Route`.

## Loose ends
We can't yet look up a name and get a namespace, so there's a few routes 
that aren't supported at the moment that fall back to `RelativeTo.Codebase`. 
