### PR TITLE
Extract sidebar tree from App to CodebaseTree

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -1,46 +1,22 @@
 module App exposing (..)
 
-import Api
 import Browser
 import Browser.Navigation as Nav
-import Definition.Category as Category
+import CodebaseTree
+import Definition.Reference exposing (Reference(..))
 import Finder
-import FullyQualifiedName as FQN exposing (FQN, unqualifiedName)
-import FullyQualifiedNameSet as FQNSet exposing (FQNSet)
 import HashQualified exposing (HashQualified(..))
-import Html
-    exposing
-        ( Html
-        , a
-        , aside
-        , div
-        , h1
-        , h2
-        , header
-        , label
-        , span
-        , text
-        )
-import Html.Attributes exposing (class, id)
-import Html.Events exposing (onClick)
-import Http
+import Html exposing (Html, aside, div, h1, header, text)
+import Html.Attributes exposing (id)
 import KeyboardShortcut
 import KeyboardShortcut.Key exposing (Key(..))
 import KeyboardShortcut.KeyboardEvent as KeyboardEvent exposing (KeyboardEvent)
-import NamespaceListing
-    exposing
-        ( DefinitionListing(..)
-        , NamespaceListing(..)
-        , NamespaceListingContent
-        )
 import RelativeTo exposing (RelativeTo(..))
-import RemoteData exposing (RemoteData(..), WebData)
+import RemoteData exposing (RemoteData(..))
 import Route exposing (Route)
 import UI
-import UI.Icon as Icon
 import Url exposing (Url)
 import Workspace
-import Workspace.Reference exposing (Reference(..))
 
 
 
@@ -56,9 +32,8 @@ type alias Model =
     { navKey : Nav.Key
     , route : Route
     , relativeTo : RelativeTo
+    , codebaseTree : CodebaseTree.Model
     , workspace : Workspace.Model
-    , rootNamespaceListing : WebData NamespaceListing
-    , expandedNamespaceListings : FQNSet
     , modal : Modal
     , keyboardShortcut : KeyboardShortcut.Model
     }
@@ -78,6 +53,9 @@ init _ url navKey =
                 _ ->
                     Workspace.init Nothing
 
+        ( codebaseTree, codebaseTreeCmd ) =
+            CodebaseTree.init
+
         {--| TODO: When we can't get a relative to, we need to resolve the name
           in the url to a hash-}
         relativeTo =
@@ -88,14 +66,13 @@ init _ url navKey =
             , route = route
             , relativeTo = relativeTo
             , workspace = workspace
-            , rootNamespaceListing = Loading
-            , expandedNamespaceListings = FQNSet.empty
+            , codebaseTree = codebaseTree
             , modal = NoModal
             , keyboardShortcut = KeyboardShortcut.init
             }
     in
     ( model
-    , Cmd.batch [ fetchRootNamespaceListing, Cmd.map WorkspaceMsg workspaceCmd ]
+    , Cmd.batch [ Cmd.map CodebaseTreeMsg codebaseTreeCmd, Cmd.map WorkspaceMsg workspaceCmd ]
     )
 
 
@@ -107,13 +84,11 @@ type Msg
     = LinkClicked Browser.UrlRequest
     | UrlChanged Url
     | Keydown KeyboardEvent
-    | ToggleExpandedNamespaceListing FQN
-    | FetchSubNamespaceListingFinished FQN (Result Http.Error NamespaceListing)
-    | FetchRootNamespaceListingFinished (Result Http.Error NamespaceListing)
     | OpenDefinition Reference
       -- sub msgs
     | FinderMsg Finder.Msg
     | WorkspaceMsg Workspace.Msg
+    | CodebaseTreeMsg CodebaseTree.Msg
     | KeyboardShortcutMsg KeyboardShortcut.Msg
 
 
@@ -132,62 +107,6 @@ update msg model =
         Keydown event ->
             keydown model event
 
