### PR TITLE
Bugfix: previously fetched listings were blank

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -145,8 +145,13 @@ update msg model =
                                 model.expandedNamespaceListings
                     }
 
+                namespaceContentFetched =
+                    model.rootNamespaceListing
+                        |> RemoteData.map (\nl -> NamespaceListing.contentFetched nl fqn)
+                        |> RemoteData.withDefault False
+
                 cmd =
-                    if shouldExpand then
+                    if shouldExpand && not namespaceContentFetched then
                         fetchSubNamespaceListing fqn
 
                     else

--- a/src/NamespaceListing.elm
+++ b/src/NamespaceListing.elm
@@ -2,6 +2,7 @@ module NamespaceListing exposing
     ( DefinitionListing(..)
     , NamespaceListing(..)
     , NamespaceListingContent
+    , contentFetched
     , decode
     , map
     )
@@ -44,6 +45,16 @@ map f (NamespaceListing hash fqn content) =
             { c | namespaces = List.map (map f) c.namespaces }
     in
     f (NamespaceListing hash fqn (RemoteData.map mapContent content))
+
+
+contentFetched : NamespaceListing -> FQN -> Bool
+contentFetched (NamespaceListing _ fqn content) needleFqn =
+    let
+        contentIncludes c =
+            List.any (\l -> contentFetched l needleFqn) c.namespaces
+    in
+    (FQN.equals fqn needleFqn && RemoteData.isSuccess content)
+        || (content |> RemoteData.map contentIncludes |> RemoteData.withDefault False)
 
 
 


### PR DESCRIPTION
## Overview
Add a fix for https://github.com/unisonweb/codebase-ui/issues/47: 
When expanding a namespace and then expanding a subnamespace within and
then collapsing the original namespace and expanding it again, the
subnamespace would appear in an "expanded" state with the down caret,
but there would be no content shown within and the only way to see the
content would be to collapse and re-expand.

## Implementation notes
Add a `contentFetched` function to the NamespaceListing to solve this
problems such that when expanding, re-fetching (and overwriting)
previously expanded namespaces doesn't happen —  meaning only namespaces
that haven't been fetched before are fetched.
