### PR TITLE
Add top level support for Constructors

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -3,7 +3,7 @@ module App exposing (..)
 import Api
 import Browser
 import Browser.Navigation as Nav
-import Definition.Category
+import Definition.Category as Category
 import Finder
 import FullyQualifiedName as FQN exposing (FQN, unqualifiedName)
 import FullyQualifiedNameSet as FQNSet exposing (FQNSet)
@@ -354,10 +354,16 @@ viewDefinitionListing listing =
     in
     case listing of
         TypeListing hash fqn category ->
-            viewDefRow (TypeReference (HashOnly hash)) fqn (Definition.Category.name category) (Definition.Category.icon category)
+            viewDefRow (TypeReference (HashOnly hash)) fqn (Category.name category) (Category.icon category)
 
         TermListing hash fqn category ->
-            viewDefRow (TermReference (HashOnly hash)) fqn (Definition.Category.name category) (Definition.Category.icon category)
+            viewDefRow (TermReference (HashOnly hash)) fqn (Category.name category) (Category.icon category)
+
+        DataConstructorListing hash fqn ->
+            viewDefRow (DataConstructorReference (HashOnly hash)) fqn "constructor" Icon.Type
+
+        AbilityConstructorListing hash fqn ->
+            viewDefRow (AbilityConstructorReference (HashOnly hash)) fqn "constructor" Icon.Ability
 
         PatchListing _ ->
             viewListingRow Nothing "Patch" "patch" Icon.Patch

--- a/src/Definition/AbilityConstructor.elm
+++ b/src/Definition/AbilityConstructor.elm
@@ -1,0 +1,72 @@
+module Definition.AbilityConstructor exposing
+    ( AbilityConstructor(..)
+    , AbilityConstructorDetail
+    , AbilityConstructorListing
+    , AbilityConstructorSource(..)
+    , AbilityConstructorSummary
+    , decodeSignature
+    , decodeSource
+    , isAbilityConstructorHash
+    )
+
+import Definition.Info exposing (Info)
+import Definition.Term as Term exposing (TermSignature)
+import Definition.Type as Type exposing (TypeSource)
+import FullyQualifiedName exposing (FQN)
+import Hash exposing (Hash)
+import Json.Decode as Decode
+import Regex
+import Syntax exposing (Syntax)
+
+
+type AbilityConstructorSource
+    = Source Syntax
+    | Builtin
+
+
+type AbilityConstructor a
+    = AbilityConstructor Hash a
+
+
+type alias AbilityConstructorDetail =
+    AbilityConstructor { info : Info, source : TypeSource }
+
+
+type alias AbilityConstructorSummary =
+    AbilityConstructor
+        { fqn : FQN
+        , name : String
+        , namespace : Maybe String
+        , signature : TermSignature
+        }
+
+
+type alias AbilityConstructorListing =
+    AbilityConstructor FQN
+
+
+
+-- HELPERS
+
+
+isAbilityConstructorHash : Hash -> Bool
+isAbilityConstructorHash hash =
+    let
+        abilityConstructorSuffix =
+            Maybe.withDefault Regex.never (Regex.fromString "#a(\\d+)$")
+    in
+    hash |> Hash.toString |> Regex.contains abilityConstructorSuffix
+
+
+
+-- JSON DECODERS
+
+
+decodeSource : Decode.Decoder TypeSource
+decodeSource =
+    Type.decodeSource
+
+
+decodeSignature : Decode.Decoder TermSignature
+decodeSignature =
+    Term.decodeSignature

