### PR TITLE
Finder: Mark matched text in name and namespace

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -128,6 +128,7 @@ table {
   --color-modal-border: transparent;
   --color-modal-subtle-fg: var(--color-main-subtle-fg);
   --color-modal-subtle-fg-em: var(--color-gray-lighten-20);
+  --color-modal-subtle-mg: var(--color-gray-lighten-55);
   --color-modal-subtle-bg: var(--color-gray-lighten-60);
   --color-modal-focus-fg: var(--color-main-fg);
   --color-modal-focus-bg: var(--color-gray-lighten-55);
@@ -1043,12 +1044,9 @@ button.secondary:hover {
 #finder .definition-match {
   position: relative;
   z-index: var(--layer-modal-above);
-  height: 3rem;
-  padding: 0 0.75rem;
-  line-height: 1.5rem;
+  padding: 1rem 0.75rem;
   display: flex;
   flex-direction: row;
-  align-items: center;
   cursor: pointer;
   border-radius: var(--border-radius-base);
 }
@@ -1057,8 +1055,14 @@ button.secondary:hover {
   background: var(--color-modal-mg);
 }
 
+#finder .definition-match:hover .keyboard-shortcut .key {
+  background: var(--color-modal-subtle-mg);
+}
+
 #finder .definition-match .icon {
+  align-self: flex-start;
   margin-right: 0.5rem;
+  margin-top: 0.2rem;
 }
 
 #finder .definition-match code {
@@ -1069,23 +1073,49 @@ button.secondary:hover {
   font-size: 0.75rem;
 }
 
-#finder .definition-match .name {
-  cursor: pointer;
-  font-weight: bold;
-  max-width: 14rem;
-  font-size: 0.875rem;
+#finder .definition-match mark {
+  color: var(--color-modal-mark-fg);
+  background: var(--color-modal-mark-bg);
+}
+
+#finder .definition-match .naming {
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  max-width: 14rem;
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  /* the width of .naming is dynamically calculated based on the number of
+   * chars in the namespace and set with a ch unit which pixel width is based
+   * on the fontsize, so we set the font size of .naming to the font size of
+   * .namespace */
+  font-size: 0.625rem;
+}
+
+#finder .definition-match .name {
+  font-weight: bold;
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+}
+
+#finder .definition-match .namespace {
+  font-size: 0.625rem;
+  margin-top: 0.25rem;
+}
+
+#finder .definition-match .namespace .in {
+  color: var(--color-modal-subtle-fg-em);
+  margin-right: 0.25rem;
 }
 
 #finder .definition-match .source {
-  height: 3rem;
-  display: flex;
-  padding: 0 1rem;
-  align-items: center;
+  padding: 1rem;
+  margin: -1rem 0;
   border-left: 1px solid var(--color-modal-separator);
 }
+
 #finder .definition-match.focused .source {
   border-color: var(--color-modal-focus-bg);
 }
@@ -1093,6 +1123,7 @@ button.secondary:hover {
 #finder .definition-match .keyboard-shortcut {
   margin-left: auto;
   font-size: 0.75rem;
+  align-self: center;
 }
 
 #finder .definition-match .keyboard-shortcut .key {
@@ -1132,9 +1163,4 @@ button.secondary:hover {
 #finder .definition-match.focused .keyboard-shortcut .key {
   color: var(--color-modal-focus-subtle-fg);
   background: var(--color-modal-focus-subtle-bg);
-}
-
-#finder mark {
-  color: var(--color-modal-mark-fg);
-  background: var(--color-modal-mark-bg);
 }

--- a/src/Definition/Info.elm
+++ b/src/Definition/Info.elm
@@ -5,6 +5,14 @@ import List.Extra as ListE
 import List.Nonempty as NEL
 
 
+
+-- TODO: Without `otherNames` and if the `FQN` was added,
+-- `Info` would be translatable to
+-- `TermSummary`/`TypeSummary`.
+-- Perhaps it should be `Naming` instead?
+-- `otherNames` is a detail thing only.
+
+
 type alias Info =
     { name : String
     , namespace : Maybe String

--- a/src/Definition/Term.elm
+++ b/src/Definition/Term.elm
@@ -44,7 +44,12 @@ type alias TermDetail =
 
 
 type alias TermSummary =
-    Term { fqn : FQN, name : String, signature : TermSignature }
+    Term
+        { fqn : FQN
+        , name : String
+        , namespace : Maybe String
+        , signature : TermSignature
+        }
 
 
 type alias TermListing =

--- a/src/Definition/Type.elm
+++ b/src/Definition/Type.elm
@@ -14,7 +14,7 @@ module Definition.Type exposing
 import Definition.Info exposing (Info)
 import FullyQualifiedName as FQN exposing (FQN)
 import Hash exposing (Hash)
-import Json.Decode as Decode exposing (at, field, string)
+import Json.Decode as Decode exposing (field, string)
 import Json.Decode.Extra exposing (when)
 import Syntax exposing (Syntax)
 
@@ -38,7 +38,12 @@ type alias TypeDetail =
 
 
 type alias TypeSummary =
-    Type { fqn : FQN, name : String, source : TypeSource }
+    Type
+        { fqn : FQN
+        , name : String
+        , namespace : Maybe String
+        , source : TypeSource
+        }
 
 
 type alias TypeListing =

--- a/src/FullyQualifiedName.elm
+++ b/src/FullyQualifiedName.elm
@@ -129,7 +129,7 @@ namespaceOf suffixName fqn =
     if isSuffixOf suffixName fqn then
         fqn
             |> toString
-            |> String.replace suffixName ""
+            |> String.dropRight (String.length suffixName)
             |> StringE.nonEmpty
             |> Maybe.map dropLastDot
 

--- a/tests/FullyQualifiedNameTests.elm
+++ b/tests/FullyQualifiedNameTests.elm
@@ -146,4 +146,14 @@ namespaceOf =
                         FQN.fromString "base.List.map"
                 in
                 Expect.equal Nothing (FQN.namespaceOf suffix fqn)
+        , test "When the suffix is included more than once, only the last match of the FQN is removed" <|
+            \_ ->
+                let
+                    suffix =
+                        "Map"
+
+                    fqn =
+                        FQN.fromString "base.Map.Map"
+                in
+                Expect.equal (Just "base.Map") (FQN.namespaceOf suffix fqn)
         ]


### PR DESCRIPTION
## Overview
* Update TermSummary and TypeSummary with a namespace field
* translate matched segments into character positions in the FQN of the
  match
* Render the name of a match with matched characters marked
* Render namespace of matches with matched characters marked

<img width="868" alt="Screen Shot 2021-04-14 at 14 58 28" src="https://user-images.githubusercontent.com/2371/114764930-86c64b00-9d32-11eb-8a56-5408c9a5c85f.png">


## Loose ends
* @runarorama has mentioned that he might add the positions to the response of the segments (which would remove the need to translate segments to positions on the frontend)
* Depends on https://github.com/unisonweb/codebase-ui/pull/43
