### PR TITLE
Add AppContext; Rename hub to share

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -4,7 +4,7 @@ import Browser
 import Browser.Navigation as Nav
 import CodebaseTree
 import Definition.Reference exposing (Reference(..))
-import Env exposing (Env, Flags, OperatingSystem(..))
+import Env as Env exposing (Env, Flags, OperatingSystem(..))
 import Finder
 import HashQualified exposing (HashQualified(..))
 import Html exposing (Html, a, aside, div, h1, h3, header, nav, section, span, text)
@@ -285,9 +285,18 @@ subscriptions model =
 
 viewMainSidebar : Model -> Html Msg
 viewMainSidebar model =
+    let
+        appContext =
+            case model.env.appContext of
+                Env.Ucm ->
+                    span [] [ text "Unison", span [ class "context ucm" ] [ text " Local" ] ]
+
+                Env.UnisonShare ->
+                    span [] [ text "Unison", span [ class "context unison-share" ] [ text " Share" ] ]
+    in
     aside
         [ id "main-sidebar" ]
-        [ header [] [ h1 [] [ text "~/.unison" ] ]
+        [ header [] [ h1 [ class "app-context" ] [ span [ class "logo-mark" ] [ Icon.view Icon.UnisonMark ], appContext ] ]
         , div [] [ Html.map CodebaseTreeMsg (CodebaseTree.view model.codebaseTree) ]
         , nav []
             [ a [ href "https://unison-lang.org", target "_blank" ] [ Icon.view Icon.UnisonMark ]

--- a/src/Env.elm
+++ b/src/Env.elm
@@ -3,6 +3,11 @@ module Env exposing (..)
 import Api exposing (ApiBasePath(..))
 
 
+type AppContext
+    = UnisonShare
+    | Ucm
+
+
 type OperatingSystem
     = MacOS
     | Windows
@@ -16,6 +21,7 @@ type alias Env =
     { operatingSystem : OperatingSystem
     , basePath : String
     , apiBasePath : ApiBasePath
+    , appContext : AppContext
     }
 
 
@@ -23,12 +29,26 @@ type alias Flags =
     { operatingSystem : String
     , basePath : String
     , apiBasePath : List String
+    , appContext : String
     }
 
 
 fromFlags : Flags -> Env
 fromFlags flags =
-    Env (operatingSystemFromString flags.operatingSystem) flags.basePath (ApiBasePath flags.apiBasePath)
+    { operatingSystem = operatingSystemFromString flags.operatingSystem
+    , basePath = flags.basePath
+    , apiBasePath = ApiBasePath flags.apiBasePath
+    , appContext = appContextFromString flags.appContext
+    }
+
+
+appContextFromString : String -> AppContext
+appContextFromString rawContext =
+    if rawContext == "UnisonShare" then
+        UnisonShare
+
+    else
+        Ucm
 
 
 operatingSystemFromString : String -> OperatingSystem

--- a/src/UnisonShare.elm
+++ b/src/UnisonShare.elm
@@ -1,4 +1,4 @@
-module Hub exposing (..)
+module UnisonShare exposing (..)
 
 import App
 import Browser

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -99,7 +99,8 @@ table {
 
   --color-sidebar-fg: var(--color-gray-lighten-50);
   --color-sidebar-bg: var(--color-gray-darken-20);
-  --color-sidebar-context-fg: var(--color-brand-orange);
+  --color-sidebar-context-unison-share-fg: var(--color-purple-base);
+  --color-sidebar-context-ucm-fg: var(--color-blue-base);
   --color-sidebar-border: transparent;
   --color-sidebar-subtle-fg: var(--color-gray-lighten-20);
   --color-sidebar-subtle-bg: transparent;
@@ -768,9 +769,34 @@ button.secondary:hover {
   margin-bottom: 2.5rem;
 }
 
-#main-sidebar h1 {
+#main-sidebar .app-context {
   font-size: var(--font-size-base);
-  color: var(--color-sidebar-context-fg);
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+}
+
+#main-sidebar .app-context .logo-mark {
+  display: flex;
+  height: 1.3rem;
+  width: 1.3rem;
+  align-items: center;
+  justify-content: center;
+  margin-right: 0.5rem;
+}
+
+#main-sidebar .app-context .logo-mark .icon {
+  font-size: 0.875rem;
+  color: var(--color-sidebar-fg);
+  margin-bottom: 2px;
+}
+
+#main-sidebar .app-context .unison-share {
+  color: var(--color-sidebar-context-unison-share-fg);
+}
+
+#main-sidebar .app-context .ucm {
+  color: var(--color-sidebar-context-ucm-fg);
 }
 
 #main-sidebar h2 {
