### PR TITLE
Add loading indicators to codebase tree

### DIFF
--- a/src/UI.elm
+++ b/src/UI.elm
@@ -19,11 +19,6 @@ badge content =
     span [ class "badge" ] [ content ]
 
 
-spinner : Html msg
-spinner =
-    div [ class "spinner" ] []
-
-
 subtle : String -> Html msg
 subtle label =
     span [ class "subtle" ] [ text label ]
@@ -32,6 +27,13 @@ subtle label =
 loadingPlaceholder : Html msg
 loadingPlaceholder =
     div [ class "loading-placeholder" ] []
+
+
+loadingPlaceholderRow : Html msg
+loadingPlaceholderRow =
+    div [ class "loading-placeholder-row" ]
+        [ div [ class "loading-placeholder" ] []
+        ]
 
 
 errorMessage : String -> Html msg

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -498,6 +498,10 @@ code a:active {
   min-width: calc(var(--font-size-base) * 3);
 }
 
+.loading-placeholder-row {
+  margin-bottom: 0.5rem;
+}
+
 #modal-overlay {
   position: fixed;
   top: 0;
@@ -800,6 +804,7 @@ button.secondary:hover {
 
 #main-sidebar .loading-placeholder {
   background: var(--color-sidebar-subtle-fg);
+  opacity: 0.5;
 }
 
 #main-sidebar header {
@@ -872,6 +877,22 @@ button.secondary:hover {
   font-size: 1rem;
   margin-right: 0.25rem;
   color: var(--color-pink-1);
+}
+
+.codebase-tree .loading {
+  padding-left: 0.5rem;
+}
+
+.codebase-tree .loading .loading-placeholder {
+  width: 8rem;
+}
+
+.codebase-tree .namespace-content .loading {
+  padding-left: 0.875rem;
+}
+
+.codebase-tree .namespace-content .loading .loading-placeholder {
+  width: 6rem;
 }
 
 .codebase-tree .namespace-tree .node:hover {


### PR DESCRIPTION
## Overview
Add loading placeholder indicators to the codebase tree both for the
first request and when expanding the tree.

https://user-images.githubusercontent.com/2371/119158457-396d8580-ba24-11eb-9115-2922892ab589.mp4

Fixes https://github.com/unisonweb/codebase-ui/issues/116