### PR TITLE
Add a loader to Finder and improve error messages

### DIFF
--- a/src/CodebaseTree.elm
+++ b/src/CodebaseTree.elm
@@ -14,7 +14,7 @@ import FullyQualifiedName as FQN exposing (FQN, unqualifiedName)
 import FullyQualifiedNameSet as FQNSet exposing (FQNSet)
 import HashQualified exposing (HashQualified(..))
 import Html exposing (Html, a, div, h2, label, span, text)
-import Html.Attributes exposing (class, classList, id)
+import Html.Attributes exposing (class, classList, id, title)
 import Html.Events exposing (onClick)
 import Http
 import RemoteData exposing (RemoteData(..), WebData)
@@ -205,7 +205,7 @@ viewNamespaceListingContent expandedNamespaceListings content =
             viewLoadedNamespaceListingContent expandedNamespaceListings loadedContent
 
         Failure err ->
-            UI.errorMessage (Api.errorToString err)
+            viewError err
 
         NotAsked ->
             UI.nothing
@@ -242,6 +242,14 @@ viewNamespaceListing expandedNamespaceListings (NamespaceListing _ fqn content) 
         ]
 
 
+viewError : Http.Error -> Html msg
+viewError err =
+    div [ class "error", title (Api.errorToString err) ]
+        [ Icon.view Icon.Warn
+        , text "Unable to load namespace"
+        ]
+
+
 view : Model -> Html Msg
 view model =
     let
@@ -253,7 +261,7 @@ view model =
                         content
 
                 Failure err ->
-                    UI.errorMessage (Api.errorToString err)
+                    viewError err
 
                 NotAsked ->
                     UI.spinner
@@ -261,7 +269,7 @@ view model =
                 Loading ->
                     UI.spinner
     in
-    div [ id "codebase-tree" ]
+    div [ class "codebase-tree" ]
         [ h2 [] [ text "All Namespaces" ]
         , div [ class "namespace-tree" ] [ listings ]
         ]

--- a/src/Definition/Reference.elm
+++ b/src/Definition/Reference.elm
@@ -1,6 +1,7 @@
 module Definition.Reference exposing (..)
 
 import HashQualified as HQ exposing (HashQualified)
+import UI.Icon as Icon exposing (Icon(..))
 import Url.Parser
 
 
@@ -68,3 +69,35 @@ toString ref =
 
         DataConstructorReference hq ->
             "data_constructor__" ++ HQ.toString hq
+
+
+toHumanString : Reference -> String
+toHumanString ref =
+    case ref of
+        TermReference hq ->
+            "Term " ++ HQ.toString hq
+
+        TypeReference hq ->
+            "Type " ++ HQ.toString hq
+
+        AbilityConstructorReference hq ->
+            "Ability constructor " ++ HQ.toString hq
+
+        DataConstructorReference hq ->
+            "Data Constructor " ++ HQ.toString hq
+
+
+toIcon : Reference -> Icon
+toIcon ref =
+    case ref of
+        TermReference _ ->
+            Icon.Term
+
+        TypeReference _ ->
+            Icon.Type
+
+        AbilityConstructorReference _ ->
+            Icon.AbilityConstructor
+
+        DataConstructorReference _ ->
+            Icon.DataConstructor

--- a/src/UI.elm
+++ b/src/UI.elm
@@ -21,7 +21,7 @@ badge content =
 
 spinner : Html msg
 spinner =
-    div [ class "spinner" ] [ text "Loading..." ]
+    div [ class "spinner" ] []
 
 
 subtle : String -> Html msg

--- a/src/Workspace/WorkspaceItem.elm
+++ b/src/Workspace/WorkspaceItem.elm
@@ -1,9 +1,9 @@
 module Workspace.WorkspaceItem exposing (..)
 
 import Api
-import Definition.AbilityConstructor as AbilityConstructor exposing (AbilityConstructor(..), AbilityConstructorDetail, AbilityConstructorSource(..))
+import Definition.AbilityConstructor exposing (AbilityConstructor(..), AbilityConstructorDetail, AbilityConstructorSource(..))
 import Definition.Category as Category exposing (Category)
