### PR TITLE
Fix bug where types were referenced as terms

### DIFF
--- a/src/Definition/Source.elm
+++ b/src/Definition/Source.elm
@@ -7,9 +7,9 @@ module Definition.Source exposing
     , viewTypeSource
     )
 
+import Definition.Reference exposing (Reference)
 import Definition.Term as Term exposing (TermSignature(..), TermSource)
 import Definition.Type as Type exposing (TypeSource)
-import Hash exposing (Hash)
 import Html exposing (Html, span, text)
 import Html.Attributes exposing (class)
 import Syntax
@@ -17,7 +17,7 @@ import UI
 
 
 type ViewConfig msg
-    = Rich (Hash -> msg)
+    = Rich (Reference -> msg)
     | Monochrome
     | Plain
 

--- a/src/Syntax.elm
+++ b/src/Syntax.elm
@@ -9,7 +9,9 @@ module Syntax exposing
     , view
     )
 
+import Definition.Reference as Reference exposing (Reference)
 import Hash exposing (Hash)
+import HashQualified as HQ
 import Html exposing (Html, a, span, text)
 import Html.Attributes exposing (class)
 import Html.Events exposing (onClick)
@@ -86,7 +88,7 @@ type SyntaxType
 
 
 type Linked msg
-    = Linked (Hash -> msg)
+    = Linked (Reference -> msg)
     | NotLinked
 
 
@@ -221,13 +223,13 @@ syntaxTypeToClassName sType =
 viewSegment : Linked msg -> SyntaxSegment -> Html msg
 viewSegment linked (SyntaxSegment sType sText) =
     let
-        hash =
+        ref =
             case sType of
                 TypeReference h ->
-                    Just h
+                    Just (Reference.TypeReference (HQ.HashOnly h))
 
                 TermReference h ->
-                    Just h
+                    Just (Reference.TermReference (HQ.HashOnly h))
 
                 _ ->
                     Nothing
@@ -235,9 +237,9 @@ viewSegment linked (SyntaxSegment sType sText) =
         className =
             syntaxTypeToClassName sType
     in
-    case ( linked, hash ) of
-        ( Linked toReferenceClickMsg, Just h ) ->
-            a [ class className, onClick (toReferenceClickMsg h) ] [ text sText ]
+    case ( linked, ref ) of
+        ( Linked toReferenceClickMsg, Just r ) ->
+            a [ class className, onClick (toReferenceClickMsg r) ] [ text sText ]
 
         _ ->
             span [ class className ] [ text sText ]

--- a/src/Workspace/WorkspaceItem.elm
+++ b/src/Workspace/WorkspaceItem.elm
@@ -196,29 +196,24 @@ viewSource toOpenReferenceMsg item =
                 ]
     in
     case item of
-        -- TODO, this reference config created like so: (Source.Rich (HashOnly
-        -- >> TermReference >> toOpenReferenceMsg) is wrong. It creates a
-        -- TermReference for all things referenced from the source. The
-        -- Reference variant should be determined by the SyntaxSegment variant
-        -- and if the hash has a constructor suffix.
         TermItem (Term _ _ detail) ->
             ( detail.source, detail.source )
-                |> Tuple.mapBoth Source.numTermLines (Source.viewTermSource (Source.Rich (HashOnly >> TermReference >> toOpenReferenceMsg)) detail.info.name)
+                |> Tuple.mapBoth Source.numTermLines (Source.viewTermSource (Source.Rich toOpenReferenceMsg) detail.info.name)
                 |> Tuple.mapBoth viewLineGutter (viewToggableSource Icon.CaretRight False)
 
         TypeItem (Type _ _ detail) ->
             ( detail.source, detail.source )
-                |> Tuple.mapBoth Source.numTypeLines (Source.viewTypeSource (Source.Rich (HashOnly >> TypeReference >> toOpenReferenceMsg)))
+                |> Tuple.mapBoth Source.numTypeLines (Source.viewTypeSource (Source.Rich toOpenReferenceMsg))
                 |> Tuple.mapBoth viewLineGutter (viewToggableSource Icon.CaretRight True)
 
         DataConstructorItem (DataConstructor _ detail) ->
             ( detail.source, detail.source )
-                |> Tuple.mapBoth Source.numTypeLines (Source.viewTypeSource (Source.Rich (HashOnly >> DataConstructorReference >> toOpenReferenceMsg)))
+                |> Tuple.mapBoth Source.numTypeLines (Source.viewTypeSource (Source.Rich toOpenReferenceMsg))
                 |> Tuple.mapBoth viewLineGutter (viewToggableSource Icon.CaretRight True)
 
         AbilityConstructorItem (AbilityConstructor _ detail) ->
             ( detail.source, detail.source )
-                |> Tuple.mapBoth Source.numTypeLines (Source.viewTypeSource (Source.Rich (HashOnly >> AbilityConstructorReference >> toOpenReferenceMsg)))
+                |> Tuple.mapBoth Source.numTypeLines (Source.viewTypeSource (Source.Rich toOpenReferenceMsg))
                 |> Tuple.mapBoth viewLineGutter (viewToggableSource Icon.CaretRight True)
 
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1199,7 +1199,8 @@ button.secondary:hover {
 
 .definition-row .content .built-in {
   margin-bottom: 1.5rem;
-  margin-left: 1.25rem;
+  /* TODO: Renable with source toggle */
+  /*margin-left: 1.25rem;*/
 }
 
 .definition-row .content .source {


### PR DESCRIPTION
## Overview
Types referenced from a Term would get a TermReference and thus a Term
url. This would mean that multiple instances of the same definition
could be open.

Fixes: https://github.com/unisonweb/codebase-ui/issues/117