-        ToggleExpandedNamespaceListing fqn ->
-            let
-                shouldExpand =
-                    not (FQNSet.member fqn model.expandedNamespaceListings)
-
-                newModel =
-                    -- TODO: Update to Loading
-                    { model
-                        | expandedNamespaceListings =
-                            FQNSet.toggle fqn
-                                model.expandedNamespaceListings
-                    }
-
-                namespaceContentFetched =
-                    model.rootNamespaceListing
-                        |> RemoteData.map (\nl -> NamespaceListing.contentFetched nl fqn)
-                        |> RemoteData.withDefault False
-
-                cmd =
-                    if shouldExpand && not namespaceContentFetched then
-                        fetchSubNamespaceListing fqn
-
-                    else
-                        Cmd.none
-            in
-            ( newModel, cmd )
-
-        FetchSubNamespaceListingFinished fetchedFqn result ->
-            let
-                replaceNamespaceListing ((NamespaceListing hash fqn _) as namespaceListing) =
-                    if FQN.equals fetchedFqn fqn then
-                        case result of
-                            Ok (NamespaceListing _ _ content) ->
-                                NamespaceListing hash fqn content
-
-                            Err err ->
-                                NamespaceListing hash fqn (Failure err)
-
-                    else
-                        namespaceListing
-
-                nextNamespaceListing =
-                    RemoteData.map (NamespaceListing.map replaceNamespaceListing) model.rootNamespaceListing
-            in
-            ( { model | rootNamespaceListing = nextNamespaceListing }, Cmd.none )
-
-        FetchRootNamespaceListingFinished result ->
-            case result of
-                Ok (NamespaceListing hash fqn content) ->
-                    ( { model | rootNamespaceListing = Success (NamespaceListing hash fqn content) }
-                    , Cmd.none
-                    )
-
-                Err err ->
-                    ( { model | rootNamespaceListing = Failure err }, Cmd.none )
-
         OpenDefinition ref ->
             openDefinition model ref
 
@@ -203,6 +122,24 @@ update msg model =
                     handleWorkspaceOutMsg model2 outMsg
             in
             ( model3, Cmd.batch [ cmd, Cmd.map WorkspaceMsg wCmd ] )
+
+        CodebaseTreeMsg cMsg ->
+            let
+                ( codebaseTree, cCmd, outMsg ) =
+                    CodebaseTree.update cMsg model.codebaseTree
+
+                model2 =
+                    { model | codebaseTree = codebaseTree }
+
+                ( model3, cmd ) =
+                    case outMsg of
+                        CodebaseTree.None ->
+                            ( model2, Cmd.none )
+
+                        CodebaseTree.OpenDefinition ref ->
+                            openDefinition model2 ref
+            in
+            ( model3, Cmd.batch [ cmd, Cmd.map CodebaseTreeMsg cCmd ] )
 
         FinderMsg fMsg ->
             case model.modal of
@@ -293,34 +230,6 @@ showFinder model =
     ( { model | modal = FinderModal fm }, Cmd.map FinderMsg fcmd )
 
 
-
--- EFFECTS
-
-
-fetchRootNamespaceListing : Cmd Msg
-fetchRootNamespaceListing =
-    let
-        rootFqn =
-            FQN.fromString "."
-    in
-    Http.get
-        { url = Api.list Nothing
-        , expect = Http.expectJson FetchRootNamespaceListingFinished (NamespaceListing.decode rootFqn)
-        }
-
-
-fetchSubNamespaceListing : FQN -> Cmd Msg
-fetchSubNamespaceListing fqn =
-    Http.get
-        { url = Api.list (Just (FQN.toString fqn))
-        , expect = Http.expectJson (FetchSubNamespaceListingFinished fqn) (NamespaceListing.decode fqn)
-        }
-
-
-
--- SUBSCRIPTIONS
-
-
 subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.batch
@@ -333,134 +242,12 @@ subscriptions model =
 -- VIEW
 
 