-import Definition.DataConstructor as DataConstructor exposing (DataConstructor(..), DataConstructorDetail, DataConstructorSource(..))
+import Definition.DataConstructor exposing (DataConstructor(..), DataConstructorDetail, DataConstructorSource(..))
 import Definition.Info as Info
 import Definition.Reference as Reference exposing (Reference(..))
 import Definition.Source as Source
@@ -11,9 +11,9 @@ import Definition.Term as Term exposing (Term(..), TermCategory, TermDetail, Ter
 import Definition.Type as Type exposing (Type(..), TypeCategory, TypeDetail, TypeSource(..))
 import FullyQualifiedName as FQN exposing (FQN)
 import Hash
-import HashQualified exposing (HashQualified(..))
+import HashQualified as HQ exposing (HashQualified(..))
 import Html exposing (Html, a, div, h3, header, section, span, strong, text)
-import Html.Attributes exposing (class, classList, id)
+import Html.Attributes exposing (class, classList, id, title)
 import Html.Events exposing (onClick)
 import Http
 import Json.Decode as Decode exposing (at, field)
@@ -277,8 +277,21 @@ view closeMsg toOpenReferenceMsg workspaceItem isFocused =
                 closeMsg
                 ref
                 isFocused
-                (h3 [] [ text "Error" ])
-                [ ( UI.nothing, UI.errorMessage (Api.errorToString err) ) ]
+                (div [ class "error-header" ]
+                    [ Icon.view Icon.Warn
+                    , Icon.view (Reference.toIcon ref)
+                    , h3 [ title (Api.errorToString err) ] [ text (HQ.toString (Reference.hashQualified ref)) ]
+                    ]
+                )
+                [ ( UI.nothing
+                  , div
+                        [ class "error" ]
+                        [ text "Unable to load definition: "
+                        , span [ class "definition-with-error" ] [ text (Reference.toHumanString ref) ]
+                        , text " —  please try again."
+                        ]
+                  )
+                ]
 
         Success ref i ->
             viewItem closeMsg toOpenReferenceMsg ref i isFocused

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -75,6 +75,11 @@ table {
   --color-gray-lighten-60: #fafafb;
   --color-gray-lighten-100: #ffffff;
 
+  /* Reds */
+  --color-pink-base: #ff4756;
+  --color-pink-lighten-20: #ff6c78;
+  --color-pink-lighten-30: #ff9ba3;
+
   /* blues */
   --color-blue-base: #5695f4;
 
@@ -100,7 +105,7 @@ table {
   --color-sidebar-fg: var(--color-gray-lighten-50);
   --color-sidebar-bg: var(--color-gray-darken-20);
   --color-sidebar-context-unison-share-fg: var(--color-purple-base);
-  --color-sidebar-context-ucm-fg: var(--color-blue-base);
+  --color-sidebar-context-ucm-fg: var(--color-green-base);
   --color-sidebar-border: transparent;
   --color-sidebar-subtle-fg: var(--color-gray-lighten-20);
   --color-sidebar-subtle-bg: transparent;
@@ -149,6 +154,7 @@ table {
   --color-modal-title-bg: transparent;
   --color-modal-mark-fg: var(--color-blue-base);
   --color-modal-mark-bg: transparent;
+  --color-modal-error-fg: var(--color-pink-base);
 
   /* Icons */
   --color-icon-type: var(--color-brand-orange);
@@ -226,6 +232,19 @@ table {
   100% {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+/* scale3D instead of scale forces the animation onto the GPU, avoiding jank */
+@keyframes pulse-grow {
+  0% {
+    transform: scale3D(1, 1, 1);
+  }
+  50% {
+    transform: scale3D(1.25, 1.25, 1.25);
+  }
+  100% {
+    transform: scale3D(1, 1, 1);
   }
 }
 
@@ -454,7 +473,7 @@ code a:active {
 /* -- UI ------------------------------------------------------------------- */
 
 .error-message {
-  color: var(--color-brand-bright-red);
+  color: var(--color-pink-base);
 }
 
 .subtle {
@@ -782,7 +801,7 @@ button.secondary:hover {
   width: 1.3rem;
   align-items: center;
   justify-content: center;
-  margin-right: 0.5rem;
+  margin-right: 0.125rem;
 }
 
 #main-sidebar .app-context .logo-mark .icon {
@@ -808,11 +827,11 @@ button.secondary:hover {
 
 /* -- Codebase Tree -------------------------------------------------------- */
 
-#codebase-tree .namespace-tree {
+.codebase-tree .namespace-tree {
   margin-left: -0.5rem;
 }
 
-#codebase-tree .namespace-tree .node {
+.codebase-tree .namespace-tree .node {
   display: flex;
   user-select: none;
   align-items: center;
@@ -822,52 +841,67 @@ button.secondary:hover {
   height: 1.75rem;
 }
 
-#codebase-tree .namespace-tree .node:hover {
+.codebase-tree .error {
+  padding-left: 0.5rem;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: 0.5rem 0;
+  color: var(--color-pink-lighten-30);
+}
+
+.codebase-tree .error .icon {
+  font-size: 1rem;
+  margin-right: 0.25rem;
+  color: var(--color-pink-base);
+}
+
+.codebase-tree .namespace-tree .node:hover {
   background: var(--color-sidebar-focus-bg);
   text-decoration: none;
 }
 
-#codebase-tree .namespace-tree .node .icon {
+.codebase-tree .namespace-tree .node .icon {
   font-size: 0.875rem;
   text-align: center;
   margin-right: 0.5rem;
   transition: transform 0.1s ease-out;
 }
 
-#codebase-tree .namespace-tree .node .icon.expanded {
+.codebase-tree .namespace-tree .node .icon.expanded {
   transform: rotate(90deg);
 }
 
-#codebase-tree .namespace-tree .node .icon:is(.caret-right, .caret-down) {
+.codebase-tree .namespace-tree .node .icon:is(.caret-right, .caret-down) {
   color: var(--color-sidebar-subtle-fg);
 }
 
-#codebase-tree .namespace-tree .node:hover .icon:is(.caret-right, .caret-down) {
+.codebase-tree .namespace-tree .node:hover .icon:is(.caret-right, .caret-down) {
   color: var(--color-sidebar-focus-fg);
 }
 
-#codebase-tree .namespace-tree .node label {
+.codebase-tree .namespace-tree .node label {
   color: var(--color-sidebar-fg);
   transition: all 0.2s;
   cursor: pointer;
 }
 
-#codebase-tree .namespace-tree .node .definition-category {
+.codebase-tree .namespace-tree .node .definition-category {
   font-family: var(--font-monospace);
   color: var(--color-sidebar-subtle-fg);
   margin-left: 0.375rem;
   font-size: 0.75rem;
 }
 
-#codebase-tree .namespace-tree .node:hover label {
+.codebase-tree .namespace-tree .node:hover label {
   color: var(--color-sidebar-focus-fg);
 }
 
-#codebase-tree .namespace-tree .node.open label {
+.codebase-tree .namespace-tree .node.open label {
   font-weight: bold;
 }
 
-#codebase-tree .namespace-tree .namespace-content {
+.codebase-tree .namespace-tree .namespace-content {
   margin-left: 1rem;
   transform-origin: left top;
   animation: slide-down 0.2s ease-out;
@@ -1082,8 +1116,37 @@ button.secondary:hover {
   color: var(--color-workspace-item-fg);
 }
 
+.definition-row header .error-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.definition-row header .error-header .icon {
+  margin-right: 0.375rem;
+}
+
+.definition-row header .error-header .icon.caret-down {
+  margin-right: 0.25rem;
+  color: var(--color-workspace-item-subtle-fg);
+}
+
+.definition-row header .error-header .icon.warn {
+  font-size: 1rem;
+  color: var(--color-pink-base);
+}
+
 .definition-row .content .gutter {
   margin-right: 1.5rem;
+}
+
+.definition-row .content .error {
+  padding-left: 1.5rem;
+  font-size: var(--font-size-medium);
+}
+
+.definition-row .content .definition-with-error {
+  font-weight: bold;
 }
 
 .definition-row .content .docs {
@@ -1151,11 +1214,8 @@ button.secondary:hover {
   background: var(--color-workspace-item-focus-mg);
 }
 
-.definition-row.focused header .name {
-  color: var(--color-workspace-item-focus-fg);
-}
-
-.definition-row.focused header .icon {
+.definition-row.focused header .name,
+.definition-row.focused header .error-header {
   color: var(--color-workspace-item-focus-fg);
 }
 
@@ -1211,15 +1271,24 @@ button.secondary:hover {
   background: var(--color-modal-mg);
   display: flex;
   align-items: center;
+  position: relative;
 }
 
 #finder header .icon.search {
-  width: 1.125rem;
-  height: 1.125rem;
   font-size: 1.125rem;
   margin-left: 1rem;
   margin-right: 1rem;
   color: var(--color-modal-subtle-fg);
+  transition: all 1s;
+  transition-delay: 0.3s;
+  will-change: transform;
+}
+
+#finder .is-searching .icon.search {
+  color: var(--color-blue-base);
+  animation: pulse-grow 1s ease-in-out infinite;
+  animation-delay: 0.3s;
+  stroke-width: 1.5;
 }
 
 #finder input {
@@ -1257,10 +1326,39 @@ button.secondary:hover {
 }
 
 #finder .empty-state {
+  position: relative;
   padding: 2rem;
   text-align: center;
   border-top: 1px solid var(--color-modal-inner-border);
   color: var(--color-modal-subtle-fg);
+}
+
+#finder .error {
+  position: relative;
+  padding: 2rem;
+  text-align: center;
+  border-top: 1px solid var(--color-modal-inner-border);
+  color: var(--color-modal-fg);
+}
+
+#finder .error p {
+  margin-bottom: 0.25rem;
+}
+
+#finder .error h3 {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+#finder .error .icon {
+  font-size: 1.3rem;
+  margin-bottom: 0.15rem;
+  margin-right: 0.25rem;
+  color: var(--color-modal-error-fg);
 }
 
 /* results */
@@ -1269,6 +1367,29 @@ button.secondary:hover {
   position: relative;
   padding: 0.75rem;
   border-top: 1px solid var(--color-modal-inner-border);
+}
+
+#finder .results:after,
+#finder .empty-state:after,
+#finder .error:after {
+  content: " ";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--color-modal-bg);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s;
+  transition-delay: 0.3s;
+}
+
+#finder .is-searching .results:after,
+#finder .is-searching .empty-state:after,
+#finder .is-searching .error:after {
+  opacity: 0.65;
+  pointer-events: auto;
 }
 
 #finder .results table {


### PR DESCRIPTION
## Overview

When the Finder takes more than ~250ms it starts to get visible and the
user is left in an awkward state when there's no feedback. Remedy this
by adding a animation on the magnifying glass icon and a transparent
overlay over the previous results (fixes https://github.com/unisonweb/codebase-ui/issues/104). 

https://user-images.githubusercontent.com/2371/118870374-7d417d00-b8b4-11eb-9ac3-190b2b0fe6b0.mp4

Additionally improve rendering of various error messages across the app (fixes https://github.com/unisonweb/codebase-ui/issues/99)

<img width="778" alt="Screen Shot 2021-05-19 at 15 07 12" src="https://user-images.githubusercontent.com/2371/118870450-91857a00-b8b4-11eb-8342-0544e892d6a0.png">
<img width="838" alt="Screen Shot 2021-05-19 at 15 05 29" src="https://user-images.githubusercontent.com/2371/118870462-93e7d400-b8b4-11eb-98d9-0bfbbdb622de.png">

## Implementation notes
This improvement also meant using a specialized
data structure for the finder search (named FinderSearch) over
RemoteData such that a search on top of a previously successful search
result could show the old result (albeit dimmed) while loading the next
result.