--- a/src/Definition/DataConstructor.elm
+++ b/src/Definition/DataConstructor.elm
@@ -1,0 +1,72 @@
+module Definition.DataConstructor exposing
+    ( DataConstructor(..)
+    , DataConstructorDetail
+    , DataConstructorListing
+    , DataConstructorSource(..)
+    , DataConstructorSummary
+    , decodeSignature
+    , decodeSource
+    , isDataConstructorHash
+    )
+
+import Definition.Info exposing (Info)
+import Definition.Term as Term exposing (TermSignature)
+import Definition.Type as Type exposing (TypeSource)
+import FullyQualifiedName exposing (FQN)
+import Hash exposing (Hash)
+import Json.Decode as Decode
+import Regex
+import Syntax exposing (Syntax)
+
+
+type DataConstructorSource
+    = Source Syntax
+    | Builtin
+
+
+type DataConstructor a
+    = DataConstructor Hash a
+
+
+type alias DataConstructorDetail =
+    DataConstructor { info : Info, source : TypeSource }
+
+
+type alias DataConstructorSummary =
+    DataConstructor
+        { fqn : FQN
+        , name : String
+        , namespace : Maybe String
+        , signature : TermSignature
+        }
+
+
+type alias DataConstructorListing =
+    DataConstructor FQN
+
+
+
+-- HELPERS
+
+
+isDataConstructorHash : Hash -> Bool
+isDataConstructorHash hash =
+    let
+        dataConstructorSuffix =
+            Maybe.withDefault Regex.never (Regex.fromString "#d(\\d+)$")
+    in
+    hash |> Hash.toString |> Regex.contains dataConstructorSuffix
+
+
+
+-- JSON DECODERS
+
+
+decodeSource : Decode.Decoder TypeSource
+decodeSource =
+    Type.decodeSource
+
+
+decodeSignature : Decode.Decoder TermSignature
+decodeSignature =
+    Term.decodeSignature

--- a/src/Definition/Term.elm
+++ b/src/Definition/Term.elm
@@ -8,8 +8,8 @@ module Definition.Term exposing
     , TermSummary
     , decodeFQN
     , decodeHash
+    , decodeSignature
     , decodeTermCategory
-    , decodeTermSignature
     )
 
 import Definition.Info exposing (Info)
@@ -69,8 +69,8 @@ decodeTermCategory tagFieldName =
         ]
 
 
-decodeTermSignature : Decode.Decoder TermSignature
-decodeTermSignature =
+decodeSignature : Decode.Decoder TermSignature
+decodeSignature =
     Decode.map TermSignature (field "termType" Syntax.decode)
 
 

--- a/src/Definition/Type.elm
+++ b/src/Definition/Type.elm
@@ -7,8 +7,8 @@ module Definition.Type exposing
     , TypeSummary
     , decodeFQN
     , decodeHash
+    , decodeSource
     , decodeTypeCategory
-    , decodeTypeSource
     )
 
 import Definition.Info exposing (Info)
@@ -62,8 +62,8 @@ decodeTypeCategory tagFieldName =
         ]
 
 
-decodeTypeSource : Decode.Decoder TypeSource
-decodeTypeSource =
+decodeSource : Decode.Decoder TypeSource
+decodeSource =
     let
         decodeUserObject =
             Decode.map Source (field "contents" Syntax.decode)

--- a/src/Finder.elm
+++ b/src/Finder.elm
@@ -2,10 +2,12 @@ module Finder exposing (Model, Msg, OutMsg(..), init, update, view)
 
 import Api
 import Browser.Dom as Dom
+import Definition.AbilityConstructor exposing (AbilityConstructor(..))
 import Definition.Category as Category
+import Definition.DataConstructor exposing (DataConstructor(..))
 import Definition.Source as Source
 import Definition.Term exposing (Term(..))
-import Definition.Type exposing (Type(..))
+import Definition.Type as Type exposing (Type(..))
 import Finder.FinderMatch as FinderMatch exposing (FinderMatch)
 import HashQualified exposing (HashQualified(..))
 import Html
@@ -328,12 +330,12 @@ viewMatch keyboardShortcut match isFocused shortcut =
                     Just key ->
                         KeyboardShortcut.viewShortcut keyboardShortcut (Sequence (Just Key.Semicolon) key)
 
