### PR TITLE
Mobile: Hide sidebar on smaller screens

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -471,7 +471,7 @@ view model =
     , body =
         [ div [ id "app" ]
             [ viewMainSidebar model
-            , Html.map WorkspaceMsg (Workspace.view model.workspace)
+            , div [ id "main-content" ] [ Html.map WorkspaceMsg (Workspace.view model.workspace) ]
             , viewModal model
             ]
         ]

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -2,12 +2,14 @@
 
 #app {
   display: grid;
-  grid-template-columns: var(--main-sidebar-width) 1fr;
+  grid-template-columns: var(--main-sidebar-width) auto;
+  grid-template-areas: "main-sidebar main-content";
 }
 
 /* -- Main Sidebar --------------------------------------------------------- */
 
 #main-sidebar {
+  grid-area: main-sidebar;
   display: flex;
   flex-direction: column;
   overflow: auto;
@@ -230,6 +232,23 @@
 
 #main-sidebar nav .show-help:hover {
   background: var(--color-sidebar-focus-bg);
+}
+
+/* -- Main Content --------------------------------------------------------- */
+
+#main-content {
+  grid-area: main-content;
+}
+
+@media only screen and (max-width: 1024px) {
+  #app {
+    grid-template-columns: auto auto;
+    grid-template-areas: "main-content main-content";
+  }
+
+  #main-sidebar {
+    display: none;
+  }
 }
 
 @import "./help-modal.css";

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -329,3 +329,11 @@
     width: calc(100vw - 2rem);
   }
 }
+
+@media only screen and (max-width: 414px) {
+  .doc aside {
+    width: auto;
+    float: none;
+    margin: 0 1rem;
+  }
+}

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1,8 +1,8 @@
 .doc {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   font-size: var(--font-size-medium);
-  max-width: 40rem;
+  width: 40rem;
 }
 
 .doc .word {
@@ -22,6 +22,9 @@
   border-radius: var(--border-radius-base);
   margin-bottom: 1rem;
   flex-direction: column;
+  /*width: 100%; ??*/
+  width: 40rem;
+  overflow: scroll;
 }
 
 .doc .source.inline-code,
@@ -87,8 +90,8 @@
   bottom: 0;
   left: 0;
   background: var(--color-workspace-item-content-border);
-  width: 4px;
-  border-radius: 2px;
+  width: 0.25rem;
+  border-radius: var(--border-radius-base);
 }
 
 .doc hr {
@@ -313,4 +316,16 @@
 }
 
 .doc .group {
+}
+
+@media only screen and (max-width: 1024px) {
+  .doc,
+  .doc .source.code,
+  .doc .sources .source,
+  .doc .folded-sources .source,
+  .doc .source.example,
+  .doc .source.eval,
+  .doc .source.signatures .signature {
+    width: calc(100vw - 2rem);
+  }
 }

--- a/src/css/workspace.css
+++ b/src/css/workspace.css
@@ -3,10 +3,12 @@
 #workspace {
   background: var(--color-workspace-bg);
   color: var(--color-workspace-fg);
+
+  --toolbar-height: 3.5rem;
 }
 
 #workspace-toolbar {
-  height: 3.5rem;
+  height: var(--toolbar-height);
   padding: 0.75rem 1rem;
   font-size: var(--font-size-medium);
   background: var(--color-workspace-item-bg);
@@ -22,7 +24,7 @@
 
 #workspace-content {
   overflow: auto;
-  height: calc(100vh - 3.5rem);
+  height: calc(100vh - var(--toolbar-height));
   padding-top: 2rem;
   scrollbar-width: auto;
   scrollbar-color: var(--color-workspace-item-subtle-fg)
@@ -314,4 +316,27 @@
 
 .definition-row.focused .actions {
   opacity: 1;
+}
+
+@media only screen and (max-width: 1024px) {
+  #workspace-content {
+    box-shadow: none;
+    height: auto;
+  }
+
+  .definition-row {
+    box-shadow: none;
+    padding: 1rem;
+  }
+
+  .definition-row .content,
+  .definition-row .content .definition-doc,
+  .definition-row .content .error {
+    padding-left: 0;
+    margin-left: 0;
+  }
+
+  .definition-row .gutter {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Overview
On viewports on or below 1024 (iPad landscape width), hide the sidebar
and adjust various sizings of the main workspace area, including the
removal of the gutter. This means that the sidebar is not accessible on
small screens for now.

<img width="1524" alt="Screen Shot 2021-07-20 at 17 24 15" src="https://user-images.githubusercontent.com/2371/126397759-77f0cc11-10f6-4988-a2c4-092080e0c609.png">

## Loose ends
With this there's no way to see the sidebar or to even really know what site the user is on, this will be added in a follow up effort through a header and hamburger menu. 

Additionally it might be worth noting that a slimmer sidebar could be useful for iPad sizes, but thats also a separate effort.