### PR TITLE
Add a main header for app context and share button

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -219,9 +219,6 @@ handleWorkspaceOutMsg model out =
         Workspace.ShowFinderRequest ->
             showFinder model
 
-        Workspace.ShowPublishRequest ->
-            ( { model | modal = PublishModal }, Cmd.none )
-
         Workspace.Focused ref ->
             ( model, Route.navigateToByReference model.navKey model.route ref )
 
@@ -289,25 +286,43 @@ subscriptions model =
 -- VIEW
 
 
+viewMainHeader : Model -> Html Msg
+viewMainHeader model =
+    let
+        appContext =
+            case model.env.appContext of
+                Env.Ucm ->
+                    h1 [ class "app-context" ] [ text "Unison", span [ class "context ucm" ] [ text "Local" ] ]
+
+                Env.UnisonShare ->
+                    h1 [ class "app-context" ] [ text "Unison", span [ class "context unison-share" ] [ text "Share" ] ]
+    in
+    header
+        [ id "main-header" ]
+        [ appContext
+        , section [ class "right" ]
+            [ Button.button (ShowModal PublishModal)
+                "Publish on Unison Share"
+                |> Button.share
+                |> Button.view
+            ]
+        ]
+
+
 viewMainSidebar : Model -> Html Msg
 viewMainSidebar model =
     let
-        ( share, appContext ) =
+        share =
             case model.env.appContext of
                 Env.Ucm ->
-                    ( a [ href "https://share.unison-lang.org", rel "noopener", target "_blank" ] [ text "Unison Share" ]
-                    , span [] [ text "Unison", span [ class "context ucm" ] [ text " Local" ] ]
-                    )
+                    a [ href "https://share.unison-lang.org", rel "noopener", target "_blank" ] [ text "Unison Share" ]
 
                 Env.UnisonShare ->
-                    ( UI.nothing
-                    , span [] [ text "Unison", span [ class "context unison-share" ] [ text " Share" ] ]
-                    )
+                    UI.nothing
     in
     aside
         [ id "main-sidebar" ]
