### PR TITLE
Fix keyboard shortcut flex gap for Safari

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -724,7 +724,17 @@ button.secondary:hover {
 .keyboard-shortcut {
   display: flex;
   flex-direction: row;
-  gap: 0.25rem;
+  /* gap: 0.25rem; */
+}
+.keyboard-shortcut .key {
+  margin-right: 0.25rem;
+}
+.keyboard-shortcut:last-child .key {
+  margin-right: 0;
+}
+
+.keyboard-shortcut .key:last-child {
+  margin-right: 0;
 }
 
 .keyboard-shortcut .key {
@@ -747,7 +757,7 @@ button.secondary:hover {
   height: 1.5rem;
   font-size: 0.625rem;
   line-heigth: 1;
-  margin: 0 0.1rem;
+  margin: 0 0.35rem;
   color: var(--color-keyboard-shortcut-then);
   align-items: center;
 }
@@ -1232,14 +1242,29 @@ button.secondary:hover {
 #help-modal .shortcuts {
   display: flex;
   flex-direction: row;
-  gap: 2.625rem;
+  /* 
+  Alas - Safari does not support gap and we have to use margins 
+  It was added in Safari 14.1 that was since pulled for unrelated reasons
+
+  gap: 2.625rem; 
+  */
 }
 
 #help-modal .shortcuts .shortcut-group {
   width: 20rem;
   display: flex;
   flex-direction: column;
+  /*
+  Alas - Safari does not support gap and we have to use margins 
+  It was added in Safari 14.1 that was since pulled for unrelated reasons
+
   gap: 0.75rem;
+  */
+  margin-right: 2.625rem;
+}
+
+#help-modal .shortcuts .shortcut-group:last-child {
+  margin-right: 0;
 }
 
 #help-modal .shortcuts h3 {
@@ -1252,6 +1277,10 @@ button.secondary:hover {
   display: flex;
   height: 1.5rem;
   align-items: center;
+  margin-bottom: 0.75rem;
+}
+#help-modal .shortcuts .row:last-child {
+  margin-bottom: 0;
 }
 
 #help-modal .shortcuts .instructions {


### PR DESCRIPTION
## Overview
The Keyboard shortcut overlay looks broken in Safari, because the
browser pulled the update that added support for flex gap. To fix this
for the time being, use margin.

<img width="855" alt="Screen Shot 2021-05-20 at 21 20 15" src="https://user-images.githubusercontent.com/2371/119068214-b57ab580-b9b1-11eb-9d7d-0168cced0e8b.png">


After Safari 14.1 has been out for a while we should revert back to use
gap if the user percentage works in our favor.

https://css-tricks.com/safari-14-1-adds-support-for-flexbox-gaps/

Fixes https://github.com/unisonweb/codebase-ui/issues/102