### PR TITLE
Debounce Finder query for Unison Share

### DIFF
--- a/src/Util.elm
+++ b/src/Util.elm
@@ -2,10 +2,17 @@ module Util exposing (..)
 
 import Json.Decode as Decode
 import List.Nonempty as NEL
+import Process
+import Task
 
 
 
 -- Various utility functions and helpers
+
+
+delayMsg : Float -> msg -> Cmd msg
+delayMsg delay msg =
+    Task.perform (\_ -> msg) (Process.sleep delay)
 
 
 decodeNonEmptyList : Decode.Decoder a -> Decode.Decoder (NEL.Nonempty a)


### PR DESCRIPTION
## Overview
Add a debounce in the Finder when searching for definitions from Unison
Share such that the server isn't hit hard with requests on each
keystroke that are since thrown away by the UI since they are not
current with the search input. Set the debounce to 300ms.

Don't debounce for Ucm.

## Implementation notes
This essentially means to wait 300ms without new input before sending off the request.

It's very common to add a debounce for 500ms+, but this felt like it was a bit much (https://lawsofux.com/doherty-threshold). We can always tweak this for later, but 300ms felt like decent for my admittedly slow typing.