-        viewMatch_ reference category naming source =
+        viewMatch_ reference icon naming source =
             tr
                 [ classList [ ( "definition-match", True ), ( "focused", isFocused ) ]
                 , onClick (Select reference)
                 ]
-                [ td [ class "category" ] [ Icon.view (Category.icon category) ]
+                [ td [ class "category" ] [ Icon.view icon ]
                 , naming
                 , td [ class "source" ] [ source ]
                 , td [ class "shortcut" ] [ shortcutIndicator ]
@@ -343,14 +345,28 @@ viewMatch keyboardShortcut match isFocused shortcut =
         FinderMatch.TypeItem (Type hash category { name, namespace, source }) ->
             viewMatch_
                 (TypeReference (HashOnly hash))
-                (Category.Type category)
+                (Category.icon (Category.Type category))
                 (viewMarkedNaming match.matchPositions namespace name)
                 (Source.viewTypeSource Source.Monochrome source)
 
         FinderMatch.TermItem (Term hash category { name, namespace, signature }) ->
             viewMatch_
                 (TermReference (HashOnly hash))
-                (Category.Term category)
+                (Category.icon (Category.Term category))
+                (viewMarkedNaming match.matchPositions namespace name)
+                (Source.viewTermSignature Source.Monochrome signature)
+
+        FinderMatch.DataConstructorItem (DataConstructor hash { name, namespace, signature }) ->
+            viewMatch_
+                (DataConstructorReference (HashOnly hash))
+                Icon.Type
+                (viewMarkedNaming match.matchPositions namespace name)
+                (Source.viewTermSignature Source.Monochrome signature)
+
+        FinderMatch.AbilityConstructorItem (AbilityConstructor hash { name, namespace, signature }) ->
+            viewMatch_
+                (AbilityConstructorReference (HashOnly hash))
+                Icon.Ability
                 (viewMarkedNaming match.matchPositions namespace name)
                 (Source.viewTermSignature Source.Monochrome signature)
 

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -4,11 +4,7 @@ module Route exposing
     , navigate
     , navigateToByReference
     , navigateToLatest
-    , navigateToTerm
-    , navigateToType
     , relativeTo
-    , toTerm
-    , toType
     , toUrlString
     )
 
@@ -82,6 +78,8 @@ urlParser =
         , Parser.map Namespace (s "latest" </> s "namespaces" </> FQN.urlParser |> Parser.map NameReference)
         , Parser.map (ByReference RelativeTo.Codebase) (s "latest" </> s "types" </> Reference.urlParser TypeReference)
         , Parser.map (ByReference RelativeTo.Codebase) (s "latest" </> s "terms" </> Reference.urlParser TermReference)
+        , Parser.map (ByReference RelativeTo.Codebase) (s "latest" </> s "ability-constructors" </> Reference.urlParser AbilityConstructorReference)
+        , Parser.map (ByReference RelativeTo.Codebase) (s "latest" </> s "data-constructors" </> Reference.urlParser DataConstructorReference)
         ]
 
 
@@ -136,16 +134,6 @@ toReference oldRoute ref =
             ByReference within ref
 
 
-toType : Route -> HashQualified -> Route
-toType oldRoute hq =
-    toReference oldRoute (TypeReference hq)
-
-
-toTerm : Route -> HashQualified -> Route
-toTerm oldRoute hq =
-    toReference oldRoute (TermReference hq)
-
-
 toUrlString : Route -> String
 toUrlString route =
     let
@@ -180,6 +168,12 @@ toUrlString route =
 
                         TermReference hq ->
                             [ RelativeTo.toUrlPath relTo, "terms" ] ++ hqToPath hq
+
+                        AbilityConstructorReference hq ->
+                            [ RelativeTo.toUrlPath relTo, "ability-constructors" ] ++ hqToPath hq
+
+                        DataConstructorReference hq ->
+                            [ RelativeTo.toUrlPath relTo, "data-constructors" ] ++ hqToPath hq
     in
     absolute path []
 
