### PR TITLE
Add folding support to Docs

### DIFF
--- a/src/Id.elm
+++ b/src/Id.elm
@@ -1,0 +1,32 @@
+module Id exposing (Id, equals, fromString, toString)
+
+{--
+
+`Id` is a simple type for getting more type safe ids and to avoid working with
+strings directly.  It also carries a type (phantom type), such that we can
+distinguish between `Id User` and `Id Doc` and not mix them by accident.
+
+Phantom types: 
+  https://wiki.haskell.org/Phantom_type
+  https://thoughtbot.com/blog/modeling-currency-in-elm-using-phantom-types
+
+--}
+
+
+type Id a
+    = Id String
+
+
+fromString : String -> Id a
+fromString rawId =
+    Id rawId
+
+
+toString : Id a -> String
+toString (Id s) =
+    s
+
+
+equals : Id a -> Id a -> Bool
+equals (Id s1) (Id s2) =
+    s1 == s2

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -172,8 +172,6 @@
 
 .codebase-tree .namespace-tree .namespace-content {
   margin-left: 1rem;
-  transform-origin: left top;
-  animation: slide-down 0.2s ease-out;
 }
 
 /* -- Main Sidebar Nav ----------------------------------------------------- */

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -136,16 +136,36 @@
   flex-direction: row;
 }
 
-.doc .folded .icon {
+.doc .folded a {
   margin-right: 0.25rem;
+  width: 1.2rem;
+  height: 1.2rem;
+  line-height: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--border-radius-base);
+  transition: all 0.2s;
+}
+.doc .folded a .icon {
   color: var(--color-workspace-item-subtle-fg);
-  font-size: 1rem;
-  padding-top: 1px;
-  cursor: pointer;
 }
 
