### PR TITLE
Fix issue where "/" basePaths weren't routable

### DIFF
--- a/src/Route.elm
+++ b/src/Route.elm
@@ -85,7 +85,16 @@ urlParser =
 
 fromUrl : String -> Url -> Route
 fromUrl basePath url =
-    { url | path = String.replace basePath "" url.path }
+    let
+        stripBasePath u =
+            if basePath == "/" then
+                u
+
+            else
+                { u | path = String.replace basePath "" u.path }
+    in
+    url
+        |> stripBasePath
         |> Parser.parse urlParser
         |> Maybe.withDefault (Namespace Latest)
 

--- a/tests/RouteTests.elm
+++ b/tests/RouteTests.elm
@@ -1,0 +1,51 @@
+module RouteTests exposing (..)
+
+import Definition.Reference as Reference exposing (Reference(..))
+import Expect
+import RelativeTo
+import Route
+import Test exposing (..)
+import Url exposing (Url)
+
+
+fromUrl : Test
+fromUrl =
+    describe "Route.fromUrl"
+        [ test "Matches with a basePath prefix" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/latest/terms/@abc123"
+
+                    basePath =
+                        "/some-token/ui/"
+
+                    expected =
+                        Route.ByReference RelativeTo.Codebase (Reference.fromString TermReference "#abc123")
+                in
+                Expect.equal expected (Route.fromUrl basePath url)
+        , test "Matches with a root basePath prefix" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/latest/terms/@abc123"
+
+                    basePath =
+                        "/"
+
+                    expected =
+                        Route.ByReference RelativeTo.Codebase (Reference.fromString TermReference "#abc123")
+                in
+                Expect.equal expected (Route.fromUrl basePath url)
+        ]
+
+
+mkUrl : String -> Url
+mkUrl path =
+    { protocol = Url.Https
+    , host = "unison-lang.org"
+    , port_ = Just 443
+    , path = path
+    , query = Nothing
+    , fragment = Nothing
+    }


### PR DESCRIPTION
## Overview
When encountering a "/" as the `basePath`, `Route.fromUrl` did some
unfortunate string replacement resulting in an un-routable URL.

Fixes: https://github.com/unisonweb/codebase-ui/issues/103

## Loose ends
We should prolly only replace the first match long term