### PR TITLE
WorkspaceItem: Decode category fields

### DIFF
--- a/src/Definition/Term.elm
+++ b/src/Definition/Term.elm
@@ -60,11 +60,11 @@ type alias TermListing =
 -- JSON DECODERS
 
 
-decodeTermCategory : Decode.Decoder TermCategory
-decodeTermCategory =
+decodeTermCategory : String -> Decode.Decoder TermCategory
+decodeTermCategory tagFieldName =
     Decode.oneOf
-        [ when (field "termTag" string) ((==) "Test") (Decode.succeed TestTerm)
-        , when (field "termTag" string) ((==) "Doc") (Decode.succeed DocTerm)
+        [ when (field tagFieldName string) ((==) "Test") (Decode.succeed TestTerm)
+        , when (field tagFieldName string) ((==) "Doc") (Decode.succeed DocTerm)
         , Decode.succeed PlainTerm
         ]
 

--- a/src/Definition/Type.elm
+++ b/src/Definition/Type.elm
@@ -54,11 +54,11 @@ type alias TypeListing =
 -- JSON DECODERS
 
 
-decodeTypeCategory : Decode.Decoder TypeCategory
-decodeTypeCategory =
+decodeTypeCategory : String -> Decode.Decoder TypeCategory
+decodeTypeCategory tagFieldName =
     Decode.oneOf
-        [ when (field "typeTag" string) ((==) "Data") (Decode.succeed DataType)
-        , when (field "typeTag" string) ((==) "Ability") (Decode.succeed AbilityType)
+        [ when (field tagFieldName string) ((==) "Data") (Decode.succeed DataType)
+        , when (field tagFieldName string) ((==) "Ability") (Decode.succeed AbilityType)
         ]
 
 

--- a/src/Finder/FinderMatch.elm
+++ b/src/Finder/FinderMatch.elm
@@ -133,7 +133,7 @@ decodeTypeItem =
     Decode.map TypeItem
         (Decode.map3 Type
             (field "namedType" Type.decodeHash)
-            (field "namedType" Type.decodeTypeCategory)
+            (field "namedType" (Type.decodeTypeCategory "typeTag"))
             (Decode.map3 makeSummary
                 (field "namedType" Type.decodeFQN)
                 (field "bestFoundTypeName" string)
@@ -155,7 +155,7 @@ decodeTermItem =
     Decode.map TermItem
         (Decode.map3 Term
             (field "namedTerm" Term.decodeHash)
-            (field "namedTerm" Term.decodeTermCategory)
+            (field "namedTerm" (Term.decodeTermCategory "termTag"))
             (Decode.map3 makeSummary
                 (field "namedTerm" Term.decodeFQN)
                 (field "bestFoundTermName" string)

--- a/src/NamespaceListing.elm
+++ b/src/NamespaceListing.elm
@@ -7,8 +7,8 @@ module NamespaceListing exposing
     )
 
 import Definition.Category as Category exposing (Category)
-import Definition.Term exposing (TermCategory(..))
-import Definition.Type exposing (TypeCategory(..))
+import Definition.Term as Term exposing (TermCategory(..))
+import Definition.Type as Type exposing (TypeCategory(..))
 import FullyQualifiedName as FQN exposing (FQN)
 import Hash exposing (Hash)
 import Json.Decode as Decode exposing (andThen, field)
@@ -91,33 +91,20 @@ decodeContent parentFqn =
         emptyNamespaceContent =
             { definitions = [], namespaces = [] }
 
-        decodeTypeTag =
-            Decode.oneOf
-                [ when (field "typeTag" Decode.string) ((==) "Data") (Decode.succeed (Category.Type DataType))
-                , when (field "typeTag" Decode.string) ((==) "Ability") (Decode.succeed (Category.Type AbilityType))
-                ]
-
         decodeTypeListing =
             Decode.map SubDefinition
                 (Decode.map3 TypeListing
                     (field "typeHash" Hash.decode)
                     (field "typeName" (FQN.decodeFromParent parentFqn))
-                    decodeTypeTag
+                    (Decode.map Category.Type (Type.decodeTypeCategory "typeTag"))
                 )
-
-        decodeTermTag =
-            Decode.oneOf
-                [ when (field "termTag" Decode.string) ((==) "Test") (Decode.succeed (Category.Term TestTerm))
-                , when (field "termTag" Decode.string) ((==) "Doc") (Decode.succeed (Category.Term DocTerm))
-                , Decode.succeed (Category.Term PlainTerm)
-                ]
 
         decodeTermListing =
             Decode.map SubDefinition
                 (Decode.map3 TermListing
                     (field "termHash" Hash.decode)
                     (field "termName" (FQN.decodeFromParent parentFqn))
-                    decodeTermTag
+                    (Decode.map Category.Term (Term.decodeTermCategory "termTag"))
                 )
 
         decodePatchListing =


### PR DESCRIPTION
## Overview
Decode the category (type/ability/doc/test/term) fields that were
recently added to the `/getDefinition` API.

Also clean up the decoders slight and use the same category decode
across the codebase.

<img width="1273" alt="Screen Shot 2021-04-23 at 10 14 28" src="https://user-images.githubusercontent.com/2371/115885998-7e4ece00-a41e-11eb-983e-448b63305d73.png">

