### PR TITLE
Finder: Add Sequence KeyboardShortcut support

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1132,6 +1132,11 @@ button.secondary:hover {
   background: var(--color-modal-subtle-bg);
 }
 
+#finder .definition-match .keyboard-shortcut .key.active {
+  color: var(--color-modal-focus-subtle-fg);
+  background: var(--color-modal-focus-subtle-bg);
+}
+
 #finder .definition-match .keyboard-shortcut .instruction {
   color: var(--color-modal-subtle-fg);
 }

--- a/src/KeyboardShortcut.elm
+++ b/src/KeyboardShortcut.elm
@@ -1,7 +1,44 @@
+{--| 
+
+  KeyboardShortcut
+  ================
+
+  This module revolves around the KeyboardShortcut custom type which can be
+  either a `Sequence` or a `Chord`.
+
+  A `Sequence` is for keyboard shortcuts that either need just a single key to
+  trigger— in which case the last key in the Sequence is all that's required to
+  check— or a multiple key presses (limited to 2) done within a short time
+  spand of each other, much like how the <leader> shortcut sequences work in
+  the Vim editor. Keystrokes are recorded in KeyboardShortcut.Model.
+  The `fromKeyboardEvent` helper creates a `Sequence` (when it doesn't match a
+  `Chord`) using the last 2 presses made. If there was only, 1 keypress, it's a
+  `Sequence` of 1.
+
+  A `Chord` is for combination keyboard shortcuts like CMD+k where the user
+  presses a key while holding a modifier.  `fromKeyboardEvent` creates `Chord`
+  over `Sequence` when a modifier is held.
+
+  TEA
+  ---
+
+  To use this module, attach `KeyboardShortcut.Model`, `KeyboardShortcut.init`,
+  `KeyboardShortcut.Msg`, and `KeyboardShortcut.update` in the parent as often
+  seen in TEA composition.  Collect keystrokes from the parents keyboard event
+  handlers wity `KeyboardShortcut.collect`
+
+  `KeyboardShortcut.view` render shortcut indicators to provide the user with
+  instruction on how a shortcut can be performed. If viewing a `Sequence`
+  shortcut, the key that initiates the sequence will be highlighted when
+  pressed.
+
+--}
+
+
 module KeyboardShortcut exposing (..)
 
 import Html exposing (Html, span, text)
-import Html.Attributes exposing (class)
+import Html.Attributes exposing (class, classList)
 import KeyboardShortcut.Key as Key exposing (Key)
 import KeyboardShortcut.KeyboardEvent as KeyboardEvent exposing (KeyboardEvent)
 import List.Nonempty as NEL
@@ -9,11 +46,14 @@ import Process
 import Task
 
 
-type KeyboardShortcut
-    = Single Key
-    | Sequence Key Key
+type
+    KeyboardShortcut
+    -- Example for x: Sequence Nothing (X Lower)
+    -- Example for ; then 3: Sequence (Just Semicolon) Three
+    = Sequence (Maybe Key) Key
       -- Chords only support only a single modifier by design;
       -- More modifiers = less ergonomic
+      -- Example for Ctrl+k: Chord Ctrl (K Lower)
     | Chord Key Key
 
 
@@ -21,9 +61,6 @@ type KeyboardShortcut
 -- MODEL
 
 
-{-| For simple shortcuts, hooking up the model, update and event isn't needed,
-but required for Sequence shortcuts as the sequence is tracked in the model
--}
 type alias Model =
     Maybe Key
 
@@ -61,60 +98,69 @@ update msg model =
                     ( Nothing, Cmd.none )
 
 
+collect : Model -> Key -> ( Model, Cmd Msg )
+collect model key =
+    update (CollectKey key) model
+
+
 decay : Key -> Cmd Msg
 decay key =
-    Process.sleep 500 |> Task.perform (always (Decay key))
+    Process.sleep 2000 |> Task.perform (always (Decay key))
 
 
 
 -- HELPERS
 
 
-keyboardEventToShortcut : Model -> KeyboardEvent -> KeyboardShortcut
-keyboardEventToShortcut model event =
-    case KeyboardEvent.modifiersHeld event of
-        Just modifiers ->
-            Chord (NEL.head modifiers) event.key
+fromKeyboardEvent : Model -> KeyboardEvent -> KeyboardShortcut
+fromKeyboardEvent model event =
+    if Key.isModifier event.key then
+        Sequence model event.key
 
