### PR TITLE
Update codebase tree to be sorted by name

### DIFF
--- a/src/CodebaseTree.elm
+++ b/src/CodebaseTree.elm
@@ -5,6 +5,7 @@ import CodebaseTree.NamespaceListing as NamespaceListing
     exposing
         ( DefinitionListing(..)
         , NamespaceListing(..)
+        , NamespaceListingChild(..)
         , NamespaceListingContent
         )
 import Definition.Category as Category
@@ -14,7 +15,7 @@ import FullyQualifiedName as FQN exposing (FQN, unqualifiedName)
 import FullyQualifiedNameSet as FQNSet exposing (FQNSet)
 import HashQualified exposing (HashQualified(..))
 import Html exposing (Html, a, div, h2, label, span, text)
-import Html.Attributes exposing (class, classList, title)
+import Html.Attributes exposing (class, title)
 import Html.Events exposing (onClick)
 import Http
 import RemoteData exposing (RemoteData(..), WebData)
@@ -202,13 +203,15 @@ viewDefinitionListing listing =
 viewLoadedNamespaceListingContent : FQNSet -> NamespaceListingContent -> Html Msg
 viewLoadedNamespaceListingContent expandedNamespaceListings content =
     let
-        namespaces =
-            List.map (viewNamespaceListing expandedNamespaceListings) content.namespaces
+        viewChild c =
+            case c of
+                SubNamespace nl ->
+                    viewNamespaceListing expandedNamespaceListings nl
 
-        definitions =
-            List.map viewDefinitionListing content.definitions
+                SubDefinition dl ->
+                    viewDefinitionListing dl
     in
-    div [] (namespaces ++ definitions)
+    div [] (List.map viewChild content)
 
 
 viewNamespaceListingContent : FQNSet -> WebData NamespaceListingContent -> Html Msg

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -27,7 +27,7 @@ table {
 
 :root {
   --size-base: 16px;
-  --main-sidebar-width: 16rem;
+  --main-sidebar-width: 18rem;
   --border-radius-base: 0.25rem;
 
   /* -- Layers ------------------------------------------------------------- */

--- a/tests/CodebaseTree/NamespaceListingTests.elm
+++ b/tests/CodebaseTree/NamespaceListingTests.elm
@@ -1,0 +1,84 @@
+module CodebaseTree.NamespaceListingTests exposing (..)
+
+import CodebaseTree.NamespaceListing as NamespaceListing exposing (NamespaceListing(..), NamespaceListingChild(..))
+import Expect
+import FullyQualifiedName as FQN
+import Hash
+import RemoteData exposing (RemoteData(..))
+import Test exposing (..)
+
+
+map : Test
+map =
+    describe "CodebaseTree.NamespaceListing.map"
+        [ test "runs the function on deeply nestes namespaces" <|
+            \_ ->
+                let
+                    hashA =
+                        Hash.fromString "#a"
+
+                    hashB =
+                        Hash.fromString "#c"
+
+                    hashC =
+                        Hash.fromString "#b"
+
+                    fqnA =
+                        FQN.fromString "a"
+
+                    fqnB =
+                        FQN.fromString "a.b"
+
+                    fqnC =
+                        FQN.fromString "a.b.c"
+
+                    original =
+                        Maybe.map3
+                            (\ha hb hc ->
+                                NamespaceListing ha
+                                    fqnA
+                                    (Success
+                                        [ SubNamespace
+                                            (NamespaceListing
+                                                hb
+                                                fqnB
+                                                (Success [ SubNamespace (NamespaceListing hc fqnC NotAsked) ])
+                                            )
+                                        ]
+                                    )
+                            )
+                            hashA
+                            hashB
+                            hashC
+
+                    expected =
+                        Maybe.map3
+                            (\ha hb hc ->
+                                NamespaceListing ha
+                                    fqnA
+                                    (Success
+                                        [ SubNamespace
+                                            (NamespaceListing
+                                                hb
+                                                fqnB
+                                                (Success [ SubNamespace (NamespaceListing hc fqnC Loading) ])
+                                            )
+                                        ]
+                                    )
+                            )
+                            hashA
+                            hashB
+                            hashC
+
+                    f ((NamespaceListing h fqn _) as nl) =
+                        if FQN.equals fqn fqnC then
+                            NamespaceListing h fqn Loading
+
+                        else
+                            nl
+
+                    result =
+                        Maybe.map (NamespaceListing.map f) original
+                in
+                Expect.equal expected result
+        ]


### PR DESCRIPTION
## Overview
Sort such that Either the type is next to Either the namespace.

<img width="942" alt="Screen Shot 2021-05-25 at 14 42 37" src="https://user-images.githubusercontent.com/2371/119556255-c4c08100-bd6c-11eb-9cf7-27ea0a06565a.png">

Fixes https://github.com/unisonweb/codebase-ui/issues/101