-        [ header [] [ h1 [ class "app-context" ] [ appContext ] ]
-        , div [] [ Html.map CodebaseTreeMsg (CodebaseTree.view model.codebaseTree) ]
+        [ div [] [ Html.map CodebaseTreeMsg (CodebaseTree.view model.codebaseTree) ]
         , nav []
             [ a [ href "https://unison-lang.org", title "Unison website", rel "noopener", target "_blank" ] [ Icon.view Icon.unisonMark ]
             , a [ href "https://unison-lang.org/docs", rel "noopener", target "_blank" ] [ text "Docs" ]
@@ -470,7 +485,8 @@ view model =
     { title = title_
     , body =
         [ div [ id "app" ]
-            [ viewMainSidebar model
+            [ viewMainHeader model
+            , viewMainSidebar model
             , div [ id "main-content" ] [ Html.map WorkspaceMsg (Workspace.view model.workspace) ]
             , viewModal model
             ]

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -2,14 +2,13 @@ module Workspace exposing (Model, Msg, OutMsg(..), init, open, subscriptions, up
 
 import Api exposing (ApiBasePath, ApiRequest)
 import Browser.Dom as Dom
-import Definition.Doc as Doc exposing (Doc)
+import Definition.Doc as Doc
 import Definition.Reference as Reference exposing (Reference)
 import Env exposing (Env)
 import HashQualified exposing (HashQualified(..))
 import Html exposing (Html, article, header, section)
 import Html.Attributes exposing (class, id)
 import Http
-import Id exposing (Id)
 import KeyboardShortcut exposing (KeyboardShortcut(..))
 import KeyboardShortcut.Key exposing (Key(..))
 import KeyboardShortcut.KeyboardEvent as KeyboardEvent exposing (KeyboardEvent)
@@ -59,7 +58,6 @@ init env mRef =
 type Msg
     = NoOp
     | Find
-    | Publish
     | OpenDefinitionRelativeTo Reference Reference
     | CloseDefinition Reference
     | UpdateZoom Reference Zoom
@@ -74,7 +72,6 @@ type OutMsg
     | Focused Reference
     | Emptied
     | ShowFinderRequest
-    | ShowPublishRequest
 
 
 update : Env -> Msg -> Model -> ( Model, Cmd Msg, OutMsg )
@@ -85,9 +82,6 @@ update env msg ({ workspaceItems } as model) =
 
         Find ->
             ( model, Cmd.none, ShowFinderRequest )
-
-        Publish ->
-            ( model, Cmd.none, ShowPublishRequest )
 
         OpenDefinitionRelativeTo relativeToRef ref ->
             openItem env.apiBasePath model (Just relativeToRef) ref
@@ -410,7 +404,6 @@ view model =
         [ header
             [ id "workspace-toolbar" ]
             [ Button.button Find "Find" |> Button.view
-            , section [ class "right" ] [ Button.button Publish "Publish on Unison Share" |> Button.share |> Button.view ]
             ]
         , section
             [ id "workspace-content" ]

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -2,8 +2,50 @@
 
 #app {
   display: grid;
+  grid-template-rows: 3.5rem auto;
   grid-template-columns: var(--main-sidebar-width) auto;
-  grid-template-areas: "main-sidebar main-content";
+  grid-template-areas:
+    "main-header main-header"
+    "main-sidebar main-content";
+}
+
+/* -- Main Header ---------------------------------------------------------- */
+
+#main-header {
+  grid-area: main-header;
+  padding: 0 1rem 0 1.5rem;
+  background: var(--color-main-header-bg);
+  color: var(--color-main-header-fg);
+  border-bottom: 1px solid var(--color-main-header-border);
+  display: flex;
+  align-items: center;
+  font-size: 1rem;
+}
+
+#main-header .app-context {
+  font-size: var(--font-size-base);
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  align-items: center;
+  font-weight: bold;
+}
+
+#main-header .app-context .context {
+  margin-left: 0.375rem;
+}
+
+#main-header .app-context .unison-share {
+  color: var(--color-main-header-context-unison-share-fg);
+}
+
+#main-header .app-context .ucm {
+  color: var(--color-main-header-context-ucm-fg);
+}
+
+#main-header .right {
+  margin-left: auto;
+  justify-self: flex-end;
 }
 
 /* -- Main Sidebar --------------------------------------------------------- */
@@ -37,40 +79,6 @@
 #main-sidebar .loading-placeholder {
   background: var(--color-sidebar-subtle-fg);
   opacity: 0.5;
-}
-
-#main-sidebar header {
-  margin-bottom: 2.5rem;
-}
-
-#main-sidebar .app-context {
-  font-size: var(--font-size-base);
-  height: 1.5rem;
-  display: flex;
-  align-items: center;
-}
-
-#main-sidebar .app-context .logo-mark {
-  display: flex;
-  height: 1.3rem;
-  width: 1.3rem;
-  align-items: center;
-  justify-content: center;
-  margin-right: 0.125rem;
-}
-
-#main-sidebar .app-context .logo-mark .icon {
-  font-size: 0.875rem;
-  color: var(--color-sidebar-fg);
-  margin-bottom: 2px;
-}
-
-#main-sidebar .app-context .unison-share {
-  color: var(--color-sidebar-context-unison-share-fg);
-}
-
-#main-sidebar .app-context .ucm {
-  color: var(--color-sidebar-context-ucm-fg);
 }
 
 #main-sidebar h2 {
@@ -240,10 +248,15 @@
   grid-area: main-content;
 }
 
+/* -- Responsive ----------------------------------------------------------- */
+
 @media only screen and (max-width: 1024px) {
   #app {
+    grid-template-rows: 3.5rem auto;
     grid-template-columns: auto auto;
-    grid-template-areas: "main-content main-content";
+    grid-template-areas:
+      "main-header main-header"
+      "main-content main-content";
   }
 
   #main-sidebar {

--- a/src/css/themes/unison/colors.css
+++ b/src/css/themes/unison/colors.css
@@ -7,7 +7,7 @@
   --color-brand-dark-purple: #520066;
 
   /* Grays */
