### PR TITLE
Add WorkspaceItems to replace OpenDefinitions

### DIFF
--- a/src/Definition/Info.elm
+++ b/src/Definition/Info.elm
@@ -1,0 +1,12 @@
+module Definition.Info exposing (..)
+
+import FullyQualifiedName exposing (FQN)
+import Hash exposing (Hash)
+
+
+type alias Info =
+    { hash : Hash
+    , namespace : Maybe String
+    , name : String
+    , otherNames : List FQN
+    }

--- a/src/Definition/Term.elm
+++ b/src/Definition/Term.elm
@@ -1,0 +1,29 @@
+module Definition.Term exposing (..)
+
+import Definition.Info exposing (Info)
+import Syntax exposing (Syntax)
+
+
+type TermSource
+    = Source TermSignature Syntax
+    | Builtin TermSignature
+
+
+type Term a
+    = Term Info a
+
+
+type TermSignature
+    = TermSignature Syntax
+
+
+type alias TermDetail =
+    Term TermSource
+
+
+type alias TermSummary =
+    Term TermSignature
+
+
+type alias TermListing =
+    Term ()

--- a/src/Definition/Type.elm
+++ b/src/Definition/Type.elm
@@ -1,0 +1,27 @@
+module Definition.Type exposing (..)
+
+import Definition.Info exposing (Info)
+import Syntax exposing (Syntax)
+
+
+type TypeSource
+    = Source Syntax
+    | Builtin
+
+
+type Type a
+    = Type Info a
+
+
+{-| Currently same as TypeSummary, but will include Docs later -
+-}
+type alias TypeDetail =
+    Type TypeSource
+
+
+type alias TypeSummary =
+    Type TypeSource
+
+
+type alias TypeListing =
+    Type ()

--- a/src/Workspace/Reference.elm
+++ b/src/Workspace/Reference.elm
@@ -1,0 +1,28 @@
+module Workspace.Reference exposing (..)
+
+import HashQualified exposing (HashQualified)
+
+
+type Reference
+    = TermReference HashQualified
+    | TypeReference HashQualified
+
+
+toString : Reference -> String
+toString ref =
+    case ref of
+        TermReference hq ->
+            "term/" ++ HashQualified.toString hq
+
+        TypeReference hq ->
+            "type/" ++ HashQualified.toString hq
+
+
+hashQualified : Reference -> HashQualified
+hashQualified ref =
+    case ref of
+        TermReference hq ->
+            hq
+
+        TypeReference hq ->
+            hq

