### PR TITLE
Fix issue with keyboard navigation on workspace

### DIFF
--- a/src/KeyboardShortcut/KeyboardEvent.elm
+++ b/src/KeyboardShortcut/KeyboardEvent.elm
@@ -165,8 +165,8 @@ decode =
         (field "altKey" bool)
         (field "ctrlKey" bool)
         (field "metaKey" bool)
-        (field "repeat" bool)
         (field "shiftKey" bool)
+        (field "repeat" bool)
         (field "key" Key.decode)
         (field "code" string)
 


### PR DESCRIPTION
## Overview
`shiftKey` and `repeat` were being parsed in place of one another
causing the `shiftKey` bool to never be set on a `KeyboardEvent` (shift
is used for moving the focus of workspace).

Fixes: https://github.com/unisonweb/codebase-ui/issues/58

## Interesting/controversial decisions
This tiny bug was quite upsetting...