-viewListingRow : Maybe msg -> String -> String -> Icon.Icon -> Html msg
-viewListingRow clickMsg label_ category icon =
-    let
-        containerClass =
-            class ("node " ++ category)
-
-        container =
-            clickMsg
-                |> Maybe.map (\msg -> a [ containerClass, onClick msg ])
-                |> Maybe.withDefault (span [ containerClass ])
-    in
-    container
-        [ Icon.view icon
-        , label [] [ text label_ ]
-        , span [ class "definition-category" ] [ text category ]
-        ]
-
-
-viewDefinitionListing : DefinitionListing -> Html Msg
-viewDefinitionListing listing =
-    let
-        viewDefRow ref fqn =
-            viewListingRow (Just (OpenDefinition ref)) (unqualifiedName fqn)
-    in
-    case listing of
-        TypeListing hash fqn category ->
-            viewDefRow (TypeReference (HashOnly hash)) fqn (Category.name category) (Category.icon category)
-
-        TermListing hash fqn category ->
-            viewDefRow (TermReference (HashOnly hash)) fqn (Category.name category) (Category.icon category)
-
-        DataConstructorListing hash fqn ->
-            viewDefRow (DataConstructorReference (HashOnly hash)) fqn "constructor" Icon.DataConstructor
-
-        AbilityConstructorListing hash fqn ->
-            viewDefRow (AbilityConstructorReference (HashOnly hash)) fqn "constructor" Icon.AbilityConstructor
-
-        PatchListing _ ->
-            viewListingRow Nothing "Patch" "patch" Icon.Patch
-
-
-viewLoadedNamespaceListingContent : FQNSet -> NamespaceListingContent -> Html Msg
-viewLoadedNamespaceListingContent expandedNamespaceListings content =
-    let
-        namespaces =
-            List.map (viewNamespaceListing expandedNamespaceListings) content.namespaces
-
-        definitions =
-            List.map viewDefinitionListing content.definitions
-    in
-    div [] (namespaces ++ definitions)
-
-
-viewNamespaceListingContent : FQNSet -> WebData NamespaceListingContent -> Html Msg
-viewNamespaceListingContent expandedNamespaceListings content =
-    case content of
-        Success loadedContent ->
-            viewLoadedNamespaceListingContent expandedNamespaceListings loadedContent
-
-        Failure err ->
-            UI.errorMessage (Api.errorToString err)
-
-        NotAsked ->
-            UI.nothing
-
-        Loading ->
-            UI.loadingPlaceholder
-
-
-viewNamespaceListing : FQNSet -> NamespaceListing -> Html Msg
-viewNamespaceListing expandedNamespaceListings (NamespaceListing _ fqn content) =
-    let
-        ( caretIcon, namespaceContent ) =
-            if FQNSet.member fqn expandedNamespaceListings then
-                ( Icon.CaretDown
-                , div [ class "namespace-content" ]
-                    [ viewNamespaceListingContent
-                        expandedNamespaceListings
-                        content
-                    ]
-                )
-
-            else
-                ( Icon.CaretRight, UI.nothing )
-    in
-    div [ class "subtree" ]
-        [ a
-            [ class "node namespace"
-            , onClick (ToggleExpandedNamespaceListing fqn)
-            ]
-            [ Icon.view caretIcon, label [] [ text (unqualifiedName fqn) ] ]
-        , namespaceContent
-        ]
-
-
-viewAllNamespaces : FQNSet -> WebData NamespaceListing -> Html Msg
-viewAllNamespaces expandedNamespaceListings namespaceRoot =
-    let
-        listings =
-            case namespaceRoot of
-                Success (NamespaceListing _ _ content) ->
-                    viewNamespaceListingContent
-                        expandedNamespaceListings
-                        content
-
-                Failure err ->
-                    UI.errorMessage (Api.errorToString err)
-
-                NotAsked ->
-                    UI.spinner
-
-                Loading ->
-                    UI.spinner
-    in
-    div [ id "all-namespaces" ]
-        [ h2 [] [ text "All Namespaces" ]
-        , div [ class "namespace-tree" ] [ listings ]
-        ]
-
-
 viewMainSidebar : Model -> Html Msg
 viewMainSidebar model =
     aside
         [ id "main-sidebar" ]
         [ header [] [ h1 [] [ text "~/.unison" ] ]
-        , viewAllNamespaces
-            model.expandedNamespaceListings
-            model.rootNamespaceListing
+        , Html.map CodebaseTreeMsg (CodebaseTree.view model.codebaseTree)
         ]
 
 

