### PR TITLE
Workspace Fix a bug where the URL wasn't cleared

### DIFF
--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -76,7 +76,11 @@ update msg model =
             openItem model (Just afterRef) ref
 
         CloseDefinition ref ->
-            ( WorkspaceItems.remove model ref, Cmd.none, None )
+            let
+                nextModel =
+                    WorkspaceItems.remove model ref
+            in
+            ( nextModel, Cmd.none, openDefinitionsFocusToOutMsg nextModel )
 
         FetchItemFinished ref itemResult ->
             let


### PR DESCRIPTION
Fixes https://github.com/unisonweb/codebase-ui/issues/46; Clicking the x
icon on the last open definition wouldn't clear the URL, but using x on
the keyboard would. They both should.