### PR TITLE
Doc: Add support for Folded and FoldedSource

### DIFF
--- a/src/TreePath.elm
+++ b/src/TreePath.elm
@@ -1,0 +1,36 @@
+{--
+
+  TreePath
+  ========
+    
+  Simple type for keeping tracking of a path down a tree of variants that
+  could have lists as data. Definition.Doc is the main example of a tree
+  structure that uses TreePath.
+
+--}
+
+
+module TreePath exposing (TreePath, TreePathItem(..), toString)
+
+
+type TreePathItem
+    = VariantIndex Int
+    | ListIndex Int
+
+
+type alias TreePath =
+    List TreePathItem
+
+
+toString : TreePath -> String
+toString path =
+    let
+        pathItemToString item =
+            case item of
+                VariantIndex i ->
+                    "VariantIndex#" ++ String.fromInt i
+
+                ListIndex i ->
+                    "ListIndex#" ++ String.fromInt i
+    in
+    path |> List.map pathItemToString |> String.join "."

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -63,7 +63,7 @@ type Msg
     | OpenDefinitionRelativeTo Reference Reference
     | CloseDefinition Reference
     | UpdateZoom Reference Zoom
-    | ToggleDocFold Reference (Id Doc)
+    | ToggleDocFold Reference Doc.FoldId
     | FetchItemFinished Reference (Result Http.Error Item)
     | Keydown KeyboardEvent
     | KeyboardShortcutMsg KeyboardShortcut.Msg

--- a/src/Workspace/WorkspaceItem.elm
+++ b/src/Workspace/WorkspaceItem.elm
@@ -184,7 +184,7 @@ viewNames onClick_ info category =
         ]
 
 
-viewDoc : (Reference -> msg) -> (Id Doc -> msg) -> DocFoldToggles -> Doc -> Html msg
+viewDoc : (Reference -> msg) -> (Doc.FoldId -> msg) -> DocFoldToggles -> Doc -> Html msg
 viewDoc toOpenReferenceMsg toggleFoldMsg docFoldToggles doc =
     div [ class "definition-doc" ] [ Doc.view toOpenReferenceMsg toggleFoldMsg docFoldToggles doc ]
 
@@ -239,7 +239,7 @@ viewItem :
     msg
     -> (Reference -> msg)
     -> (Zoom -> msg)
-    -> (Id Doc -> msg)
+    -> (Doc.FoldId -> msg)
     -> Reference
     -> { item : Item, zoom : Zoom, docFoldToggles : DocFoldToggles }
     -> Bool
@@ -314,7 +314,7 @@ view :
     msg
     -> (Reference -> msg)
     -> (Zoom -> msg)
-    -> (Id Doc -> msg)
+    -> (Doc.FoldId -> msg)
     -> WorkspaceItem
     -> Bool
     -> Html msg

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -10,8 +10,8 @@
 }
 
 .doc .source.code,
-.doc .source.sources,
-.doc .source.folded-sources,
+.doc .sources .source,
+.doc .folded-sources .source,
 .doc .source.example,
 .doc .source.eval,
 .doc .source.signatures .signature {
@@ -20,6 +20,7 @@
   background: var(--color-workspace-item-doc-source-bg);
   border-radius: var(--border-radius-base);
   margin-bottom: 1rem;
+  flex-direction: column;
 }
 
 .doc .source.inline-code,
@@ -31,6 +32,11 @@
   margin-right: 0.5ch;
   background: var(--color-workspace-item-doc-source-bg);
   border-radius: var(--border-radius-base);
+}
+
+.doc .sources .source .details,
+.doc .folded-sources .source .details {
+  margin-left: 1.5rem;
 }
 
 /* code and inline-code render sub docs, not syntax */
@@ -145,10 +151,34 @@
 .doc .folded {
   margin-bottom: 1rem;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
 }
 
