### PR TITLE
Add preventDefault for global Finder shortcuts

### DIFF
--- a/src/CodebaseTree.elm
+++ b/src/CodebaseTree.elm
@@ -86,7 +86,6 @@ update env msg model =
                         |> RemoteData.withDefault False
 
                 newModel =
-                    -- TODO: Update to Loading
                     { model
                         | expandedNamespaceListings = FQNSet.toggle fqn model.expandedNamespaceListings
                         , rootNamespaceListing = nextNamespaceListing

--- a/src/preventDefaultGlobalKeyboardEvents.js
+++ b/src/preventDefaultGlobalKeyboardEvents.js
@@ -1,0 +1,25 @@
+/*
+ * Firefox has binds for Ctrl+k, Cmd+k, and "/" We want to use those to open
+ * the Finder.
+ *
+ * Unfortunately we can't do this in Elm, since Browser.Events doesn't support
+ * preventDefault, so we're duplicating the shortcuts and calling
+ * preventDefault in JS. The Elm handler picks up the event later on.
+ *
+ * TODO: This is a bit brittle and relies on the Elm handler being added after
+ * this one. There might be a better solution build with ports for this.
+ */
+
+function preventDefaultGlobalKeyboardEvents() {
+  window.addEventListener("keydown", (ev) => {
+    if (
+      ev.key === "/" ||
+      (ev.metaKey && ev.key == "k") ||
+      (ev.ctrlKey && ev.key == "k")
+    ) {
+      ev.preventDefault();
+    }
+  });
+}
+
+export default preventDefaultGlobalKeyboardEvents;

--- a/src/ucm.js
+++ b/src/ucm.js
@@ -1,5 +1,6 @@
 import "./init";
 import detectOs from "./detectOs";
+import preventDefaultGlobalKeyboardEvents from "./preventDefaultGlobalKeyboardEvents";
 import { Elm } from "./Ucm.elm";
 
 const basePath = new URL(document.baseURI).pathname;
@@ -21,6 +22,8 @@ const flags = {
   apiBasePath,
   appContext: "Ucm",
 };
+
+preventDefaultGlobalKeyboardEvents();
 
 // The main entry point for the `ucm` target of the Codebase UI.
 Elm.Ucm.init({ flags });

--- a/src/unisonShare.js
+++ b/src/unisonShare.js
@@ -1,5 +1,6 @@
 import "./init";
 import detectOs from "./detectOs";
+import preventDefaultGlobalKeyboardEvents from "./preventDefaultGlobalKeyboardEvents";
 import { Elm } from "./UnisonShare.elm";
 
 const basePath = new URL(document.baseURI).pathname;
@@ -11,6 +12,8 @@ const flags = {
   apiBasePath,
   appContext: "UnisonShare",
 };
+
+preventDefaultGlobalKeyboardEvents();
 
 // The main entry point for the `UnisonShare` target of the Codebase UI.
 Elm.UnisonShare.init({ flags });


### PR DESCRIPTION
## Overview
Firefox has some clashes with the keyboard shortcuts of the Finder that
can't be prevented from within Elm (https://github.com/elm/browser/issues/89); add a simple— slightly hackish—
event handler on the JavaScript side to preventDefault on the specific
Finder keyboard events.

Fixes: https://github.com/unisonweb/codebase-ui/issues/136