### PR TITLE
Shorterm fix: Strip constructor position in hash

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,6 +11,7 @@
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
+            "elm/regex": "1.0.0",
             "elm/svg": "1.0.1",
             "elm/url": "1.0.0",
             "elm-community/json-extra": "4.3.0",
@@ -28,7 +29,6 @@
             "elm/file": "1.0.5",
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
-            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3"

--- a/src/Api.elm
+++ b/src/Api.elm
@@ -2,6 +2,7 @@ module Api exposing (errorToString, find, getDefinition, list)
 
 import Env
 import Http
+import Regex
 import Syntax
 import Url.Builder exposing (QueryParameter, absolute, int, string)
 
@@ -15,9 +16,18 @@ list rawFQN =
         |> Maybe.withDefault []
         |> serverUrl [ "list" ]
 
+
 getDefinition : List String -> String
 getDefinition fqnsOrHashes =
+    let
+        re =
+            Maybe.withDefault Regex.never (Regex.fromString "#[d|a|](\\d+)$")
+
+        stripConstructorPositionFromHash =
+            Regex.replace re (always "")
+    in
     fqnsOrHashes
+        |> List.map stripConstructorPositionFromHash
         |> List.map (string "names")
         |> serverUrl [ "getDefinition" ]
 


### PR DESCRIPTION
## Overview
When requesting definitions by hash, strip the constructor suffix (`#d0`
and `#a0`) before requesting. This allows constructors to be fetched as
types and is a bit of a bandaid. A proper support for constructors are
needed long term.

## Interesting/controversial decisions
Long term we should discuss a more complete support for constructors both in the frontend and backend.

Here's some rough thoughts:

* Backend: it should be possible to request a definition using a hash that includes a constructor suffix. It's a hash provided by the backend and not being able query by what was provided is unintuitive. 
* Frontend: We'd want to support `/ability-constructors` and `/data-constructors` in the URL with both hashes including constructor suffix and names.
* Frontend: We'd want icons for constructors that are separate from terms and types. 
* Frontend: Constructors are not merely a type of either of those, they are conceptionally their own thing (technically they are terms) and should be treated as such (this begs the question if tests and docs and abilities should be elevated to be on the same conceptional level as terms and types). 

---

@runarorama @pchiusano I've gone back and forth a lot on this effort; built out a whole lot only to walk it back again a few times as I've honed in on my thinking about constructors. Would love to connect on the above.