--- a/src/CodebaseTree.elm
+++ b/src/CodebaseTree.elm
@@ -1,0 +1,268 @@
+module CodebaseTree exposing (Model, Msg, OutMsg(..), init, update, view)
+
+import Api
+import CodebaseTree.NamespaceListing as NamespaceListing
+    exposing
+        ( DefinitionListing(..)
+        , NamespaceListing(..)
+        , NamespaceListingContent
+        )
+import Definition.Category as Category
+import Definition.Reference exposing (Reference(..))
+import FullyQualifiedName as FQN exposing (FQN, unqualifiedName)
+import FullyQualifiedNameSet as FQNSet exposing (FQNSet)
+import HashQualified exposing (HashQualified(..))
+import Html exposing (Html, a, div, h2, label, span, text)
+import Html.Attributes exposing (class, id)
+import Html.Events exposing (onClick)
+import Http
+import RemoteData exposing (RemoteData(..), WebData)
+import UI
+import UI.Icon as Icon
+
+
+
+-- MODEL
+
+
+type alias Model =
+    { rootNamespaceListing : WebData NamespaceListing
+    , expandedNamespaceListings : FQNSet
+    }
+
+
+init : ( Model, Cmd Msg )
+init =
+    let
+        model =
+            { rootNamespaceListing = Loading, expandedNamespaceListings = FQNSet.empty }
+    in
+    ( model, fetchRootNamespaceListing )
+
+
+
+-- UPDATE
+
+
+type Msg
+    = ToggleExpandedNamespaceListing FQN
+    | FetchSubNamespaceListingFinished FQN (Result Http.Error NamespaceListing)
+    | FetchRootNamespaceListingFinished (Result Http.Error NamespaceListing)
+    | OpenDefinitionListing Reference
+
+
+type OutMsg
+    = None
+    | OpenDefinition Reference
+
+
+update : Msg -> Model -> ( Model, Cmd Msg, OutMsg )
+update msg model =
+    case msg of
+        ToggleExpandedNamespaceListing fqn ->
+            let
+                shouldExpand =
+                    not (FQNSet.member fqn model.expandedNamespaceListings)
+
+                newModel =
+                    -- TODO: Update to Loading
+                    { model
+                        | expandedNamespaceListings =
+                            FQNSet.toggle fqn
+                                model.expandedNamespaceListings
+                    }
+
+                namespaceContentFetched =
+                    model.rootNamespaceListing
+                        |> RemoteData.map (\nl -> NamespaceListing.contentFetched nl fqn)
+                        |> RemoteData.withDefault False
+
+                cmd =
+                    if shouldExpand && not namespaceContentFetched then
+                        fetchSubNamespaceListing fqn
+
+                    else
+                        Cmd.none
+            in
+            ( newModel, cmd, None )
+
+        FetchSubNamespaceListingFinished fetchedFqn result ->
+            let
+                replaceNamespaceListing ((NamespaceListing hash fqn _) as namespaceListing) =
+                    if FQN.equals fetchedFqn fqn then
+                        case result of
+                            Ok (NamespaceListing _ _ content) ->
+                                NamespaceListing hash fqn content
+
+                            Err err ->
+                                NamespaceListing hash fqn (Failure err)
+
+                    else
+                        namespaceListing
+
+                nextNamespaceListing =
+                    RemoteData.map (NamespaceListing.map replaceNamespaceListing) model.rootNamespaceListing
+            in
+            ( { model | rootNamespaceListing = nextNamespaceListing }, Cmd.none, None )
+
+        FetchRootNamespaceListingFinished result ->
+            case result of
+                Ok (NamespaceListing hash fqn content) ->
+                    ( { model | rootNamespaceListing = Success (NamespaceListing hash fqn content) }
+                    , Cmd.none
+                    , None
+                    )
+
+                Err err ->
+                    ( { model | rootNamespaceListing = Failure err }, Cmd.none, None )
+
+        OpenDefinitionListing ref ->
+            ( model, Cmd.none, OpenDefinition ref )
+
+
+
+-- EFFECTS
+
+
+fetchRootNamespaceListing : Cmd Msg
+fetchRootNamespaceListing =
+    let
+        rootFqn =
+            FQN.fromString "."
+    in
+    Http.get
+        { url = Api.list Nothing
+        , expect = Http.expectJson FetchRootNamespaceListingFinished (NamespaceListing.decode rootFqn)
+        }
+
+
+fetchSubNamespaceListing : FQN -> Cmd Msg
+fetchSubNamespaceListing fqn =
+    Http.get
+        { url = Api.list (Just (FQN.toString fqn))
+        , expect = Http.expectJson (FetchSubNamespaceListingFinished fqn) (NamespaceListing.decode fqn)
+        }
+
+
+
+-- VIEW
+
+
+viewListingRow : Maybe msg -> String -> String -> Icon.Icon -> Html msg
+viewListingRow clickMsg label_ category icon =
+    let
+        containerClass =
+            class ("node " ++ category)
+
+        container =
+            clickMsg
+                |> Maybe.map (\msg -> a [ containerClass, onClick msg ])
+                |> Maybe.withDefault (span [ containerClass ])
+    in
+    container
+        [ Icon.view icon
+        , label [] [ text label_ ]
+        , span [ class "definition-category" ] [ text category ]
+        ]
+
+
+viewDefinitionListing : DefinitionListing -> Html Msg
+viewDefinitionListing listing =
+    let
+        viewDefRow ref fqn =
+            viewListingRow (Just (OpenDefinitionListing ref)) (unqualifiedName fqn)
+    in
+    case listing of
+        TypeListing hash fqn category ->
+            viewDefRow (TypeReference (HashOnly hash)) fqn (Category.name category) (Category.icon category)
+
+        TermListing hash fqn category ->
+            viewDefRow (TermReference (HashOnly hash)) fqn (Category.name category) (Category.icon category)
+
+        DataConstructorListing hash fqn ->
+            viewDefRow (DataConstructorReference (HashOnly hash)) fqn "constructor" Icon.DataConstructor
+
+        AbilityConstructorListing hash fqn ->
+            viewDefRow (AbilityConstructorReference (HashOnly hash)) fqn "constructor" Icon.AbilityConstructor
+
+        PatchListing _ ->
+            viewListingRow Nothing "Patch" "patch" Icon.Patch
+
+
+viewLoadedNamespaceListingContent : FQNSet -> NamespaceListingContent -> Html Msg
+viewLoadedNamespaceListingContent expandedNamespaceListings content =
+    let
+        namespaces =
+            List.map (viewNamespaceListing expandedNamespaceListings) content.namespaces
+
+        definitions =
+            List.map viewDefinitionListing content.definitions
+    in
+    div [] (namespaces ++ definitions)
+
+
+viewNamespaceListingContent : FQNSet -> WebData NamespaceListingContent -> Html Msg
+viewNamespaceListingContent expandedNamespaceListings content =
+    case content of
+        Success loadedContent ->
+            viewLoadedNamespaceListingContent expandedNamespaceListings loadedContent
+
+        Failure err ->
+            UI.errorMessage (Api.errorToString err)
+
+        NotAsked ->
+            UI.nothing
+
+        Loading ->
+            UI.loadingPlaceholder
+
+
+viewNamespaceListing : FQNSet -> NamespaceListing -> Html Msg
+viewNamespaceListing expandedNamespaceListings (NamespaceListing _ fqn content) =
+    let
+        ( caretIcon, namespaceContent ) =
+            if FQNSet.member fqn expandedNamespaceListings then
+                ( Icon.CaretDown
+                , div [ class "namespace-content" ]
+                    [ viewNamespaceListingContent
+                        expandedNamespaceListings
+                        content
+                    ]
+                )
+
+            else
+                ( Icon.CaretRight, UI.nothing )
+    in
+    div [ class "subtree" ]
+        [ a
+            [ class "node namespace"
+            , onClick (ToggleExpandedNamespaceListing fqn)
+            ]
+            [ Icon.view caretIcon, label [] [ text (unqualifiedName fqn) ] ]
+        , namespaceContent
+        ]
+
+
+view : Model -> Html Msg
+view model =
+    let
+        listings =
+            case model.rootNamespaceListing of
+                Success (NamespaceListing _ _ content) ->
+                    viewNamespaceListingContent
+                        model.expandedNamespaceListings
+                        content
+
+                Failure err ->
+                    UI.errorMessage (Api.errorToString err)
+
+                NotAsked ->
+                    UI.spinner
+
+                Loading ->
+                    UI.spinner
+    in
+    div [ id "all-namespaces" ]
+        [ h2 [] [ text "All Namespaces" ]
+        , div [ class "namespace-tree" ] [ listings ]
+        ]