-        Nothing ->
-            case model of
-                Just k ->
-                    Sequence k event.key
+    else
+        case KeyboardEvent.modifiersHeld event of
+            Just modifiers ->
+                Chord (NEL.head modifiers) event.key
 
-                Nothing ->
-                    Single event.key
+            Nothing ->
+                Sequence model event.key
+
+
+startedSequenceWith : Model -> Key -> Bool
+startedSequenceWith model key =
+    Just key == model
 
 
 
 -- VIEW
 
 
-viewKey : Key -> Html msg
-viewKey key =
-    span [ class "key" ] [ text (Key.view key) ]
+viewKey : Key -> Bool -> Html msg
+viewKey key isActive =
+    span [ classList [ ( "key", True ), ( "active", isActive ) ] ] [ text (Key.view key) ]
 
 
-viewShortcut : KeyboardShortcut -> Html msg
-viewShortcut shortcut =
+viewShortcut : Model -> KeyboardShortcut -> Html msg
+viewShortcut model shortcut =
     let
         instruction text_ =
             span [ class "instruction" ] [ text text_ ]
 
         content =
             case shortcut of
-                Single key ->
-                    [ viewKey key ]
+                Sequence Nothing key ->
+                    [ viewKey key False ]
 
-                Sequence keyA keyB ->
-                    [ viewKey keyA
+                Sequence (Just keyA) keyB ->
+                    [ viewKey keyA (startedSequenceWith model keyA)
                     , instruction "then"
-                    , viewKey keyB
+                    , viewKey keyB False
                     ]
 
                 Chord mod key ->
-                    [ viewKey mod
+                    [ viewKey mod False
                     , instruction "plus"
-                    , viewKey key
+                    , viewKey key False
                     ]
     in
     span [ class "keyboard-shortcut" ] content

--- a/src/KeyboardShortcut/Key.elm
+++ b/src/KeyboardShortcut/Key.elm
@@ -3,6 +3,8 @@ module KeyboardShortcut.Key exposing
     , LetterCase(..)
     , decode
     , fromString
+    , isModifier
+    , toNumber
     , view
     )
 
@@ -92,9 +94,77 @@ type Key
     | Raw String
 
 
+
+-- HELPERS
+
+
+isModifier : Key -> Bool
+isModifier k =
+    case k of
+        Ctrl ->
+            True
+
+        Alt ->
+            True
+
+        Meta ->
+            True
+
+        Shift ->
+            True
+
+        _ ->
+            False
+
+
+toNumber : Key -> Maybe Int
+toNumber k =
+    case k of
+        Zero ->
+            Just 0
+
+        One ->
+            Just 1
+
+        Two ->
+            Just 2
+
+        Three ->
+            Just 3
+
+        Four ->
+            Just 4
+
+        Five ->
+            Just 5
+
+        Six ->
+            Just 6
+
+        Seven ->
+            Just 7
+
+        Eight ->
+            Just 8
+
+        Nine ->
+            Just 9
+
+        _ ->
+            Nothing
+
+
+
+-- DECODE
+
+
 decode : Decode.Decoder Key
 decode =
     Decode.map fromString Decode.string
+
+
+
+-- CREATE
 
 
 fromString : String -> Key
@@ -399,6 +469,10 @@ fromString str =
 
         _ ->
             Raw str
+
+
+
+-- VIEW
 
 
 view : Key -> String

--- a/src/SearchResults.elm
+++ b/src/SearchResults.elm
@@ -5,6 +5,7 @@ module SearchResults exposing
     , focusOn
     , from
     , fromList
+    , getAt
     , isEmpty
     , length
     , map
@@ -17,6 +18,7 @@ module SearchResults exposing
     , toMaybe
     )
 
+import List.Extra as ListE
 import List.Zipper as Zipper exposing (Zipper)
 import Maybe.Extra exposing (unwrap)
 
@@ -60,6 +62,11 @@ length results =
             data
                 |> Zipper.toList
                 |> List.length