--- a/src/Workspace/WorkspaceItems.elm
+++ b/src/Workspace/WorkspaceItems.elm
@@ -1,0 +1,363 @@
+{-
+   WorkspaceItems is the main data structure for working with definitions in
+   the Workspace area. It supports holding Loading definitions and inserting
+   definitions after another.
+
+   It features a `focus` indicator and a before and after just like a Zipper.
+   `focus` can be changed with `next` and `prev`.
+
+   Invariants:
+     It structurally can't hold the invariant that it should not contain
+     duplicates, so this is instead enforced via the API; uniqueness is
+     determined by Reference and Hash.
+-}
+-- TODO: All reference equality check should reach into definition for hash
+-- equality when possible
+
+
+module Workspace.WorkspaceItems exposing (..)
+
+import Definition.Term exposing (TermDetail)
+import Definition.Type exposing (TypeDetail)
+import List
+import List.Extra as ListE
+import Workspace.Reference exposing (Reference)
+
+
+type Error
+    = Error String
+
+
+{-| This technically allows multiple of the same definition across the 3 fields.
+This is conceptionally not allowed and is enforced by the helper functions.
+-}
+type WorkspaceItems
+    = Empty
+    | WorkspaceItems
+        { before : List WorkspaceItem
+        , focus : WorkspaceItem
+        , after : List WorkspaceItem
+        }
+
+
+type Item
+    = TermItem TermDetail
+    | TypeItem TypeDetail
+
+
+type WorkspaceItem
+    = Loading Reference
+    | Failure Reference Error
+    | Success Reference Item
+
+
+reference : WorkspaceItem -> Reference
+reference item =
+    case item of
+        Loading r ->
+            r
+
+        Failure r _ ->
+            r
+
+        Success r _ ->
+            r
+
+
+init : Maybe WorkspaceItem -> WorkspaceItems
+init focused =
+    case focused of
+        Nothing ->
+            Empty
+
+        Just i ->
+            singleton i
+
+
+fromItems :
+    List WorkspaceItem
+    -> WorkspaceItem
+    -> List WorkspaceItem
+    -> WorkspaceItems
+fromItems before focus_ after =
+    WorkspaceItems { before = before, focus = focus_, after = after }
+
+
+empty : WorkspaceItems
+empty =
+    Empty
+
+
+isEmpty : WorkspaceItems -> Bool
+isEmpty workspaceItems =
+    case workspaceItems of
+        Empty ->
+            True
+
+        WorkspaceItems _ ->
+            False
+
+
+singleton : WorkspaceItem -> WorkspaceItems
+singleton item =
+    WorkspaceItems { before = [], focus = item, after = [] }
+
+
+
+-- MODIFY
+
+
+insertWithFocus : WorkspaceItems -> WorkspaceItem -> WorkspaceItems
+insertWithFocus items item =
+    WorkspaceItems { before = toList items, focus = item, after = [] }
+
+
+{-| Insert after a Hash. If the Hash is not in WorkspaceItems, insert at the
+end. If the element to insert already exists in WorkspaceItems, move it to
+after the provided Hash
+-}
+insertWithFocusAfter :
+    WorkspaceItems
+    -> Reference
+    -> WorkspaceItem
+    -> WorkspaceItems
+insertWithFocusAfter items afterRef toInsert =
+    case items of
+        Empty ->
+            singleton toInsert
+
+        WorkspaceItems _ ->
+            if member items afterRef then
+                let
+                    insertAfter item =
+                        if reference item == afterRef then
+                            [ item, toInsert ]
+
+                        else
+                            [ item ]
+
+                    make ( before, afterInclusive ) =
+                        WorkspaceItems
+                            { before = before
+                            , focus = toInsert
+                            , after = List.drop 1 afterInclusive
+                            }
+                in
+                items
+                    |> toList
+                    |> List.concatMap insertAfter
+                    |> ListE.splitWhen (\i -> reference toInsert == reference i)
+                    |> Maybe.map make
+                    |> Maybe.withDefault (singleton toInsert)
+
+            else
+                insertWithFocus items toInsert
+
+
+replace : WorkspaceItems -> Reference -> WorkspaceItem -> WorkspaceItems
+replace items ref newItem =
+    let
+        replaceMatching i =
+            if reference i == ref then
+                newItem
+
+            else
+                i
+    in
+    map replaceMatching items
+
+
+remove : WorkspaceItems -> Reference -> WorkspaceItems
+remove items ref =
+    case items of
+        Empty ->
+            Empty
+
+        WorkspaceItems data ->
+            let
+                without r =
+                    ListE.filterNot (\i -> reference i == r)
+            in
+            if ref == reference data.focus then
+                let
+                    rightBeforeFocus =
+                        ListE.last data.before
+
+                    rightAfterFocus =
+                        List.head data.after
+                in
+                case rightAfterFocus of
+                    Just i ->
+                        WorkspaceItems
+                            { before = data.before
+                            , focus = i
+                            , after = without (reference i) data.after
+                            }
+
+                    Nothing ->
+                        case rightBeforeFocus of
+                            Just i ->
+                                WorkspaceItems
+                                    { before = without (reference i) data.before
+                                    , focus = i
+                                    , after = data.after
+                                    }
+
+                            Nothing ->
+                                Empty
+
+            else
+                WorkspaceItems
+                    { before = without ref data.before
+                    , focus = data.focus
+                    , after = without ref data.after
+                    }
+
+
+
+-- QUERY
+
+
+{-| TODO: Support NameOnly better
+-}
+member : WorkspaceItems -> Reference -> Bool
+member items ref =
+    items |> references |> List.member ref
+
+
+references : WorkspaceItems -> List Reference
+references items =
+    items
+        |> toList
+        |> List.map reference
+
+
+
+-- Focus
+
+
+focus : WorkspaceItems -> Maybe WorkspaceItem
+focus items =
+    case items of
+        Empty ->
+            Nothing
+
+        WorkspaceItems data ->
+            Just data.focus
+
+
+focusOn : WorkspaceItems -> Reference -> WorkspaceItems
+focusOn items ref =
+    let
+        fromSplits ( before, afterInclusive ) =
+            case afterInclusive of
+                [] ->
+                    Nothing
+
+                newFocus :: after ->
+                    Just { before = before, focus = newFocus, after = after }
+    in
+    items
+        |> toList
+        |> ListE.splitWhen (\i -> reference i == ref)
+        |> Maybe.andThen fromSplits
+        |> Maybe.map WorkspaceItems
+        |> Maybe.withDefault items
+
+
+isFocused : WorkspaceItems -> Reference -> Bool
+isFocused workspaceItems ref =
+    workspaceItems
+        |> focus
+        |> Maybe.map (\i -> reference i == ref)
+        |> Maybe.withDefault False
+
+
+next : WorkspaceItems -> WorkspaceItems
+next items =
+    case items of
+        Empty ->
+            Empty
+
+        WorkspaceItems data ->
+            case data.after of
+                [] ->
+                    items
+
+                newFocus :: rest ->
+                    WorkspaceItems
+                        { before = data.before ++ [ data.focus ]
+                        , focus = newFocus
+                        , after = rest
+                        }
+
+
+prev : WorkspaceItems -> WorkspaceItems
+prev items =
+    case items of
+        Empty ->
+            Empty
+
+        WorkspaceItems data ->
+            case ListE.unconsLast data.before of
+                Nothing ->
+                    items
+
+                Just ( newFocus, newBefore ) ->
+                    WorkspaceItems
+                        { before = newBefore
+                        , focus = newFocus
+                        , after = data.focus :: data.after
+                        }
+
+
+
+-- TRANFORM
+
+
+map :
+    (WorkspaceItem -> WorkspaceItem)
+    -> WorkspaceItems
+    -> WorkspaceItems
+map f wItems =
+    case wItems of
+        Empty ->
+            Empty
+
+        WorkspaceItems data ->
+            WorkspaceItems
+                { before = List.map f data.before
+                , focus = f data.focus
+                , after = List.map f data.after
+                }
+
+
+mapToList : (WorkspaceItem -> Bool -> a) -> WorkspaceItems -> List a
+mapToList f wItems =
+    case wItems of
+        Empty ->
+            []
+
+        WorkspaceItems data ->
+            let
+                before =
+                    data.before
+                        |> List.map (\i -> f i False)
+
+                after =
+                    data.after
+                        |> List.map (\i -> f i False)
+            in
+            before ++ (f data.focus True :: after)
+
+
+{-| Converting the workspace items to a list, looses the focus indicator
+-}
+toList : WorkspaceItems -> List WorkspaceItem
+toList wItems =
+    case wItems of
+        Empty ->
+            []
+
+        WorkspaceItems items ->
+            items.before ++ (items.focus :: items.after)