--- a/src/CodebaseTree/NamespaceListing.elm
+++ b/src/CodebaseTree/NamespaceListing.elm
@@ -1,4 +1,4 @@
-module NamespaceListing exposing
+module CodebaseTree.NamespaceListing exposing
     ( DefinitionListing(..)
     , NamespaceListing(..)
     , NamespaceListingContent

--- a/src/Definition/Reference.elm
+++ b/src/Definition/Reference.elm
@@ -1,4 +1,4 @@
-module Workspace.Reference exposing (..)
+module Definition.Reference exposing (..)
 
 import HashQualified as HQ exposing (HashQualified)
 import Url.Parser

--- a/src/Finder.elm
+++ b/src/Finder.elm
@@ -5,6 +5,7 @@ import Browser.Dom as Dom
 import Definition.AbilityConstructor exposing (AbilityConstructor(..))
 import Definition.Category as Category
 import Definition.DataConstructor exposing (DataConstructor(..))
+import Definition.Reference exposing (Reference(..))
 import Definition.Source as Source
 import Definition.Term exposing (Term(..))
 import Definition.Type exposing (Type(..))
@@ -51,7 +52,6 @@ import Task
 import UI
 import UI.Icon as Icon
 import UI.Modal as Modal
-import Workspace.Reference exposing (Reference(..))
 
 
 

--- a/src/Finder/FinderMatch.elm
+++ b/src/Finder/FinderMatch.elm
@@ -2,6 +2,7 @@ module Finder.FinderMatch exposing (..)
 
 import Definition.AbilityConstructor as AbilityConstructor exposing (AbilityConstructor(..), AbilityConstructorSummary)
 import Definition.DataConstructor as DataConstructor exposing (DataConstructor(..), DataConstructorSummary)
+import Definition.Reference exposing (Reference(..))
 import Definition.Term as Term exposing (Term(..), TermSummary)
 import Definition.Type as Type exposing (Type(..), TypeSummary)
 import FullyQualifiedName as FQN
@@ -11,7 +12,6 @@ import Json.Decode as Decode exposing (at, field, string)
 import Json.Decode.Extra exposing (when)
 import List.Nonempty as NEL
 import Util exposing (decodeNonEmptyList, decodeTag)
-import Workspace.Reference exposing (Reference(..))
 
 
 type FinderItem

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -9,6 +9,7 @@ module Route exposing
     )
 
 import Browser.Navigation as Nav