@@ -202,19 +196,4 @@ navigateToLatest navKey =
 
 navigateToByReference : Nav.Key -> Route -> Reference -> Cmd msg
 navigateToByReference navKey currentRoute reference =
-    case reference of
-        TypeReference hq ->
-            navigateToType navKey currentRoute hq
-
-        TermReference hq ->
-            navigateToTerm navKey currentRoute hq
-
-
-navigateToType : Nav.Key -> Route -> HashQualified -> Cmd msg
-navigateToType navKey currentRoute hq =
-    navigate navKey (toType currentRoute hq)
-
-
-navigateToTerm : Nav.Key -> Route -> HashQualified -> Cmd msg
-navigateToTerm navKey currentRoute hq =
-    navigate navKey (toTerm currentRoute hq)
+    navigate navKey (toReference currentRoute reference)

--- a/src/Workspace/Reference.elm
+++ b/src/Workspace/Reference.elm
@@ -7,6 +7,8 @@ import Url.Parser
 type Reference
     = TermReference HashQualified
     | TypeReference HashQualified
+    | AbilityConstructorReference HashQualified
+    | DataConstructorReference HashQualified
 
 
 
@@ -41,6 +43,12 @@ hashQualified ref =
         TypeReference hq ->
             hq
 
+        AbilityConstructorReference hq ->
+            hq
+
+        DataConstructorReference hq ->
+            hq
+
 
 
 -- TRANSFORM
@@ -50,7 +58,13 @@ toString : Reference -> String
 toString ref =
     case ref of
         TermReference hq ->
-            "term/" ++ HQ.toString hq
+            "term__" ++ HQ.toString hq
 
         TypeReference hq ->
-            "type/" ++ HQ.toString hq
+            "type__" ++ HQ.toString hq
+
+        AbilityConstructorReference hq ->
+            "ability_constructor__" ++ HQ.toString hq
+
+        DataConstructorReference hq ->
+            "data_constructor__" ++ HQ.toString hq

--- a/tests/Workspace/WorkspaceItemsTests.elm
+++ b/tests/Workspace/WorkspaceItemsTests.elm
@@ -247,7 +247,7 @@ next =
                             |> getFocusedRef
                             |> Maybe.map Reference.toString
                 in
-                Expect.equal (Just "term/#c") result
+                Expect.equal (Just "term__#c") result
         , test "keeps focus if no elements after" <|
             \_ ->
                 let
@@ -257,7 +257,7 @@ next =
                             |> getFocusedRef
                             |> Maybe.map Reference.toString
                 in
-                Expect.equal (Just "term/#focus") result
+                Expect.equal (Just "term__#focus") result
         ]
 
 
@@ -273,7 +273,7 @@ prev =
                             |> getFocusedRef
                             |> Maybe.map Reference.toString
                 in
-                Expect.equal (Just "term/#b") result
+                Expect.equal (Just "term__#b") result
         , test "keeps focus if no elements before" <|
             \_ ->
                 let
@@ -283,7 +283,7 @@ prev =
                             |> getFocusedRef
                             |> Maybe.map Reference.toString
                 in
-                Expect.equal (Just "term/#focus") result
+                Expect.equal (Just "term__#focus") result
         ]
 
 
@@ -325,7 +325,7 @@ mapToList =
                             |> WorkspaceItems.mapToList (\i _ -> Reference.toString (reference i))
 
                     expected =
-                        [ "term/#a", "term/#b", "term/#focus", "term/#c", "term/#d" ]
+                        [ "term__#a", "term__#b", "term__#focus", "term__#c", "term__#d" ]
                 in
                 Expect.equal expected result
         ]


### PR DESCRIPTION
## Overview
Add support for Constructors (either Ability- or DataConstructors) on
the same level as Terms and Types. They are related to both (technically
are Terms), but have some unique characteristics that is more
ergonomically handled in the UI if they are handled as they own unique
thing.

This also adds routing support for constructor and support for icons.

## Loose ends
This doesn't use the new icons yet.