--- a/tests/Workspace/WorkspaceItemsTests.elm
+++ b/tests/Workspace/WorkspaceItemsTests.elm
@@ -1,0 +1,383 @@
+module Workspace.WorkspaceItemsTests exposing (..)
+
+import Expect
+import Hash
+import HashQualified exposing (HashQualified(..))
+import Test exposing (..)
+import Workspace.Reference as Reference exposing (Reference(..))
+import Workspace.WorkspaceItems as WorkspaceItems exposing (..)
+
+
+
+-- MODIFY
+
+
+insertWithFocus : Test
+insertWithFocus =
+    let
+        result =
+            WorkspaceItems.insertWithFocus WorkspaceItems.empty term
+
+        currentFocusedRef =
+            getFocusedRef result
+    in
+    describe "WorkspaceItems.insertWithFocus"
+        [ test "Inserts the term" <|
+            \_ ->
+                Expect.true "term is a member" (WorkspaceItems.member result termRef)
+        , test "Sets focus" <|
+            \_ ->
+                Expect.true "Has focus" (Maybe.withDefault False <| Maybe.map (\r -> r == termRef) currentFocusedRef)
+        ]
+
+
+insertWithFocusAfter : Test
+insertWithFocusAfter =
+    let
+        afterRef =
+            TermReference (HashOnly (Hash.fromString "#a"))
+
+        toInsert =
+            term
+
+        expected =
+            [ Loading (TermReference (HashOnly (Hash.fromString "#a")))
+            , Loading termRef
+            , Loading (TermReference (HashOnly (Hash.fromString "#b")))
+            , Loading (TermReference (HashOnly (Hash.fromString "#focus")))
+            , Loading (TermReference (HashOnly (Hash.fromString "#c")))
+            , Loading (TermReference (HashOnly (Hash.fromString "#d")))
+            ]
+
+        inserted =
+            WorkspaceItems.insertWithFocusAfter workspaceItems afterRef toInsert
+
+        currentFocusedRef =
+            getFocusedRef inserted
+    in
+    describe "WorkspaceItems.insertWithFocusAfter"
+        [ test "Inserts after the the 'after hash'" <|
+            \_ ->
+                Expect.equal expected (WorkspaceItems.toList inserted)
+        , test "When inserted, the new element has focus" <|
+            \_ ->
+                Expect.true "Has focus" (Maybe.withDefault False <| Maybe.map (\r -> r == reference toInsert) currentFocusedRef)
+        , test "When the 'after hash' is not present, insert at the end" <|
+            \_ ->
+                let
+                    atEnd =
+                        [ Loading (TermReference (HashOnly (Hash.fromString "#a")))
+                        , Loading (TermReference (HashOnly (Hash.fromString "#b")))
+                        , Loading (TermReference (HashOnly (Hash.fromString "#focus")))
+                        , Loading (TermReference (HashOnly (Hash.fromString "#c")))
+                        , Loading (TermReference (HashOnly (Hash.fromString "#d")))
+                        , Loading (reference toInsert)
+                        ]
+
+                    result =
+                        toInsert
+                            |> WorkspaceItems.insertWithFocusAfter workspaceItems (TermReference (HashOnly (Hash.fromString "#notfound")))
+                            |> WorkspaceItems.toList
+                in
+                Expect.equal atEnd result
+        ]
+
+
+replace : Test
+replace =
+    describe "WorkspaceItems.replace"
+        [ test "Can replace element in 'before' focus" <|
+            \_ ->
+                let
+                    newItem =
+                        Failure (TermReference (HashOnly (Hash.fromString "#b"))) (Error "err")
+
+                    expected =
+                        [ Loading (TermReference (HashOnly (Hash.fromString "#a")))
+                        , newItem
+                        , Loading (TermReference (HashOnly (Hash.fromString "#focus")))
+                        , Loading (TermReference (HashOnly (Hash.fromString "#c")))
+                        , Loading (TermReference (HashOnly (Hash.fromString "#d")))
+                        ]
+
+                    result =
+                        newItem
+                            |> WorkspaceItems.replace workspaceItems (TermReference (HashOnly (Hash.fromString "#b")))
+                            |> WorkspaceItems.toList
+                in
+                Expect.equal expected result
+        , test "Can replace element in focus" <|
+            \_ ->
+                let
+                    newItem =
+                        Failure (TermReference (HashOnly (Hash.fromString "#focus"))) (Error "err")
+
+                    expected =
+                        [ Loading (TermReference (HashOnly (Hash.fromString "#a")))
+                        , Loading (TermReference (HashOnly (Hash.fromString "#b")))
+                        , newItem
+                        , Loading (TermReference (HashOnly (Hash.fromString "#c")))
+                        , Loading (TermReference (HashOnly (Hash.fromString "#d")))
+                        ]
+
+                    result =
+                        newItem
+                            |> WorkspaceItems.replace workspaceItems (TermReference (HashOnly (Hash.fromString "#focus")))
+                            |> WorkspaceItems.toList
+                in
+                Expect.equal expected result
+        , test "Can replace element in 'after' focus" <|
+            \_ ->
+                let
+                    newItem =
+                        Failure (TermReference (HashOnly (Hash.fromString "#d"))) (Error "err")
+
+                    expected =
+                        [ Loading (TermReference (HashOnly (Hash.fromString "#a")))
+                        , Loading (TermReference (HashOnly (Hash.fromString "#b")))
+                        , Loading (TermReference (HashOnly (Hash.fromString "#focus")))
+                        , Loading (TermReference (HashOnly (Hash.fromString "#c")))
+                        , newItem
+                        ]
+
+                    result =
+                        newItem
+                            |> WorkspaceItems.replace workspaceItems (TermReference (HashOnly (Hash.fromString "#d")))
+                            |> WorkspaceItems.toList
+                in
+                Expect.equal expected result
+        ]
+
+
+remove : Test
+remove =
+    describe "WorkspaceItems.remove"
+        [ test "Returns original when trying to remove a missing Hash" <|
+            \_ ->
+                let
+                    expected =
+                        WorkspaceItems.toList workspaceItems
+
+                    result =
+                        notFoundRef
+                            |> WorkspaceItems.remove workspaceItems
+                            |> WorkspaceItems.toList
+                in
+                Expect.equal expected result
+        , test "Removes the element" <|
+            \_ ->
+                let
+                    toRemove =
+                        TermReference (HashOnly (Hash.fromString "#a"))
+
+                    result =
+                        WorkspaceItems.remove workspaceItems toRemove
+                in
+                Expect.false "#a is removed" (WorkspaceItems.member result toRemove)
+        , test "When the element to remove is focused, remove the element and change focus to right after it" <|
+            \_ ->
+                let
+                    toRemove =
+                        TermReference (HashOnly (Hash.fromString "#focus"))
+
+                    expectedNewFocus =
+                        TermReference (HashOnly (Hash.fromString "#c"))
+
+                    result =
+                        WorkspaceItems.remove workspaceItems toRemove
+                in
+                Expect.true "#focus is removed and #c has focus" (not (WorkspaceItems.member result toRemove) && WorkspaceItems.isFocused result expectedNewFocus)
+        , test "When the element to remove is focused and there are no elements after, remove the element and change focus to right before it" <|
+            \_ ->
+                let
+                    toRemove =
+                        TermReference (HashOnly (Hash.fromString "#focus"))
+
+                    expectedNewFocus =
+                        TermReference (HashOnly (Hash.fromString "#b"))
+
+                    result =
+                        WorkspaceItems.remove (WorkspaceItems.fromItems before focused []) toRemove
+                in
+                Expect.true "#focus is removed and #b has focus" (not (WorkspaceItems.member result toRemove) && WorkspaceItems.isFocused result expectedNewFocus)
+        , test "When the element to remove is focused there are no other elements, it returns Empty" <|
+            \_ ->
+                let
+                    result =
+                        WorkspaceItems.remove (WorkspaceItems.singleton term) (reference term)
+                in
+                Expect.true "Definition is empty" (WorkspaceItems.isEmpty result)
+        ]
+
+
+
+-- QUERY
+
+
+member : Test
+member =
+    let
+        items =
+            WorkspaceItems.singleton term
+    in
+    describe "WorkspaceItems.member"
+        [ test "Returns true for a ref housed within" <|
+            \_ ->
+                Expect.true "item is a member" (WorkspaceItems.member items termRef)
+        , test "Returns false for a ref *not* housed within" <|
+            \_ ->
+                Expect.false "item is *not* a member" (WorkspaceItems.member items notFoundRef)
+        ]
+
+
+
+-- FOCUS
+
+
+next : Test
+next =
+    describe "WorkspaceItems.next"
+        [ test "moves focus to the next element" <|
+            \_ ->
+                let
+                    result =
+                        workspaceItems
+                            |> WorkspaceItems.next
+                            |> getFocusedRef
+                            |> Maybe.map Reference.toString
+                in
+                Expect.equal (Just "term/#c") result
+        , test "keeps focus if no elements after" <|
+            \_ ->
+                let
+                    result =
+                        WorkspaceItems.fromItems before focused []
+                            |> WorkspaceItems.next
+                            |> getFocusedRef
+                            |> Maybe.map Reference.toString
+                in
+                Expect.equal (Just "term/#focus") result
+        ]
+
+
+prev : Test
+prev =
+    describe "WorkspaceItems.prev"
+        [ test "moves focus to the prev element" <|
+            \_ ->
+                let
+                    result =
+                        workspaceItems
+                            |> WorkspaceItems.prev
+                            |> getFocusedRef
+                            |> Maybe.map Reference.toString
+                in
+                Expect.equal (Just "term/#b") result
+        , test "keeps focus if no elements before" <|
+            \_ ->
+                let
+                    result =
+                        WorkspaceItems.fromItems [] focused after
+                            |> WorkspaceItems.prev
+                            |> getFocusedRef
+                            |> Maybe.map Reference.toString
+                in
+                Expect.equal (Just "term/#focus") result
+        ]
+
+
+
+-- MAP
+
+
+map : Test
+map =
+    describe "WorkspaceItems.map"
+        [ test "Maps definitions" <|
+            \_ ->
+                let
+                    result =
+                        workspaceItems
+                            |> WorkspaceItems.map (\i -> Failure (reference i) (Error "err"))
+                            |> WorkspaceItems.toList
+
+                    expected =
+                        [ Failure (TermReference (HashOnly (Hash.fromString "#a"))) (Error "err")
+                        , Failure (TermReference (HashOnly (Hash.fromString "#b"))) (Error "err")
+                        , Failure (TermReference (HashOnly (Hash.fromString "#focus"))) (Error "err")
+                        , Failure (TermReference (HashOnly (Hash.fromString "#c"))) (Error "err")
+                        , Failure (TermReference (HashOnly (Hash.fromString "#d"))) (Error "err")
+                        ]
+                in
+                Expect.equal expected result
+        ]
+
+
+mapToList : Test
+mapToList =
+    describe "WorkspaceItems.mapToList"
+        [ test "Maps definitions" <|
+            \_ ->
+                let
+                    result =
+                        workspaceItems
+                            |> WorkspaceItems.mapToList (\i _ -> Reference.toString (reference i))
+
+                    expected =
+                        [ "term/#a", "term/#b", "term/#focus", "term/#c", "term/#d" ]
+                in
+                Expect.equal expected result
+        ]
+
+
+
+-- TEST HELPERS
+
+
+termRef : Reference
+termRef =
+    TermReference hashQualified
+
+
+notFoundRef : Reference
+notFoundRef =
+    TermReference (HashOnly (Hash.fromString "#notfound"))
+
+
+hashQualified : HashQualified
+hashQualified =
+    HashOnly (Hash.fromString "#testhash")
+
+
+term : WorkspaceItem
+term =
+    Loading termRef
+
+
+before : List WorkspaceItem
+before =
+    [ Loading (TermReference (HashOnly (Hash.fromString "#a")))
+    , Loading (TermReference (HashOnly (Hash.fromString "#b")))
+    ]
+
+
+focused : WorkspaceItem
+focused =
+    Loading (TermReference (HashOnly (Hash.fromString "#focus")))
+
+
+after : List WorkspaceItem
+after =
+    [ Loading (TermReference (HashOnly (Hash.fromString "#c")))
+    , Loading (TermReference (HashOnly (Hash.fromString "#d")))
+    ]
+
+
+workspaceItems : WorkspaceItems
+workspaceItems =
+    WorkspaceItems.fromItems before focused after
+
+
+getFocusedRef : WorkspaceItems -> Maybe Reference
+getFocusedRef =
+    WorkspaceItems.focus >> Maybe.map WorkspaceItems.reference


### PR DESCRIPTION
## Overview
Part of the work outlined in https://github.com/unisonweb/codebase-ui/pull/38.

Add in the types and tests related to `WorkspaceItems` such that it can
eventually replace `OpenDefinitions`.

## Implementation notes
`WorkspaceItems` differs from `OpenDefinitions` in that its `Reference`
based instead of `Hash` based and supports `Term` and `Type` directly
instead of through `Definition` (which will be retired in its current
form). It also differs in that it tracks `Loading`, `Failure` and
`Success` directly instead of through `RemoteData`.

`Term` and `Type` are now their own thing that share an `Info` between
them. They are somewhat extensible allowing for both summary levels of
data (for things like the `Finder`), listing data for
`NamespaceListings` and detailed versions for the `Workspace`.

## Caveats

Note: that none of this is yet in use.