### PR TITLE
Insert newly opened items at the top

### DIFF
--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -209,10 +209,9 @@ openItem apiBasePath ({ workspaceItems } as model) relativeToRef ref =
             nextWorkspaceItems =
                 case relativeToRef of
                     Nothing ->
-                        WorkspaceItems.insertWithFocus workspaceItems toInsert
+                        WorkspaceItems.prependWithFocus workspaceItems toInsert
 
                     Just r ->
-                        -- WorkspaceItems.insertWithFocusAfter model r toInsert
                         WorkspaceItems.insertWithFocusBefore workspaceItems r toInsert
         in
         ( { model | workspaceItems = nextWorkspaceItems }

--- a/src/Workspace/WorkspaceItems.elm
+++ b/src/Workspace/WorkspaceItems.elm
@@ -78,9 +78,24 @@ singleton item =
 -- MODIFY
 
 
-insertWithFocus : WorkspaceItems -> WorkspaceItem -> WorkspaceItems
-insertWithFocus items item =
+appendWithFocus : WorkspaceItems -> WorkspaceItem -> WorkspaceItems
+appendWithFocus items item =
     WorkspaceItems { before = toList items, focus = item, after = [] }
+
+
+prependWithFocus : WorkspaceItems -> WorkspaceItem -> WorkspaceItems
+prependWithFocus workspaceItems item =
+    case workspaceItems of
+        Empty ->
+            singleton item
+
+        WorkspaceItems items ->
+            WorkspaceItems
+                { before = []
+                , focus = item
+                , after =
+                    items.before ++ (items.focus :: items.after)
+                }
 
 
 {-| Insert before a Hash. If the Hash is not in WorkspaceItems, insert with
@@ -122,7 +137,7 @@ insertWithFocusBefore items beforeRef toInsert =
                     |> Maybe.withDefault (singleton toInsert)
 
             else
-                insertWithFocus items toInsert
+                prependWithFocus items toInsert
 
 
 {-| Insert after a Hash. If the Hash is not in WorkspaceItems, insert at the
@@ -164,7 +179,7 @@ insertWithFocusAfter items afterRef toInsert =
                     |> Maybe.withDefault (singleton toInsert)
 
             else
-                insertWithFocus items toInsert
+                appendWithFocus items toInsert
 
 
 replace : WorkspaceItems -> Reference -> WorkspaceItem -> WorkspaceItems
@@ -243,6 +258,20 @@ references items =
     items
         |> toList
         |> List.map WorkspaceItem.reference
+
+
+head : WorkspaceItems -> Maybe WorkspaceItem
+head items =
+    items
+        |> toList
+        |> List.head
+
+
+last : WorkspaceItems -> Maybe WorkspaceItem
+last items =
+    items
+        |> toList
+        |> ListE.last
 
 
 

--- a/src/css/workspace.css
+++ b/src/css/workspace.css
@@ -29,6 +29,7 @@
     calc(100vh - var(--workspace-toolbar-height)) - var(--main-header-height)
   );
   padding-top: 2rem;
+  scroll-behavior: smooth;
   scrollbar-width: auto;
   scrollbar-color: var(--color-workspace-item-subtle-fg)
     var(--color-workspace-item-bg);

--- a/tests/Workspace/WorkspaceItemsTests.elm
+++ b/tests/Workspace/WorkspaceItemsTests.elm
@@ -13,19 +13,38 @@ import Workspace.WorkspaceItems as WorkspaceItems exposing (..)
 -- MODIFY
 
 
-insertWithFocus : Test
-insertWithFocus =
+appendWithFocus : Test
+appendWithFocus =
     let
         result =
-            WorkspaceItems.insertWithFocus WorkspaceItems.empty term
+            WorkspaceItems.appendWithFocus WorkspaceItems.empty term
 
         currentFocusedRef =
             getFocusedRef result
     in
-    describe "WorkspaceItems.insertWithFocus"
-        [ test "Inserts the term" <|
+    describe "WorkspaceItems.appendWithFocus"
+        [ test "Appends the term" <|
             \_ ->
-                Expect.true "term is a member" (WorkspaceItems.member result termRef)
+                Expect.equal (Just term) (WorkspaceItems.last result)
+        , test "Sets focus" <|
+            \_ ->
+                Expect.true "Has focus" (Maybe.withDefault False <| Maybe.map (\r -> r == termRef) currentFocusedRef)
+        ]
+
+
+prependWithFocus : Test
+prependWithFocus =
+    let
+        result =
+            WorkspaceItems.prependWithFocus WorkspaceItems.empty term
+
+        currentFocusedRef =
+            getFocusedRef result
+    in
+    describe "WorkspaceItems.prependWithFocus"
+        [ test "Prepends the term" <|
+            \_ ->
+                Expect.equal (Just term) (WorkspaceItems.head result)
         , test "Sets focus" <|
             \_ ->
                 Expect.true "Has focus" (Maybe.withDefault False <| Maybe.map (\r -> r == termRef) currentFocusedRef)


### PR DESCRIPTION
## Overview

When opening a new item from the Sidebar or the Finder, insert it at the
very top of the workspace and scroll to it. Do not change the "insert
above" behavior when opening a definition from another definition.