-.doc .folded .icon:hover {
+.doc .folded a:hover {
+  background: var(--color-workspace-item-subtle-bg);
+}
+.doc .folded a:hover .icon {
   color: var(--color-workspace-item-subtle-fg-em);
+}
+
+.doc .folded .icon {
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.1s ease-out;
+}
+
+.doc .folded.is-folded .icon {
+  transform: rotate(-90deg);
 }
 
 .doc p {

--- a/src/css/themes/unison/light.css
+++ b/src/css/themes/unison/light.css
@@ -48,13 +48,14 @@
   --color-workspace-item-link-hover: var(--color-blue-2);
   --color-workspace-item-subtle-fg: var(--color-gray-lighten-40);
   --color-workspace-item-subtle-fg-em: var(--color-gray-lighten-20);
-  --color-workspace-item-subtle-bg: var(--color-main-subtle-bg);
+  --color-workspace-item-subtle-bg: var(--color-gray-lighten-60);
   --color-workspace-item-em-bg: var(--color-gray-lighten-55);
   --color-workspace-item-content-border: var(--color-gray-lighten-55);
   --color-workspace-item-border: transparent;
 
   --color-workspace-item-focus-fg: var(--color-gray-darken-30);
   --color-workspace-item-focus-subtle-fg: var(--color-gray-lighten-30);
+  --color-workspace-item-focus-subtle-bg: var(--color-gray-lighten-50);
   --color-workspace-item-focus-mg: var(--color-gray-lighten-55);
   --color-workspace-item-focus-source-bg: transparent;
   --color-workspace-item-focus-doc-source-bg: var(--color-gray-lighten-55);

--- a/src/css/workspace.css
+++ b/src/css/workspace.css
@@ -299,6 +299,7 @@
   --color-workspace-item-fg: var(--color-workspace-item-focus-fg);
   --color-workspace-item-bg: var(--color-workspace-item-focus-bg);
   --color-workspace-item-subtle-fg: var(--color-workspace-item-focus-subtle-fg);
+  --color-workspace-item-subtle-bg: var(--color-workspace-item-focus-subtle-bg);
   --color-workspace-item-content-border: var(
     --color-workspace-item-focus-content-border
   );

--- a/tests/Definition/DocTests.elm
+++ b/tests/Definition/DocTests.elm
@@ -1,0 +1,58 @@
+module Definition.DocTests exposing (..)
+
+import Definition.Doc as Doc exposing (Doc)
+import Expect
+import Id exposing (Id)
+import Test exposing (..)
+
+
+isDocFoldToggled : Test
+isDocFoldToggled =
+    describe "Doc.isDocFoldToggled"
+        [ test "returns True if the doc is toggled" <|
+            \_ ->
+                let
+                    toggles =
+                        Doc.toggleFold Doc.emptyDocFoldToggles id
+                in
+                Expect.true "doc is toggled" (Doc.isDocFoldToggled toggles id)
+        , test "returns False if the doc is not toggled" <|
+            \_ ->
+                let
+                    toggles =
+                        Doc.emptyDocFoldToggles
+                in
+                Expect.false "doc is not toggled" (Doc.isDocFoldToggled toggles id)
+        ]
+
+
+toggleFold : Test
+toggleFold =
+    describe "Doc.toggleFold"
+        [ test "Adds a toggle if not present" <|
+            \_ ->
+                let
+                    toggles =
+                        Doc.toggleFold Doc.emptyDocFoldToggles id
+                in
+                Expect.true "doc was added" (Doc.isDocFoldToggled toggles id)
+        , test "Removes a toggle if present" <|
+            \_ ->
+                let
+                    toggles =
+                        Doc.toggleFold Doc.emptyDocFoldToggles id
+
+                    without =
+                        Doc.toggleFold toggles id
+                in
+                Expect.false "doc was removed" (Doc.isDocFoldToggled without id)
+        ]
+
+
+
+-- Helpers
+
+
+id : Id Doc
+id =
+    Id.fromString "abcdef"

--- a/tests/IdTests.elm
+++ b/tests/IdTests.elm
@@ -1,0 +1,36 @@
+module IdTests exposing (..)
+
+import Expect
+import Id
+import Test exposing (..)
+
+
+equals : Test
+equals =
+    describe "Id.equals"
+        [ test "Returns True when equal" <|
+            \_ ->
+                Expect.true
+                    "Expected Id \"abc\" and Id \"abc\" to be equal"
+                    (Id.equals (Id.fromString "abc") (Id.fromString "abc"))
+        , test "Returns False when not equal" <|
+            \_ ->
+                Expect.false
+                    "Expected Id \"abc\" and Id \"def\" to *not* be equal"
+                    (Id.equals (Id.fromString "abc") (Id.fromString "def"))
+        ]
+
+
+fromAndToString : Test
+fromAndToString =
+    describe "Id fromString and toString"
+        [ test "Extracts the raw id value" <|
+            \_ ->
+                let
+                    result =
+                        "abc"
+                            |> Id.fromString
+                            |> Id.toString
+                in
+                Expect.equal "abc" result
+        ]


### PR DESCRIPTION
## Overview
Support folding for `Doc` elements `Folded` and `FoldedSource`.

Part of the work for https://github.com/unisonweb/codebase-ui/issues/77

https://user-images.githubusercontent.com/2371/123471575-fcb52100-d5c3-11eb-9eb8-4c8fe750241a.mp4

## Implementation notes
Track folding state for the `Doc` elements `Folded` and `FoldedSource`
through a `DocFoldedToggles` type that wraps a `Set` of a new `Id` type
(a simple `Id` type with a phantom type for type safe ids). Use this new
new folding state on `WorkspaceItem`, which has gotten most of its
fields merged in to a record to make it easier to add more in the future
and to have them be named.

Add a `Id Doc` field to `Folded` and `FoldedSource` (intended to be
generated on parse time) for identifying which node in the doc tree has
its fold toggled.

Toggling works by being either present or not. When present, it is the
opposite of the original fold state that was provided by the
server—meaning the state that was in the original doc the author wrote.

Add a few stylistic improvements to folding both in docs and in the main
sidebar such that the expand doesn't animate, but the caret does and the
caret in the doc fold has been given more space such that it is an
easier click target.
