### PR TITLE
Syntax: Fix padding/margin around term and types

### DIFF
--- a/src/css/syntax.css
+++ b/src/css/syntax.css
@@ -10,7 +10,7 @@ code {
 
 code a {
   display: inline-block;
-  padding: 0 0.375rem;
+  padding: 0 0.25rem;
   margin: 0 -0.25rem;
   border-radius: var(--border-radius-base);
   line-height: 1.4;


### PR DESCRIPTION
## Overview
The padding and negative margin on references to terms and types in the
definition source rendering (added to allow for better click targets)
should be balanced and equal to avoid code being misaligned when
compared to rendering in `ucm`.

fixes: https://github.com/unisonweb/codebase-ui/issues/162