@@ -805,7 +831,7 @@ button.secondary:hover {
   font-size: 0.875rem;
   text-align: center;
   margin-right: 0.5rem;
-  transition: transform 0.2s ease-out;
+  transition: transform 0.1s ease-out;
 }
 
 #codebase-tree .namespace-tree .node .icon.expanded {

--- a/src/ucm.ejs
+++ b/src/ucm.ejs
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Unison Codebase</title>
+    <title>Unison Local Codebase</title>
     <% if (webpackConfig.mode === "production") {%>
       <script type="text/javascript">
         const pathSegments = location.pathname.split("/").filter(p => p !== "");

--- a/src/ucm.js
+++ b/src/ucm.js
@@ -19,6 +19,7 @@ const flags = {
   operatingSystem: detectOs(window.navigator),
   basePath,
   apiBasePath,
+  appContext: "Ucm",
 };
 
 // The main entry point for the `ucm` target of the Codebase UI.

--- a/src/unisonShare.ejs
+++ b/src/unisonShare.ejs
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Unison Codebase</title>
+    <title>Unison Share</title>
     <link rel="icon" type="image/svg+xml" href="<%= require('./favicon.svg') %>">
   </head>
   <body></body>

--- a/src/unisonShare.js
+++ b/src/unisonShare.js
@@ -1,6 +1,6 @@
 import "./init";
 import detectOs from "./detectOs";
-import { Elm } from "./Hub.elm";
+import { Elm } from "./UnisonShare.elm";
 
 const basePath = new URL(document.baseURI).pathname;
 const apiBasePath = ["api"];
@@ -9,7 +9,8 @@ const flags = {
   operatingSystem: detectOs(window.navigator),
   basePath,
   apiBasePath,
+  appContext: "UnisonShare",
 };
 
-// The main entry point for the `hub` target of the Codebase UI.
-Elm.Hub.init({ flags });
+// The main entry point for the `UnisonShare` target of the Codebase UI.
+Elm.UnisonShare.init({ flags });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -37,25 +37,27 @@ const shared = {
   },
 };
 
-const hubCfg = {
+const unisonShareCfg = {
   ...shared,
 
-  entry: "./src/hub.js",
+  entry: "./src/unisonShare.js",
 
   plugins: [
     new HtmlWebpackPlugin({
       favicon: "./static/favicon.ico",
-      template: "./src/hub.ejs",
+      template: "./src/unisonShare.ejs",
       inject: "body",
       publicPath: "/static/",
       base: "/",
-      filename: path.resolve(__dirname, "dist/hub/index.html"),
+      filename: path.resolve(__dirname, "dist/unisonShare/index.html"),
     }),
 
     new FileManagerPlugin({
       events: {
         onEnd: {
-          archive: [{ source: "dist/hub", destination: "dist/hub.zip" }],
+          archive: [
+            { source: "dist/unisonShare", destination: "dist/unisonShare.zip" },
+          ],
         },
       },
     }),
@@ -63,7 +65,7 @@ const hubCfg = {
 
   output: {
     filename: "[name].[contenthash].js",
-    path: path.resolve(__dirname, "dist/hub/static"),
+    path: path.resolve(__dirname, "dist/unisonShare/static"),
     clean: true,
   },
 };
@@ -99,4 +101,4 @@ const ucmCfg = {
   },
 };
 
-module.exports = [hubCfg, ucmCfg];
+module.exports = [unisonShareCfg, ucmCfg];


### PR DESCRIPTION
## Overview
Add the AppContext (and in the process rename "hub" to "share"), and
include context related header of the main sidebar, Unison Local (ucm) &
Unison Share (share, previously hub).

## Notes
@stew this changes the zip in the release from being "hub.zip" to "unisonShare.zip".