+import Definition.Reference as Reference exposing (Reference(..))
 import FullyQualifiedName as FQN exposing (FQN)
 import Hash exposing (Hash)
 import HashQualified exposing (HashQualified(..))
@@ -17,7 +18,6 @@ import RelativeTo exposing (RelativeTo)
 import Url exposing (Url)
 import Url.Builder exposing (absolute)
 import Url.Parser as Parser exposing ((</>), Parser, oneOf, s)
-import Workspace.Reference as Reference exposing (Reference(..))
 
 
 

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -2,6 +2,7 @@ module Workspace exposing (Model, Msg, OutMsg(..), init, open, subscriptions, up
 
 import Api
 import Browser.Dom as Dom
+import Definition.Reference as Reference exposing (Reference)
 import HashQualified exposing (HashQualified(..))
 import Html exposing (Html, article, header, section)
 import Html.Attributes exposing (class, id)
@@ -12,7 +13,6 @@ import Route exposing (Route(..))
 import Task
 import UI
 import UI.Button as Button
-import Workspace.Reference as Reference exposing (Reference)
 import Workspace.WorkspaceItem as WorkspaceItem exposing (Item(..), WorkspaceItem(..))
 import Workspace.WorkspaceItems as WorkspaceItems exposing (WorkspaceItems)
 

--- a/src/Workspace/WorkspaceItem.elm
+++ b/src/Workspace/WorkspaceItem.elm
@@ -5,6 +5,7 @@ import Definition.AbilityConstructor as AbilityConstructor exposing (AbilityCons
 import Definition.Category as Category exposing (Category)
 import Definition.DataConstructor as DataConstructor exposing (DataConstructor(..), DataConstructorDetail, DataConstructorSource(..))
 import Definition.Info as Info
+import Definition.Reference as Reference exposing (Reference(..))
 import Definition.Source as Source
 import Definition.Term as Term exposing (Term(..), TermCategory, TermDetail, TermSignature(..), TermSource(..))
 import Definition.Type as Type exposing (Type(..), TypeCategory, TypeDetail, TypeSource(..))
@@ -24,7 +25,6 @@ import Syntax
 import UI
 import UI.Icon as Icon
 import Util
-import Workspace.Reference as Reference exposing (Reference(..))
 
 
 type WorkspaceItem

--- a/src/Workspace/WorkspaceItems.elm
+++ b/src/Workspace/WorkspaceItems.elm
@@ -17,9 +17,9 @@
 
 module Workspace.WorkspaceItems exposing (..)
 
+import Definition.Reference exposing (Reference)
 import List
 import List.Extra as ListE
-import Workspace.Reference exposing (Reference)
 import Workspace.WorkspaceItem as WorkspaceItem exposing (WorkspaceItem)
 
 

--- a/tests/Workspace/WorkspaceItemsTests.elm
+++ b/tests/Workspace/WorkspaceItemsTests.elm
@@ -1,10 +1,10 @@
 module Workspace.WorkspaceItemsTests exposing (..)
 
+import Definition.Reference as Reference exposing (Reference(..))
 import Expect
 import HashQualified exposing (HashQualified(..))
 import Http exposing (Error(..))
 import Test exposing (..)
-import Workspace.Reference as Reference exposing (Reference(..))
 import Workspace.WorkspaceItem exposing (WorkspaceItem(..), reference)
 import Workspace.WorkspaceItems as WorkspaceItems exposing (..)
 


### PR DESCRIPTION
## Overview
A minor refactor, just moving modules around. Been meaning to do this for a while.

## Implementation notes
* Extract the namespace listing tree ui to its own module from App.
* Move Workspace.Reference to Definition.Reference