+
+
+getAt : Int -> SearchResults a -> Maybe a
+getAt index results =
+    results |> toList |> ListE.getAt index
 
 
 map : (Matches a -> Matches a) -> SearchResults a -> SearchResults a

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -2,12 +2,10 @@ module Workspace exposing (Model, Msg, OutMsg(..), init, open, subscriptions, up
 
 import Api
 import Browser.Dom as Dom
-import Browser.Events
 import HashQualified exposing (HashQualified(..))
 import Html exposing (Html, article, header, section)
 import Html.Attributes exposing (class, id)
 import Http
-import Json.Decode as Decode
 import KeyboardShortcut.Key exposing (Key(..))
 import KeyboardShortcut.KeyboardEvent as KeyboardEvent exposing (KeyboardEvent)
 import Route exposing (Route(..))
@@ -55,7 +53,7 @@ type Msg
     | OpenDefinitionAfter Reference Reference
     | CloseDefinition Reference
     | FetchItemFinished Reference (Result Http.Error Item)
-    | HandleKeyboardEvent KeyboardEvent
+    | Keydown KeyboardEvent
 
 
 type OutMsg
@@ -95,8 +93,8 @@ update msg model =
             in
             ( nextWorkspaceItems, Cmd.none, openDefinitionsFocusToOutMsg nextWorkspaceItems )
 
-        HandleKeyboardEvent event ->
-            handleKeyboardEvent model event
+        Keydown event ->
+            keydown model event
 
 
 
@@ -158,8 +156,8 @@ openDefinitionsFocusToOutMsg openDefs =
         |> Maybe.withDefault Emptied
 
 
-handleKeyboardEvent : Model -> KeyboardEvent -> ( Model, Cmd Msg, OutMsg )
-handleKeyboardEvent model keyboardEvent =
+keydown : Model -> KeyboardEvent -> ( Model, Cmd Msg, OutMsg )
+keydown model keyboardEvent =
     let
         scrollToCmd =
             WorkspaceItems.focus
@@ -272,10 +270,7 @@ scrollToDefinition ref =
 
 subscriptions : Model -> Sub Msg
 subscriptions _ =
-    Browser.Events.onKeyDown
-        (Decode.map HandleKeyboardEvent
-            KeyboardEvent.decode
-        )
+    KeyboardEvent.subscribe KeyboardEvent.Keydown Keydown
 
 
 

--- a/tests/SearchResultsTests.elm
+++ b/tests/SearchResultsTests.elm
@@ -79,6 +79,37 @@ prev =
 
 
 
+-- QUERY
+
+
+getAt : Test
+getAt =
+    describe "SearchResults.getAt"
+        [ test "When there are no results it returns Nothing" <|
+            \_ ->
+                let
+                    result =
+                        SearchResults.fromList [] |> SearchResults.getAt 3
+                in
+                Expect.equal Nothing result
+        , test "When there the index is out of bounds it returns Nothing" <|
+            \_ ->
+                let
+                    result =
+                        SearchResults.fromList [ "foo", "bar", "baz" ] |> SearchResults.getAt 10
+                in
+                Expect.equal Nothing result
+        , test "When there is an item at the index it returns Just of that item" <|
+            \_ ->
+                let
+                    result =
+                        SearchResults.fromList [ "foo", "bar", "baz" ] |> SearchResults.getAt 1
+                in
+                Expect.equal (Just "bar") result
+        ]
+
+
+
 -- MAP
 
 

--- a/tests/Workspace/WorkspaceItemsTests.elm
+++ b/tests/Workspace/WorkspaceItemsTests.elm
@@ -1,7 +1,6 @@
 module Workspace.WorkspaceItemsTests exposing (..)
 
 import Expect
-import Hash
 import HashQualified exposing (HashQualified(..))
 import Http exposing (Error(..))
 import Test exposing (..)


### PR DESCRIPTION
## Overview
Update Finder to work with the Sequence shortcut with semicolon as the
sequence initiating key for selecting matches by the number they appear
in the result list.

https://user-images.githubusercontent.com/2371/115611849-9c9ab980-a2b8-11eb-9081-d7f5c9b379bf.mp4

## Implementation notes
Added various helper functions for setting up KeyboardEvent handlers,
detecting modifiers, creating KeyboardShortcuts from KeyboardEvents,
etc.

Removed the Single variant of KeyboardShortcut and merged that behavior
into Sequence; when caring about single key press shortcuts, a Sequence
where only the last key is considered should be used.