### PR TITLE
Use design system colors for syntax highlighting

### DIFF
--- a/src/Syntax.elm
+++ b/src/Syntax.elm
@@ -10,6 +10,7 @@ module Syntax exposing
     )
 
 import Definition.Reference as Reference exposing (Reference)
+import FullyQualifiedName as FQN exposing (FQN)
 import Hash exposing (Hash)
 import HashQualified as HQ
 import Html exposing (Html, a, span, text)
@@ -220,6 +221,16 @@ syntaxTypeToClassName sType =
             "doc-keyword"
 
 
+viewFQN : FQN -> Html msg
+viewFQN fqn =
+    fqn
+        |> FQN.segments
+        |> NEL.map (\s -> span [ class "segment" ] [ text s ])
+        |> NEL.toList
+        |> List.intersperse (span [ class "sep" ] [ text "." ])
+        |> span [ class "fqn" ]
+
+
 viewSegment : Linked msg -> SyntaxSegment -> Html msg
 viewSegment linked (SyntaxSegment sType sText) =
     let
@@ -236,13 +247,23 @@ viewSegment linked (SyntaxSegment sType sText) =
 
         className =
             syntaxTypeToClassName sType
+
+        content =
+            if String.contains "->" sText then
+                span [ class "arrow" ] [ text sText ]
+
+            else if String.contains "." sText then
+                viewFQN (FQN.fromString sText)
+
+            else
+                text sText
     in
     case ( linked, ref ) of
         ( Linked toReferenceClickMsg, Just r ) ->
-            a [ class className, onClick (toReferenceClickMsg r) ] [ text sText ]
+            a [ class className, onClick (toReferenceClickMsg r) ] [ content ]
 
         _ ->
-            span [ class className ] [ text sText ]
+            span [ class className ] [ content ]
 
 
 view : Linked msg -> Syntax -> Html msg

--- a/src/css/syntax.css
+++ b/src/css/syntax.css
@@ -26,6 +26,9 @@ code a:active {
   transform: translate(0, 0.1rem);
 }
 
+.rich .fqn .sep {
+  color: var(--color-syntax-subtle-em);
+}
 .rich .text-literal,
 .rich .bytes-literal,
 .rich .char-literal {
@@ -34,34 +37,63 @@ code a:active {
 
 .rich .boolean-literal,
 .rich .constructor {
-  color: var(--color-syntax-variant);
+  color: var(--color-syntax-constructor);
 }
 
-.rich .blank,
+.rich .constructor .segment {
+  color: var(--color-syntax-constructor-namespace);
+}
+
+.rich .constructor .segment:last-child {
+  color: var(--color-syntax-constructor);
+}
+
 .rich .var,
 .rich .data-type-params {
   color: var(--color-syntax-base);
 }
 
-.rich .numberic-literal,
-.rich .term-reference,
+.rich .numeric-literal,
 .rich .type-reference,
-.rich .data-type-modifier,
-.rich .hash-qualifier,
-.rich .request {
-  color: var(--color-syntax-name);
+.rich .data-type-modifier {
+  color: var(--color-syntax-type);
+}
+
+.rich .type-reference .fqn .segment {
+  color: var(--color-syntax-type-namespace);
+}
+
+.rich .type-reference .fqn .segment:last-child {
+  color: var(--color-syntax-type);
+}
+
+.rich .term-reference,
+.rich .request,
+.rich .hash-qualifier {
+  color: var(--color-syntax-term);
+}
+
+.rich .term-reference .fqn .segment,
+.rich .hash-qualifier .fqn .segment {
+  color: var(--color-syntax-term-namespace);
+}
+
+.rich .term-reference .fqn .segment:last-child,
+.rich .hash-qualifier .fqn .segment:last-child {
+  color: var(--color-syntax-term);
 }
 
 .rich .op.cons,
 .rich .op.snoc,
 .rich .op.concat,
 .rich .type-operator,
+.rich .binding-equals,
 .rich .type-ascription-colon {
   color: var(--color-syntax-operator);
 }
 
 .rich .delay-force-char {
-  color: var(--color-syntax-operator);
+  color: var(--color-syntax-ability);
   font-weight: bold;
 }
 
@@ -72,15 +104,19 @@ code a:active {
   color: var(--color-syntax-keyword);
 }
 
+.rich .delimeter-char {
+  color: var(--color-syntax-subtle-em);
+}
+
 .rich .comment,
 .rich .ability-braces,
-.rich .binding-equals,
 .rich .unit,
 .rich .use-keyword,
 .rich .use-prefix,
 .rich .use-suffix,
-.rich .delimeter-char,
+.rich .blank,
 .rich .parenthesis,
+.rich .arrow,
 .rich .doc-delimeter {
   color: var(--color-syntax-subtle);
 }

--- a/src/css/themes/unison/light.css
+++ b/src/css/themes/unison/light.css
@@ -129,13 +129,18 @@
 
   /* Syntax */
   --color-syntax-base: var(--color-main-fg);
-  --color-syntax-subtle: var(--color-main-subtle-fg);
-  --color-syntax-keyword: #225ebe;
-  --color-syntax-operator: #c7474e;
-  --color-syntax-name: #6848ba;
-  --color-syntax-type: #225ebe;
-  --color-syntax-variant: #438443;
-  --color-syntax-text: #438443;
+  --color-syntax-subtle: var(--color-gray-lighten-20);
+  --color-syntax-subtle-em: var(--color-gray-base);
+  --color-syntax-keyword: var(--color-pink-2);
+  --color-syntax-operator: var(--color-gray-lighten-30);
+  --color-syntax-term: var(--color-purple-2);
+  --color-syntax-term-namespace: var(--color-purple-3);
+  --color-syntax-ability: var(--color-pink-1);
+  --color-syntax-type: var(--color-blue-1);
+  --color-syntax-type-namespace: var(--color-blue-2);
+  --color-syntax-constructor: var(--color-blue-1);
+  --color-syntax-constructor-namespace: var(--color-blue-2);
+  --color-syntax-text: var(--color-green-1);
 
   --color-syntax-monochrome-subtle: var(--color-main-subtle-fg);
   --color-syntax-monochrome-base: var(--color-gray-base);


### PR DESCRIPTION
## Overview
Update the syntax css to be more granular (support FQNs) and have more
variety and get rid of the old syntax colors in favor of colors from the
Unison Design System.

### Before
<img width="1191" alt="Screen Shot 2021-07-05 at 11 43 32" src="https://user-images.githubusercontent.com/2371/124495596-4f41ca80-dd86-11eb-917c-3af624e6287f.png">

### After
<img width="1191" alt="Screen Shot 2021-07-05 at 11 41 25" src="https://user-images.githubusercontent.com/2371/124495608-51a42480-dd86-11eb-90f5-6fd438f9e22d.png">

(Note that a few terms are colored as types because of this bug: https://github.com/unisonweb/unison/issues/2154)
