### PR TITLE
Add Publish on Unison Share cta and instructions

### DIFF
--- a/src/Finder.elm
+++ b/src/Finder.elm
@@ -144,14 +144,20 @@ update env msg model =
             let
                 isSequenceShortcutInput =
                     String.contains ";" input
+
+                isShowFinderShortcut =
+                    input == "/"
+
+                isValidInput =
+                    not isSequenceShortcutInput && not isShowFinderShortcut
             in
             if String.isEmpty input then
                 ( { model | input = input, search = NotAsked }, Cmd.none, Remain )
 
-            else if String.length input > 1 && not isSequenceShortcutInput then
+            else if String.length input > 1 && isValidInput then
                 ( { model | input = input }, Util.delayMsg debounceDelay (PerformSearch input), Remain )
 
-            else if not isSequenceShortcutInput then
+            else if isValidInput then
                 ( { model | input = input }, Cmd.none, Remain )
 
             else

--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -1,4 +1,4 @@
-module UI.Button exposing (ButtonType(..), primary, secondary, view)
+module UI.Button exposing (ButtonType(..), callToAction, primary, secondary, view)
 
 import Html exposing (Html, button, text)
 import Html.Attributes exposing (class)
@@ -6,8 +6,14 @@ import Html.Events exposing (onClick)
 
 
 type ButtonType
-    = Primary
+    = CallToAction
+    | Primary
     | Secondary
+
+
+callToAction : msg -> String -> Html msg
+callToAction =
+    view CallToAction
 
 
 primary : msg -> String -> Html msg
@@ -34,6 +40,9 @@ view type_ clickMsg label =
 buttonTypeToClassName : ButtonType -> String
 buttonTypeToClassName type_ =
     case type_ of
+        CallToAction ->
+            "call-to-action"
+
         Primary ->
             "primary"
 

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -57,6 +57,7 @@ init env mRef =
 type Msg
     = NoOp
     | Find
+    | Publish
     | OpenDefinitionRelativeTo Reference Reference
     | CloseDefinition Reference
     | UpdateZoom Reference Zoom
@@ -70,6 +71,7 @@ type OutMsg
     | Focused Reference
     | Emptied
     | ShowFinderRequest
+    | ShowPublishRequest
 
 
 update : Env -> Msg -> Model -> ( Model, Cmd Msg, OutMsg )
@@ -80,6 +82,9 @@ update env msg ({ workspaceItems } as model) =
 
         Find ->
             ( model, Cmd.none, ShowFinderRequest )
+
+        Publish ->
+            ( model, Cmd.none, ShowPublishRequest )
 
         OpenDefinitionRelativeTo relativeToRef ref ->
             openItem env.apiBasePath model (Just relativeToRef) ref
@@ -378,7 +383,9 @@ view model =
     article [ id "workspace" ]
         [ header
             [ id "workspace-toolbar" ]
-            [ Button.secondary Find "Find" ]
+            [ Button.secondary Find "Find"
+            , section [ class "right" ] [ Button.callToAction Publish "Publish on Unison Share" ]
+            ]
         , section
             [ id "workspace-content" ]
             [ section [ class "definitions-pane" ] (viewWorkspaceItems model.workspaceItems) ]

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -181,6 +181,11 @@ table {
   --color-icon-patch: var(--color-blue-2);
 
   /* Buttons */
+  --color-button-call-to-action-fg: var(--color-purple-1);
+  --color-button-call-to-action-bg: var(--color-purple-4);
+  --color-button-call-to-action-hover-fg: var(--color-gray-lighten-100);
+  --color-button-call-to-action-hover-bg: var(--color-purple-1);
+
   --color-button-primary-fg: var(--color-gray-lighten-60);
   --color-button-primary-bg: var(--color-gray-darken-20);
   --color-button-primary-hover-fg: var(--color-gray-lighten-60);
@@ -637,6 +642,16 @@ button:active {
   transform: translate(0, 0.1rem);
 }
 
+button.call-to-action {
+  color: var(--color-button-call-to-action-fg);
+  background: var(--color-button-call-to-action-bg);
+}
+
+button.call-to-action:hover {
+  color: var(--color-button-call-to-action-hover-fg);
+  background: var(--color-button-call-to-action-hover-bg);
+}
+
 button.primary {
   color: var(--color-button-primary-fg);
   background: var(--color-button-primary-bg);
@@ -1078,6 +1093,13 @@ button.secondary:hover {
   font-size: var(--font-size-medium);
   background: var(--color-workspace-item-bg);
   border-bottom: 1px solid var(--color-workspace-border);
+  display: flex;
+  flex-direction: row;
+}
+
+#workspace-toolbar .right {
+  align-self: flex-end;
+  margin-left: auto;
 }
 
 #workspace-content {
@@ -1436,6 +1458,39 @@ button.secondary:hover {
 
 #help-modal .subtle {
   color: var(--color-modal-subtle-fg);
+}
+
+/* -- PublishModal --------------------------------------------------------- */
+
+#publish-modal {
+  width: 32.5rem;
+}
+
+#publish-modal .main {
+  font-size: var(--font-size-base);
+  line-height: 1.5em;
+}
+
+#publish-modal .main a {
+  color: var(--color-blue-2);
+  font-weight: bold;
+}
+
+#publish-modal .main a:hover {
+  color: var(--color-blue-1);
+  text-decoration: none;
+}
+
+#publish-modal .help {
+  display: inline-block;
+  margin-top: 1.5rem;
+  font-size: var(--font-size-small);
+  color: var(--color-modal-subtle-fg-em);
+  text-decoration: underline;
+}
+
+#publish-modal .help:hover {
+  color: var(--color-modal-fg);
 }
 
 /* -- Finder --------------------------------------------------------------- */


### PR DESCRIPTION
## Overview
Add a button, "Publish on Unison Share" in the top right of the
workspace toolbar that, when clicked, shows publishing instructions in a
modal.


https://user-images.githubusercontent.com/2371/120832405-a148c380-c52e-11eb-9df2-acb8c9902aff.mp4


Also adds a Unison Share link in the lower left nav when in Unison Local.

## Interesting/controversial decisions
The button is also in place on Unison Local—it seems like a good thing to re-enforce Unison Share there. Thoughts?'