-  --color-gray-darken-5: #3d3e43;
+  --color-gray-darken-10: #41424b;
   --color-gray-darken-20: #2d2e35;
   --color-gray-darken-25: #22232a;
   --color-gray-darken-30: #18181c;

--- a/src/css/themes/unison/light.css
+++ b/src/css/themes/unison/light.css
@@ -14,6 +14,12 @@
   --color-main-mark-fg: var(--color-blue-2);
   --color-main-mark-bg: transparent;
 
+  --color-main-header-fg: var(--color-gray-lighten-100);
+  --color-main-header-bg: var(--color-gray-darken-10);
+  --color-main-header-context-unison-share-fg: var(--color-purple-4);
+  --color-main-header-context-ucm-fg: var(--color-pink-3);
+  --color-main-header-border: var(--color-gray-base);
+
   --color-keyboard-shortcut-key-fg: var(--color-gray-base);
   --color-keyboard-shortcut-key-bg: var(--color-gray-lighten-50);
   --color-keyboard-shortcut-then: var(--color-gray-lighten-20);
@@ -21,13 +27,11 @@
 
   --color-sidebar-fg: var(--color-gray-lighten-50);
   --color-sidebar-bg: var(--color-gray-darken-20);
-  --color-sidebar-context-unison-share-fg: var(--color-purple-4);
-  --color-sidebar-context-ucm-fg: var(--color-pink-3);
   --color-sidebar-border: transparent;
   --color-sidebar-subtle-fg: var(--color-gray-lighten-20);
   --color-sidebar-subtle-bg: transparent;
   --color-sidebar-focus-fg: var(--color-gray-lighten-60);
-  --color-sidebar-focus-bg: var(--color-gray-darken-5);
+  --color-sidebar-focus-bg: var(--color-gray-darken-10);
   --color-sidebar-keyboard-shortcut-key-fg: var(--color-gray-lighten-30);
   --color-sidebar-keyboard-shortcut-key-bg: var(--color-gray-base);
   --color-sidebar-keyboard-shortcut-then: var(--color-gray-lighten-20);
@@ -107,7 +111,7 @@
   --color-button-primary-mono-fg: var(--color-gray-lighten-60);
   --color-button-primary-mono-bg: var(--color-gray-darken-20);
   --color-button-primary-mono-hover-fg: var(--color-gray-lighten-60);
-  --color-button-primary-mono-hover-bg: var(--color-gray-darken-5);
+  --color-button-primary-mono-hover-bg: var(--color-gray-darken-10);
 
   --color-button-primary-fg: var(--color-gray-lighten-60);
   --color-button-primary-bg: var(--color-gray-blue-2);
@@ -116,8 +120,8 @@
 
   --color-button-share-fg: var(--color-purple-1);
   --color-button-share-bg: var(--color-purple-4);
-  --color-button-share-hover-fg: var(--color-gray-lighten-60);
-  --color-button-share-hover-bg: var(--color-purple-3);
+  --color-button-share-hover-fg: var(--color-purple-2);
+  --color-button-share-hover-bg: var(--color-purple-4);
 
   --color-button-danger-fg: var(--color-gray-lighten-100);
   --color-button-danger-bg: var(--color-pink-1);


### PR DESCRIPTION
## Overview
This adds a main header for the app context and the share button. This means that the UI for smaller screens without a sidebar have a lot more context

<img width="948" alt="Screen Shot 2021-07-20 at 19 40 03" src="https://user-images.githubusercontent.com/2371/126408640-a18e5df2-c3c8-49cf-9fab-e575cc14212f.png">
<img width="1201" alt="Screen Shot 2021-07-20 at 19 39 44" src="https://user-images.githubusercontent.com/2371/126408641-96c4c72a-1256-4482-bfcd-4289110a8b31.png">
<img width="948" alt="Screen Shot 2021-07-20 at 19 39 51" src="https://user-images.githubusercontent.com/2371/126408642-dce67b63-ca61-477c-981c-41e8f8a04b16.png">
