### PR TITLE
Workspace: Use WorkspaceItems over OpenDefinitions

### DIFF
--- a/src/Definition.elm
+++ b/src/Definition.elm
@@ -1,9 +1,13 @@
+-- TODO: DEPRECATE
+
+
 module Definition exposing (..)
 
 import Api
 import Definition.Category as Category exposing (Category)
 import FullyQualifiedName as FQN exposing (FQN)
 import Hash exposing (Hash)
+import HashQualified exposing (HashQualified(..))
 import Html exposing (Html, a, code, div, h3, header, section, span, strong, text)
 import Html.Attributes exposing (class, classList, id)
 import Html.Events exposing (onClick)
@@ -25,6 +29,7 @@ import Syntax
 import UI
 import UI.Icon as Icon
 import Util
+import Workspace.Reference exposing (Reference(..))
 
 
 
@@ -100,6 +105,16 @@ name definition =
 
         Term _ info ->
             info.name
+
+
+reference : Definition -> Reference
+reference definition =
+    case definition of
+        Type h _ ->
+            TypeReference (HashOnly h)
+
+        Term h _ ->
+            TermReference (HashOnly h)
 
 
 equals : Definition -> Definition -> Bool

--- a/src/Definition/Info.elm
+++ b/src/Definition/Info.elm
@@ -1,12 +1,47 @@
 module Definition.Info exposing (..)
 
-import FullyQualifiedName exposing (FQN)
+import FullyQualifiedName as FQN exposing (FQN)
 import Hash exposing (Hash)
+import List.Extra as ListE
+import List.Nonempty as NEL
 
 
 type alias Info =
     { hash : Hash
-    , namespace : Maybe String
     , name : String
+    , namespace : Maybe String
     , otherNames : List FQN
     }
+
+
+makeInfo :
+    Hash
+    -> String
+    -> NEL.Nonempty FQN
+    -> Info
+makeInfo hash_ name_ allFqns =
+    let
+        ( namespace, otherNames ) =
+            namespaceAndOtherNames name_ allFqns
+    in
+    Info hash_ name_ namespace otherNames
+
+
+
+-- Helpers
+
+
+namespaceAndOtherNames : String -> NEL.Nonempty FQN -> ( Maybe String, List FQN )
+namespaceAndOtherNames suffixName fqns =
+    let
+        fqnWithin =
+            fqns
+                |> NEL.filter (FQN.isSuffixOf suffixName) (NEL.head fqns)
+                |> NEL.head
+
+        fqnsWithout =
+            fqns
+                |> NEL.toList
+                |> ListE.filterNot (FQN.equals fqnWithin)
+    in
+    ( FQN.namespaceOf suffixName fqnWithin, fqnsWithout )

