### PR TITLE
Finder: arrowkeys, clickable areas, and sequences

### DIFF
--- a/src/Finder.elm
+++ b/src/Finder.elm
@@ -513,10 +513,16 @@ view model =
                     , results
                     ]
                 )
+
+        keyboardEvent =
+            KeyboardEvent.on KeyboardEvent.Keydown Keydown
+                |> KeyboardEvent.stopPropagation
+                |> KeyboardEvent.preventDefaultWhen (\evt -> evt.key == ArrowUp || evt.key == ArrowDown)
+                |> KeyboardEvent.attach
     in
     Modal.modal "finder" Close content
         -- We stopPropagation such that movement shortcuts, like J or K, for the
         -- workspace aren't triggered when in the modal when the use is trying to
         -- type those letters into the search field
-        |> Modal.withAttributes [ KeyboardEvent.stopPropagationOn KeyboardEvent.Keydown Keydown ]
+        |> Modal.withAttributes [ keyboardEvent ]
         |> Modal.view

--- a/src/KeyboardShortcut.elm
+++ b/src/KeyboardShortcut.elm
@@ -115,7 +115,7 @@ collect model key =
 
 decay : Key -> Cmd Msg
 decay key =
-    Process.sleep 2000 |> Task.perform (always (Decay key))
+    Process.sleep 3000 |> Task.perform (always (Decay key))
 
 
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1731,6 +1731,7 @@ button.danger:hover {
   text-overflow: ellipsis;
   max-width: 14rem;
   overflow: hidden;
+  cursor: pointer;
 }
 
 #finder .definition-match .namespace {
@@ -1739,6 +1740,7 @@ button.danger:hover {
   text-overflow: ellipsis;
   max-width: 14rem;
   overflow: hidden;
+  cursor: pointer;
 }
 
 #finder .definition-match .namespace .in {


### PR DESCRIPTION
## Overview
* Fix an issue where arrow keys used for moving up and down the Finder
  results would move the cursor in the input (implemented this with a
  more compositional keyboard event API)
* Ensure the names in the results of the Finder have the clickable
  cursor
* Update the keyboard sequence delay to 3 seconds to make it more
  ergonomic to perform sequence shortcuts

Fixes https://github.com/unisonweb/codebase-ui/issues/142, https://github.com/unisonweb/codebase-ui/issues/135, https://github.com/unisonweb/codebase-ui/issues/139