-.doc .folded a {
+.doc .folded .fold-toggle {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.doc .folded .builtin-summary {
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  align-items: center;
+}
+
+.doc .source.folded .fold-toggle .badge {
+  margin-left: auto;
+  justify-self: flex-end;
+  background: var(--color-workspace-item-doc-source-mg);
+  border: 0;
+}
+
+.doc .folded .fold-toggle:hover {
+  text-decoration: none;
+}
+
+.doc .folded .fold-toggle-indicator {
   margin-right: 0.25rem;
   width: 1.2rem;
   height: 1.2rem;
@@ -159,15 +189,19 @@
   border-radius: var(--border-radius-base);
   transition: all 0.2s;
 }
-.doc .folded a .icon {
+.doc .folded .fold-toggle-indicator .icon {
   color: var(--color-workspace-item-subtle-fg);
 }
 
-.doc .folded a:hover {
+.doc .folded:not(.disabled) .fold-toggle:hover .fold-toggle-indicator {
   background: var(--color-workspace-item-subtle-bg);
 }
-.doc .folded a:hover .icon {
+.doc .folded:not(.disabled) .fold-toggle:hover .icon {
   color: var(--color-workspace-item-subtle-fg-em);
+}
+
+.doc .source.folded:not(.disabled) .fold-toggle:hover .fold-toggle-indicator {
+  background: var(--color-workspace-item-doc-source-mg);
 }
 
 .doc .folded .icon {
@@ -176,8 +210,17 @@
   transition: transform 0.1s ease-out;
 }
 
+.doc .folded.disabled .icon {
+  cursor: inherit;
+  opacity: 0.5;
+}
+
 .doc .folded.is-folded .icon {
   transform: rotate(-90deg);
+}
+
+.doc .folded .details {
+  margin-left: 1.5rem;
 }
 
 .doc p {

--- a/src/css/themes/unison/colors.css
+++ b/src/css/themes/unison/colors.css
@@ -17,6 +17,7 @@
   --color-gray-lighten-20: #818286;
   --color-gray-lighten-30: #bdbfc6;
   --color-gray-lighten-40: #d1d5dc;
+  --color-gray-lighten-45: #d9e0e7;
   --color-gray-lighten-50: #e6ebf0;
   --color-gray-lighten-55: #f1f3f5;
   --color-gray-lighten-60: #fafafb;

--- a/src/css/themes/unison/light.css
+++ b/src/css/themes/unison/light.css
@@ -42,6 +42,7 @@
   --color-workspace-item-mg: var(--color-gray-lighten-60);
   --color-workspace-item-source-bg: transparent;
   --color-workspace-item-doc-source-bg: var(--color-gray-lighten-60);
+  --color-workspace-item-doc-source-mg: var(--color-gray-lighten-45);
   --color-workspace-item-bg: transparent;
   --color-workspace-item-link: var(--color-blue-1);
   --color-workspace-item-link-active: var(--color-pink-1);

--- a/src/css/workspace.css
+++ b/src/css/workspace.css
@@ -311,3 +311,7 @@
     --color-workspace-item-focus-doc-source-bg
   );
 }
+
+.definition-row.focused .actions {
+  opacity: 1;
+}

--- a/tests/Definition/DocTests.elm
+++ b/tests/Definition/DocTests.elm
@@ -2,8 +2,8 @@ module Definition.DocTests exposing (..)
 
 import Definition.Doc as Doc exposing (Doc(..))
 import Expect
-import Id exposing (Id)
 import Test exposing (..)
+import TreePath
 
 
 mergeWords : Test
@@ -69,6 +69,6 @@ toggleFold =
 -- Helpers
 
 
-id : Id Doc
+id : Doc.FoldId
 id =
-    Id.fromString "abcdef"
+    Doc.FoldId [ TreePath.VariantIndex 0, TreePath.ListIndex 3 ]

--- a/tests/TreePathTests.elm
+++ b/tests/TreePathTests.elm
@@ -1,0 +1,18 @@
+module TreePathTests exposing (..)
+
+import Expect
+import Test exposing (..)
+import TreePath
+
+
+toString : Test
+toString =
+    describe "TreePath.toString"
+        [ test "Returns a string version of a TreePath" <|
+            \_ ->
+                let
+                    path =
+                        [ TreePath.VariantIndex 0, TreePath.ListIndex 1, TreePath.VariantIndex 4 ]
+                in
+                Expect.equal "VariantIndex#0.ListIndex#1.VariantIndex#4" (TreePath.toString path)
+        ]


### PR DESCRIPTION
## Overview
Fully support doc folding closing https://github.com/unisonweb/codebase-ui/issues/77

<img width="743" alt="Screen Shot 2021-07-19 at 17 35 32" src="https://user-images.githubusercontent.com/2371/126233632-831ef64d-923e-480f-ab0c-891836a2d0c3.png">

## Implementation notes
* Replace the DocId idea with a FoldId that wraps a DocPath made up up
  indices in either variants of lists and use that to track the Folded
  state.
* Correctly JSON Decode Folded, Source, and FoldedSource
* Update UI to render folded elements better (including source and
  builtin source)

## Interesting/controversial decisions
There's a little overlap with how source in definitions work, but I think having it separate like this means the Doc module is a bit more self-contained and concerned with rendering docs uniquely. That said, the `EmbeddedSource` type should probably be removed in favor of `TermSource`/`TypeSource`.