--- a/src/Definition/Source.elm
+++ b/src/Definition/Source.elm
@@ -1,11 +1,5 @@
--- TODO: DEPRECATE
-
-
-module Source exposing
-    ( TermSource(..)
-    , TypeSignature(..)
-    , TypeSource(..)
-    , ViewConfig(..)
+module Definition.Source exposing
+    ( ViewConfig(..)
     , numTermLines
     , numTypeLines
     , viewTermSignature
@@ -13,25 +7,13 @@ module Source exposing
     , viewTypeSource
     )
 
+import Definition.Term as Term exposing (TermSignature(..), TermSource)
+import Definition.Type as Type exposing (TypeSource)
 import Hash exposing (Hash)
 import Html exposing (Html, span, text)
 import Html.Attributes exposing (class)
-import Syntax exposing (Syntax)
+import Syntax
 import UI
-
-
-type TypeSource
-    = TypeSource Syntax
-    | BuiltinType
-
-
-type TypeSignature
-    = TypeSignature Syntax
-
-
-type TermSource
-    = TermSource TypeSignature Syntax
-    | BuiltinTerm TypeSignature
 
 
 type ViewConfig msg
@@ -47,20 +29,20 @@ type ViewConfig msg
 numTypeLines : TypeSource -> Int
 numTypeLines source =
     case source of
-        TypeSource syntax ->
+        Type.Source syntax ->
             Syntax.numLines syntax
 
-        BuiltinType ->
+        Type.Builtin ->
             1
 
 
 numTermLines : TermSource -> Int
 numTermLines source =
     case source of
-        TermSource _ syntax ->
+        Term.Source _ syntax ->
             Syntax.numLines syntax
 
-        BuiltinTerm (TypeSignature syntax) ->
+        Term.Builtin (TermSignature syntax) ->
             Syntax.numLines syntax
 
 
@@ -73,10 +55,10 @@ viewTypeSource viewConfig source =
     let
         content =
             case source of
-                TypeSource syntax ->
+                Type.Source syntax ->
                     viewSyntax viewConfig syntax
 
-                BuiltinType ->
+                Type.Builtin ->
                     span
                         []
                         [ span [] [ text "builtin " ]
@@ -89,10 +71,10 @@ viewTypeSource viewConfig source =
 viewTermSignature : ViewConfig msg -> String -> TermSource -> Html msg
 viewTermSignature viewConfig _ source =
     case source of
-        TermSource (TypeSignature signature) _ ->
+        Term.Source (TermSignature signature) _ ->
             viewCode viewConfig (viewSyntax viewConfig signature)
 
-        BuiltinTerm (TypeSignature signature) ->
+        Term.Builtin (TermSignature signature) ->
             viewCode viewConfig (viewSyntax viewConfig signature)
 
 
@@ -101,10 +83,10 @@ viewTermSource viewConfig termName source =
     let
         content =
             case source of
-                TermSource _ syntax ->
+                Term.Source _ syntax ->
                     viewSyntax viewConfig syntax
 
-                BuiltinTerm (TypeSignature syntax) ->
+                Term.Builtin (TermSignature syntax) ->
                     span
                         []
                         [ span [ class "hash-qualifier" ] [ text termName ]

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -2,6 +2,7 @@ module Route exposing
     ( Route(..)
     , fromUrl
     , navigate
+    , navigateToByReference
     , navigateToLatest
     , navigateToTerm
     , navigateToType
@@ -20,6 +21,7 @@ import RelativeTo exposing (RelativeTo)
 import Url exposing (Url)
 import Url.Builder exposing (absolute)
 import Url.Parser as Parser exposing ((</>), Parser, oneOf, s)
+import Workspace.Reference exposing (Reference(..))
 
 
 
@@ -212,6 +214,16 @@ navigate navKey route =
 navigateToLatest : Nav.Key -> Cmd msg
 navigateToLatest navKey =
     navigate navKey (Namespace Latest)
+
+
+navigateToByReference : Nav.Key -> Route -> Reference -> Cmd msg
+navigateToByReference navKey currentRoute reference =
+    case reference of
+        TypeReference hq ->
+            navigateToType navKey currentRoute hq
+
+        TermReference hq ->
+            navigateToTerm navKey currentRoute hq
 
 
 navigateToType : Nav.Key -> Route -> HashQualified -> Cmd msg

--- a/src/Workspace/WorkspaceItem.elm
+++ b/src/Workspace/WorkspaceItem.elm
@@ -1,0 +1,373 @@
+module Workspace.WorkspaceItem exposing (..)
+
+import Api
+import Definition.Category as Category exposing (Category)
+import Definition.Info as Info
+import Definition.Source as Source
+import Definition.Term as Term exposing (Term(..), TermDetail, TermSignature(..), TermSource(..))
+import Definition.Type as Type exposing (Type(..), TypeDetail, TypeSource(..))
+import FullyQualifiedName as FQN exposing (FQN)
+import Hash
+import HashQualified exposing (HashQualified(..))
+import Html exposing (Html, a, code, div, h3, header, section, span, strong, text)
+import Html.Attributes exposing (class, classList, id)
+import Html.Events exposing (onClick)
+import Http
+import Json.Decode as Decode exposing (at, field)
+import Json.Decode.Extra exposing (when)
+import List.Nonempty as NEL
+import String.Extra exposing (pluralize)
+import Syntax
+import UI
+import UI.Icon as Icon
+import Util
+import Workspace.Reference as Reference exposing (Reference(..))
+
+
+type WorkspaceItem
+    = Loading Reference
+    | Failure Reference Http.Error
+    | Success Reference Item
+
+
+type Item
+    = TermItem TermDetail
+    | TypeItem TypeDetail
+
+
+reference : WorkspaceItem -> Reference
+reference item =
+    case item of
+        Loading r ->
+            r
+
+        Failure r _ ->
+            r
+
+        Success r _ ->
+            r
+
+
+isSameReference : WorkspaceItem -> Reference -> Bool
+isSameReference item ref =
+    reference item == ref
+
+
+isSameByReference : WorkspaceItem -> WorkspaceItem -> Bool
+isSameByReference a b =
+    reference a == reference b
+
+
+
+-- VIEW
+
+
+viewBuiltinBadge : String -> Category -> Html msg
+viewBuiltinBadge name_ category =
+    let
+        content =
+            span
+                []
+                [ strong [] [ text name_ ]
+                , text " is a "
+                , strong [] [ text ("built-in " ++ Category.name category) ]
+                , text " provided by the Unison runtime"
+                ]
+    in
+    UI.badge content
+
+
+viewBuiltin : Item -> Html msg
+viewBuiltin item =
+    case item of
+        TermItem (Term info source) ->
+            case source of
+                Term.Builtin _ ->
+                    div [ class "built-in" ]
+                        [ viewBuiltinBadge info.name (Category.Term Category.PlainTerm) ]
+
+                Term.Source _ _ ->
+                    UI.nothing
+
+        TypeItem (Type info source) ->
+            case source of
+                Type.Builtin ->
+                    div [ class "built-in" ]
+                        [ viewBuiltinBadge info.name (Category.Type Category.DataType) ]
+
+                Type.Source _ ->
+                    UI.nothing
+
+
+{-| TODO: Some of this that isn't Workspace specific might be moved into Definition.Info
+-}
+viewNames :
+    { a | name : String, namespace : Maybe String, otherNames : List FQN }
+    -> Category
+    -> Html msg
+viewNames info category =
+    let
+        namespace =
+            case info.namespace of
+                Just ns ->
+                    div [ class "namespace" ]
+                        [ span [ class "separator in" ] [ text "in" ]
+                        , text ns
+                        ]
+
+                Nothing ->
+                    UI.nothing
+
+        numOtherNames =
+            List.length info.otherNames
+
+        otherNames =
+            if numOtherNames > 0 then
+                let
+                    otherNamesTooltipContent =
+                        div [] (List.map (\n -> div [] [ text (FQN.toString n) ]) info.otherNames)
+
+                    otherNamesLabel =
+                        text (pluralize "other name..." "other names..." numOtherNames)
+                in
+                div []
+                    [ span [ class "separator" ] [ text "•" ]
+                    , span [ class "other-names" ] [ UI.withTooltip otherNamesTooltipContent otherNamesLabel ]
+                    ]
+
+            else
+                UI.nothing
+    in
+    div [ class "names" ]
+        [ Icon.view Icon.CaretDown
+        , Icon.view (Category.icon category)
+        , h3 [ class "name" ] [ text info.name ]
+        , div [ class "info" ] [ namespace, otherNames ]
+        ]
+
+
+{-| TODO: Yikes, this isn't great. Needs cleanup
+-}
+viewSource : (Reference -> msg) -> Item -> ( Html msg, Html msg )
+viewSource toOpenReferenceMsg item =
+    let
+        viewLineGutter numLines =
+            let
+                lines =
+                    numLines
+                        |> List.range 1
+                        |> List.map (String.fromInt >> text >> List.singleton >> div [])
+            in
+            UI.codeBlock [] (div [] lines)
+
+        viewToggableSource icon disabled renderedSource =
+            div [ class "source" ]
+                [ div
+                    [ classList
+                        [ ( "source-toggle", True )
+                        , ( "disabled", disabled )
+                        ]
+                    ]
+                    [ Icon.view icon ]
+                , renderedSource
+                ]
+    in
+    case item of
+        TermItem (Term info source) ->
+            ( source, source )
+                |> Tuple.mapBoth Source.numTermLines (Source.viewTermSource (Source.Rich (HashOnly >> TermReference >> toOpenReferenceMsg)) info.name)
+                |> Tuple.mapBoth viewLineGutter (viewToggableSource Icon.CaretDown False)
+
+        TypeItem (Type _ source) ->
+            ( source, source )
+                |> Tuple.mapBoth Source.numTypeLines (Source.viewTypeSource (Source.Rich (HashOnly >> TypeReference >> toOpenReferenceMsg)))
+                |> Tuple.mapBoth viewLineGutter (viewToggableSource Icon.CaretRight True)
+
+
+viewItem : msg -> (Reference -> msg) -> Reference -> Item -> Bool -> Html msg
+viewItem closeMsg toOpenReferenceMsg ref item isFocused =
+    case item of
+        TermItem (Term info _) ->
+            viewClosableRow
+                closeMsg
+                ref
+                isFocused
+                (viewNames info (Category.Term Category.PlainTerm))
+                [ ( UI.nothing, viewBuiltin item )
+                , viewSource toOpenReferenceMsg item
+                ]
+
+        TypeItem (Type info _) ->
+            viewClosableRow
+                closeMsg
+                ref
+                isFocused
+                (viewNames info (Category.Type Category.DataType))
+                [ ( UI.nothing, viewBuiltin item )
+                , viewSource toOpenReferenceMsg item
+                ]
+
+
+view : msg -> (Reference -> msg) -> WorkspaceItem -> Bool -> Html msg
+view closeMsg toOpenReferenceMsg workspaceItem isFocused =
+    case workspaceItem of
+        Loading ref ->
+            viewRow ref isFocused ( UI.nothing, UI.loadingPlaceholder ) [ ( UI.nothing, UI.loadingPlaceholder ) ]
+
+        Failure ref err ->
+            viewClosableRow
+                closeMsg
+                ref
+                isFocused
+                (h3 [] [ text "Error" ])
+                [ ( UI.nothing, UI.errorMessage (Api.errorToString err) ) ]
+
+        Success ref i ->
+            viewItem closeMsg toOpenReferenceMsg ref i isFocused
+
+
+
+-- VIEW HELPERS
+
+
+viewGutter : Html msg -> Html msg
+viewGutter content =
+    div [ class "gutter" ] [ content ]
+
+
+viewRow :
+    Reference
+    -> Bool
+    -> ( Html msg, Html msg )
+    -> List ( Html msg, Html msg )
+    -> Html msg
+viewRow ref isFocused ( headerGutter, headerContent ) content =
+    let
+        headerItems =
+            [ viewGutter headerGutter, headerContent ]
+
+        contentRows =
+            List.map (\( g, c ) -> div [ class "inner-row" ] [ viewGutter g, c ]) content
+    in
+    div
+        [ classList [ ( "focused", isFocused ), ( "definition-row", True ) ]
+        , id ("definition-" ++ Reference.toString ref)
+        ]
+        [ header [ class "inner-row" ] headerItems
+        , section [ class "content" ] contentRows
+        ]
+
+
+viewClosableRow :
+    msg
+    -> Reference
+    -> Bool
+    -> Html msg
+    -> List ( Html msg, Html msg )
+    -> Html msg
+viewClosableRow closeMsg hash_ isFocused header contentItems =
+    let
+        close =
+            a [ class "close", onClick closeMsg ] [ Icon.view Icon.X ]
+    in
+    viewRow hash_ isFocused ( close, header ) contentItems
+
+
+
+-- JSON DECODERS
+
+
+decodeTypeNamesAndSource :
+    Decode.Decoder
+        { name : String
+        , otherNames : NEL.Nonempty FQN
+        , source : TypeSource
+        }
+decodeTypeNamesAndSource =
+    let
+        make name otherNames source =
+            { name = name, otherNames = otherNames, source = source }
+
+        decodeTypeDefTag =
+            at [ "typeDefinition", "tag" ] Decode.string
+
+        decodeUserObject =
+            Decode.map Type.Source (at [ "typeDefinition", "contents" ] Syntax.decode)
+    in
+    Decode.map3 make
+        (field "bestTypeName" Decode.string)
+        (field "typeNames" (Util.decodeNonEmptyList FQN.decode))
+        (Decode.oneOf
+            [ when decodeTypeDefTag ((==) "UserObject") decodeUserObject
+            , when decodeTypeDefTag ((==) "BuiltinObject") (Decode.succeed Type.Builtin)
+            ]
+        )
+
+
+decodeTypes : Decode.Decoder (List TypeDetail)
+decodeTypes =
+    let
+        buildTypes =
+            List.map (\( h, i ) -> Type (Info.makeInfo (Hash.fromString h) i.name i.otherNames) i.source)
+    in
+    Decode.keyValuePairs decodeTypeNamesAndSource |> Decode.map buildTypes
+
+
+decodeTermNamesAndSource :
+    Decode.Decoder
+        { name : String
+        , otherNames : NEL.Nonempty FQN
+        , source : TermSource
+        }
+decodeTermNamesAndSource =
+    let
+        make name otherNames source =
+            { name = name
+            , otherNames = otherNames
+            , source = source
+            }
+
+        decodeTermDefTag =
+            at [ "termDefinition", "tag" ] Decode.string
+
+        decodeUserObject =
+            Decode.map2 Term.Source
+                (Decode.map TermSignature (field "signature" Syntax.decode))
+                (at [ "termDefinition", "contents" ] Syntax.decode)
+
+        decodeBuiltin =
+            Decode.map (TermSignature >> Term.Builtin) (field "signature" Syntax.decode)
+    in
+    Decode.map3 make
+        (field "bestTermName" Decode.string)
+        (field "termNames" (Util.decodeNonEmptyList FQN.decode))
+        (Decode.oneOf
+            [ when decodeTermDefTag ((==) "UserObject") decodeUserObject
+            , when decodeTermDefTag ((==) "BuiltinObject") decodeBuiltin
+            ]
+        )
+
+
+decodeTerms : Decode.Decoder (List TermDetail)
+decodeTerms =
+    let
+        buildTerms =
+            List.map (\( h, i ) -> Term (Info.makeInfo (Hash.fromString h) i.name i.otherNames) i.source)
+    in
+    Decode.keyValuePairs decodeTermNamesAndSource |> Decode.map buildTerms
+
+
+decodeList : Decode.Decoder (List Item)
+decodeList =
+    Decode.map2 List.append
+        (Decode.map (List.map TermItem) (field "termDefinitions" decodeTerms))
+        (Decode.map (List.map TypeItem) (field "typeDefinitions" decodeTypes))
+
+
+decodeItem : Decode.Decoder Item
+decodeItem =
+    Decode.map List.head decodeList
+        |> Decode.andThen
+            (Maybe.map Decode.succeed
+                >> Maybe.withDefault (Decode.fail "Empty list")
+            )

--- a/tests/Workspace/WorkspaceItemsTests.elm
+++ b/tests/Workspace/WorkspaceItemsTests.elm
@@ -3,8 +3,10 @@ module Workspace.WorkspaceItemsTests exposing (..)
 import Expect
 import Hash
 import HashQualified exposing (HashQualified(..))
+import Http exposing (Error(..))
 import Test exposing (..)
 import Workspace.Reference as Reference exposing (Reference(..))
+import Workspace.WorkspaceItem exposing (WorkspaceItem(..), reference)
 import Workspace.WorkspaceItems as WorkspaceItems exposing (..)
 
 
@@ -90,7 +92,7 @@ replace =
             \_ ->
                 let
                     newItem =
-                        Failure (TermReference (HashOnly (Hash.fromString "#b"))) (Error "err")
+                        Failure (TermReference (HashOnly (Hash.fromString "#b"))) (Http.BadUrl "err")
 
                     expected =
                         [ Loading (TermReference (HashOnly (Hash.fromString "#a")))
@@ -110,7 +112,7 @@ replace =
             \_ ->
                 let
                     newItem =
-                        Failure (TermReference (HashOnly (Hash.fromString "#focus"))) (Error "err")
+                        Failure (TermReference (HashOnly (Hash.fromString "#focus"))) (Http.BadUrl "err")
 
                     expected =
                         [ Loading (TermReference (HashOnly (Hash.fromString "#a")))
@@ -130,7 +132,7 @@ replace =
             \_ ->
                 let
                     newItem =
-                        Failure (TermReference (HashOnly (Hash.fromString "#d"))) (Error "err")
+                        Failure (TermReference (HashOnly (Hash.fromString "#d"))) (Http.BadUrl "err")
 
                     expected =
                         [ Loading (TermReference (HashOnly (Hash.fromString "#a")))
@@ -298,15 +300,15 @@ map =
                 let
                     result =
                         workspaceItems
-                            |> WorkspaceItems.map (\i -> Failure (reference i) (Error "err"))
+                            |> WorkspaceItems.map (\i -> Failure (reference i) (Http.BadUrl "err"))
                             |> WorkspaceItems.toList
 
                     expected =
-                        [ Failure (TermReference (HashOnly (Hash.fromString "#a"))) (Error "err")
-                        , Failure (TermReference (HashOnly (Hash.fromString "#b"))) (Error "err")
-                        , Failure (TermReference (HashOnly (Hash.fromString "#focus"))) (Error "err")
-                        , Failure (TermReference (HashOnly (Hash.fromString "#c"))) (Error "err")
-                        , Failure (TermReference (HashOnly (Hash.fromString "#d"))) (Error "err")
+                        [ Failure (TermReference (HashOnly (Hash.fromString "#a"))) (Http.BadUrl "err")
+                        , Failure (TermReference (HashOnly (Hash.fromString "#b"))) (Http.BadUrl "err")
+                        , Failure (TermReference (HashOnly (Hash.fromString "#focus"))) (Http.BadUrl "err")
+                        , Failure (TermReference (HashOnly (Hash.fromString "#c"))) (Http.BadUrl "err")
+                        , Failure (TermReference (HashOnly (Hash.fromString "#d"))) (Http.BadUrl "err")
                         ]
                 in
                 Expect.equal expected result
@@ -380,4 +382,4 @@ workspaceItems =
 
 getFocusedRef : WorkspaceItems -> Maybe Reference
 getFocusedRef =
-    WorkspaceItems.focus >> Maybe.map WorkspaceItems.reference
+    WorkspaceItems.focus >> Maybe.map reference


### PR DESCRIPTION
## Overview
Update the Workspace to use the new WorkspaceItems and move
WorkspaceItem to its own file.

Most of this just shuffles types around to use the new WorkspaceItems types.

## Implementation notes
Update Definition to be backwards compatible until its ready to be
removed.

## Loose ends
There's still cleanup needed to fully retire definitions and open definitions.
