### PR TITLE
Animate expanding the codebase tree

### DIFF
--- a/src/CodebaseTree.elm
+++ b/src/CodebaseTree.elm
@@ -13,7 +13,7 @@ import FullyQualifiedName as FQN exposing (FQN, unqualifiedName)
 import FullyQualifiedNameSet as FQNSet exposing (FQNSet)
 import HashQualified exposing (HashQualified(..))
 import Html exposing (Html, a, div, h2, label, span, text)
-import Html.Attributes exposing (class, id)
+import Html.Attributes exposing (class, classList, id)
 import Html.Events exposing (onClick)
 import Http
 import RemoteData exposing (RemoteData(..), WebData)
@@ -220,9 +220,9 @@ viewNamespaceListingContent expandedNamespaceListings content =
 viewNamespaceListing : FQNSet -> NamespaceListing -> Html Msg
 viewNamespaceListing expandedNamespaceListings (NamespaceListing _ fqn content) =
     let
-        ( caretIcon, namespaceContent ) =
+        ( isExpanded, namespaceContent ) =
             if FQNSet.member fqn expandedNamespaceListings then
-                ( Icon.CaretDown
+                ( True
                 , div [ class "namespace-content" ]
                     [ viewNamespaceListingContent
                         expandedNamespaceListings
@@ -231,14 +231,16 @@ viewNamespaceListing expandedNamespaceListings (NamespaceListing _ fqn content) 
                 )
 
             else
-                ( Icon.CaretRight, UI.nothing )
+                ( False, UI.nothing )
     in
     div [ class "subtree" ]
         [ a
             [ class "node namespace"
             , onClick (ToggleExpandedNamespaceListing fqn)
             ]
-            [ Icon.view caretIcon, label [] [ text (unqualifiedName fqn) ] ]
+            [ Icon.custom [ classList [ ( "expanded", isExpanded ) ] ] Icon.CaretRight
+            , label [] [ text (unqualifiedName fqn) ]
+            ]
         , namespaceContent
         ]
 
@@ -262,7 +264,7 @@ view model =
                 Loading ->
                     UI.spinner
     in
-    div [ id "all-namespaces" ]
+    div [ id "codebase-tree" ]
         [ h2 [] [ text "All Namespaces" ]
         , div [ class "namespace-tree" ] [ listings ]
         ]

--- a/src/UI/Icon.elm
+++ b/src/UI/Icon.elm
@@ -1,6 +1,6 @@
-module UI.Icon exposing (Icon(..), view)
+module UI.Icon exposing (Icon(..), custom, view)
 
-import Html exposing (Html, div)
+import Html exposing (Attribute, Html, div)
 import Html.Attributes exposing (class)
 import Svg exposing (svg, use)
 import Svg.Attributes exposing (height, width, xlinkHref)
@@ -30,10 +30,8 @@ type Icon
     | Search
 
 
-{-| Example: UI.Icon.view UI.Icon.Checkmark |
--}
-view : Icon -> Html msg
-view icon =
+custom : List (Attribute msg) -> Icon -> Html msg
+custom attrs icon =
     let
         iconName =
             toIdString icon
@@ -44,10 +42,17 @@ view icon =
         className =
             "icon " ++ iconName
     in
-    -- Random, its not possible to dynamically set classNames on svg elements
-    div [ class className ]
+    -- Randomly, its not possible to dynamically set classNames on svg elements
+    div (class className :: attrs)
         [ svg [ width "100%", height "100%" ] [ use [ xlinkHref ref ] [] ]
         ]
+
+
+{-| Example: UI.Icon.view UI.Icon.Checkmark |
+-}
+view : Icon -> Html msg
+view icon =
+    custom [] icon
 
 
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -686,11 +686,13 @@ button.secondary:hover {
   margin-bottom: 0.125rem;
 }
 
-.namespace-tree {
+/* -- Codebase Tree -------------------------------------------------------- */
+
+#codebase-tree .namespace-tree {
   margin-left: -0.5rem;
 }
 
-.namespace-tree .node {
+#codebase-tree .namespace-tree .node {
   display: flex;
   user-select: none;
   align-items: center;
@@ -700,47 +702,55 @@ button.secondary:hover {
   height: 1.75rem;
 }
 
-.namespace-tree .node:hover {
+#codebase-tree .namespace-tree .node:hover {
   background: var(--color-sidebar-focus-bg);
   text-decoration: none;
 }
 
-.namespace-tree .node .icon {
+#codebase-tree .namespace-tree .node .icon {
   font-size: 0.875rem;
   text-align: center;
   margin-right: 0.5rem;
+  transition: transform 0.2s ease-out;
 }
-.namespace-tree .node .icon:is(.caret-right, .caret-down) {
+
+#codebase-tree .namespace-tree .node .icon.expanded {
+  transform: rotate(90deg);
+}
+
+#codebase-tree .namespace-tree .node .icon:is(.caret-right, .caret-down) {
   color: var(--color-sidebar-subtle-fg);
 }
 
-.namespace-tree .node:hover .icon:is(.caret-right, .caret-down) {
+#codebase-tree .namespace-tree .node:hover .icon:is(.caret-right, .caret-down) {
   color: var(--color-sidebar-focus-fg);
 }
 
-.namespace-tree .node label {
+#codebase-tree .namespace-tree .node label {
   color: var(--color-sidebar-fg);
   transition: all 0.2s;
   cursor: pointer;
 }
 
-.namespace-tree .node .definition-category {
+#codebase-tree .namespace-tree .node .definition-category {
   font-family: var(--font-monospace);
   color: var(--color-sidebar-subtle-fg);
   margin-left: 0.375rem;
   font-size: 0.75rem;
 }
 
-.namespace-tree .node:hover label {
+#codebase-tree .namespace-tree .node:hover label {
   color: var(--color-sidebar-focus-fg);
 }
 
-.namespace-tree .node.open label {
+#codebase-tree .namespace-tree .node.open label {
   font-weight: bold;
 }
 
-.namespace-tree .namespace-content {
+#codebase-tree .namespace-tree .namespace-content {
   margin-left: 1rem;
+  transform-origin: left top;
+  animation: slide-down 0.2s ease-out;
 }
 
 /* -- Workspace ------------------------------------------------------------ */


### PR DESCRIPTION
## Overview
Some minor polish to animate the expansion of the codebase tree:

https://user-images.githubusercontent.com/2371/117065202-2ef97f00-acf5-11eb-93b5-a4bfc7220a94.mp4

fixes: https://github.com/unisonweb/codebase-ui/issues/76

## Loose ends
It doesn't animate when collapsing. This is a little more involved as it involves hiding elements before removing them from the DOM.
