### PR TITLE
Open definitions above instead of below

### DIFF
--- a/src/Workspace/WorkspaceItems.elm
+++ b/src/Workspace/WorkspaceItems.elm
@@ -83,6 +83,48 @@ insertWithFocus items item =
     WorkspaceItems { before = toList items, focus = item, after = [] }
 
 
+{-| Insert before a Hash. If the Hash is not in WorkspaceItems, insert with
+focus. If the element to insert already exists in WorkspaceItems, move it to
+after the provided Hash
+-}
+insertWithFocusBefore :
+    WorkspaceItems
+    -> Reference
+    -> WorkspaceItem
+    -> WorkspaceItems
+insertWithFocusBefore items beforeRef toInsert =
+    case items of
+        Empty ->
+            singleton toInsert
+
+        WorkspaceItems _ ->
+            if member items beforeRef then
+                let
+                    insertBefore item =
+                        if WorkspaceItem.isSameReference item beforeRef then
+                            [ toInsert, item ]
+
+                        else
+                            [ item ]
+
+                    make ( before, afterInclusive ) =
+                        WorkspaceItems
+                            { before = before
+                            , focus = toInsert
+                            , after = List.drop 1 afterInclusive
+                            }
+                in
+                items
+                    |> toList
+                    |> List.concatMap insertBefore
+                    |> ListE.splitWhen (WorkspaceItem.isSameByReference toInsert)
+                    |> Maybe.map make
+                    |> Maybe.withDefault (singleton toInsert)
+
+            else
+                insertWithFocus items toInsert
+
+
 {-| Insert after a Hash. If the Hash is not in WorkspaceItems, insert at the
 end. If the element to insert already exists in WorkspaceItems, move it to
 after the provided Hash

--- a/tests/Workspace/WorkspaceItemsTests.elm
+++ b/tests/Workspace/WorkspaceItemsTests.elm
@@ -57,13 +57,65 @@ insertWithFocusAfter =
             getFocusedRef inserted
     in
     describe "WorkspaceItems.insertWithFocusAfter"
-        [ test "Inserts after the the 'after hash'" <|
+        [ test "Inserts after the 'after ref'" <|
             \_ ->
                 Expect.equal expected (WorkspaceItems.toList inserted)
         , test "When inserted, the new element has focus" <|
             \_ ->
                 Expect.true "Has focus" (Maybe.withDefault False <| Maybe.map (\r -> r == reference toInsert) currentFocusedRef)
-        , test "When the 'after hash' is not present, insert at the end" <|
+        , test "When the 'after ref' is not present, insert at the end" <|
+            \_ ->
+                let
+                    atEnd =
+                        [ Loading (termRefFromStr "#a")
+                        , Loading (termRefFromStr "#b")
+                        , Loading (termRefFromStr "#focus")
+                        , Loading (termRefFromStr "#c")
+                        , Loading (termRefFromStr "#d")
+                        , Loading (reference toInsert)
+                        ]
+
+                    result =
+                        toInsert
+                            |> WorkspaceItems.insertWithFocusAfter workspaceItems notFoundRef
+                            |> WorkspaceItems.toList
+                in
+                Expect.equal atEnd result
+        ]
+
+
+insertWithFocusBefore : Test
+insertWithFocusBefore =
+    let
+        beforeRef =
+            termRefFromStr "#b"
+
+        toInsert =
+            term
+
+        expected =
+            [ Loading (termRefFromStr "#a")
+            , Loading termRef
+            , Loading (termRefFromStr "#b")
+            , Loading (termRefFromStr "#focus")
+            , Loading (termRefFromStr "#c")
+            , Loading (termRefFromStr "#d")
+            ]
+
+        inserted =
+            WorkspaceItems.insertWithFocusBefore workspaceItems beforeRef toInsert
+
+        currentFocusedRef =
+            getFocusedRef inserted
+    in
+    describe "WorkspaceItems.insertWithFocusBefore"
+        [ test "Inserts before the 'before ref'" <|
+            \_ ->
+                Expect.equal expected (WorkspaceItems.toList inserted)
+        , test "When inserted, the new element has focus" <|
+            \_ ->
+                Expect.true "Has focus" (Maybe.withDefault False <| Maybe.map (\r -> r == reference toInsert) currentFocusedRef)
+        , test "When the 'before hash' is not present, insert at the end" <|
             \_ ->
                 let
                     atEnd =


### PR DESCRIPTION
## Overview
When clicking to open a new definition from the source of another
definition, open it above instead of below the definition.

## Interesting/controversial decisions
This is a bit of an exploratory PR to test if above or below is most natural as a default.

**This PR should implement a modifier so we can compare easily, but does not yet do that.**