### PR TITLE
Support references to constructors in Syntax

### DIFF
--- a/src/CodebaseTree/NamespaceListing.elm
+++ b/src/CodebaseTree/NamespaceListing.elm
@@ -118,10 +118,10 @@ decodeContent parentFqn =
             field "tag" Decode.string
 
         termTypeByHash hash =
-            if AbilityConstructor.isAbilityConstructorHash hash then
+            if Hash.isAbilityConstructorHash hash then
                 "AbilityConstructor"
 
-            else if DataConstructor.isDataConstructorHash hash then
+            else if Hash.isDataConstructorHash hash then
                 "DataConstructor"
 
             else

--- a/src/Definition/AbilityConstructor.elm
+++ b/src/Definition/AbilityConstructor.elm
@@ -6,7 +6,6 @@ module Definition.AbilityConstructor exposing
     , AbilityConstructorSummary
     , decodeSignature
     , decodeSource
-    , isAbilityConstructorHash
     )
 
 import Definition.Info exposing (Info)
@@ -15,7 +14,6 @@ import Definition.Type as Type exposing (TypeSource)
 import FullyQualifiedName exposing (FQN)
 import Hash exposing (Hash)
 import Json.Decode as Decode
-import Regex
 import Syntax exposing (Syntax)
 
 
@@ -43,19 +41,6 @@ type alias AbilityConstructorSummary =
 
 type alias AbilityConstructorListing =
     AbilityConstructor FQN
-
-
-
--- HELPERS
-
-
-isAbilityConstructorHash : Hash -> Bool
-isAbilityConstructorHash hash =
-    let
-        abilityConstructorSuffix =
-            Maybe.withDefault Regex.never (Regex.fromString "#a(\\d+)$")
-    in
-    hash |> Hash.toString |> Regex.contains abilityConstructorSuffix
 
 
 

--- a/src/Definition/DataConstructor.elm
+++ b/src/Definition/DataConstructor.elm
@@ -6,7 +6,6 @@ module Definition.DataConstructor exposing
     , DataConstructorSummary
     , decodeSignature
     , decodeSource
-    , isDataConstructorHash
     )
 
 import Definition.Info exposing (Info)
@@ -15,7 +14,6 @@ import Definition.Type as Type exposing (TypeSource)
 import FullyQualifiedName exposing (FQN)
 import Hash exposing (Hash)
 import Json.Decode as Decode
-import Regex
 import Syntax exposing (Syntax)
 
 
@@ -43,19 +41,6 @@ type alias DataConstructorSummary =
 
 type alias DataConstructorListing =
     DataConstructor FQN
-
-
-
--- HELPERS
-
-
-isDataConstructorHash : Hash -> Bool
-isDataConstructorHash hash =
-    let
-        dataConstructorSuffix =
-            Maybe.withDefault Regex.never (Regex.fromString "#d(\\d+)$")
-    in
-    hash |> Hash.toString |> Regex.contains dataConstructorSuffix
 
 
 

--- a/src/Finder/FinderMatch.elm
+++ b/src/Finder/FinderMatch.elm
@@ -233,10 +233,10 @@ decodeItem : Decode.Decoder FinderItem
 decodeItem =
     let
         termTypeByHash hash =
-            if AbilityConstructor.isAbilityConstructorHash hash then
+            if Hash.isAbilityConstructorHash hash then
                 "AbilityConstructor"
 
-            else if DataConstructor.isDataConstructorHash hash then
+            else if Hash.isDataConstructorHash hash then
                 "DataConstructor"
 
             else

--- a/src/Hash.elm
+++ b/src/Hash.elm
@@ -4,6 +4,8 @@ module Hash exposing
     , equals
     , fromString
     , fromUrlString
+    , isAbilityConstructorHash
+    , isDataConstructorHash
     , isRawHash
     , prefix
     , toString
@@ -13,6 +15,7 @@ module Hash exposing
     )
 
 import Json.Decode as Decode
+import Regex
 import Url.Parser
 import Util
 
@@ -71,6 +74,28 @@ prefix =
 urlPrefix : String
 urlPrefix =
     "@"
+
+
+
+-- HELPERS
+
+
+isDataConstructorHash : Hash -> Bool
+isDataConstructorHash hash =
+    let
+        dataConstructorSuffix =
+            Maybe.withDefault Regex.never (Regex.fromString "#d(\\d+)$")
+    in
+    hash |> toString |> Regex.contains dataConstructorSuffix
+
+
+isAbilityConstructorHash : Hash -> Bool
+isAbilityConstructorHash hash =
+    let
+        abilityConstructorSuffix =
+            Maybe.withDefault Regex.never (Regex.fromString "#a(\\d+)$")
+    in
+    hash |> toString |> Regex.contains abilityConstructorSuffix
 
 
 

--- a/src/css/syntax.css
+++ b/src/css/syntax.css
@@ -44,15 +44,15 @@ code a:active {
 }
 
 .rich .boolean-literal,
-.rich .constructor {
+.rich .data-constructor-reference {
   color: var(--color-syntax-constructor);
 }
 
-.rich .constructor .segment {
+.rich .data-constructor-reference .segment {
   color: var(--color-syntax-constructor-namespace);
 }
 
-.rich .constructor .segment:last-child {
+.rich .data-constructor-reference .segment:last-child {
   color: var(--color-syntax-constructor);
 }
 
@@ -76,7 +76,7 @@ code a:active {
 }
 
 .rich .term-reference,
-.rich .request,
+.rich .ability-constructor-reference,
 .rich .hash-qualifier {
   color: var(--color-syntax-term);
 }
@@ -140,12 +140,12 @@ code a:active {
 
 .monochrome .type-reference,
 .monochrome .boolean-literal,
-.monochrome .constructor,
+.monochrome .data-constructor-reference,
 .monochrome .numeric-literal,
 .monochrome .term-reference,
 .monochrome .data-type-modifier,
 .monochrome .hash-qualifier,
-.monochrome .request {
+.monochrome .ability-constructor-reference {
   color: var(--color-syntax-monochrome-em);
 }
 
@@ -180,7 +180,7 @@ code a:active {
 .plain .bytes-literal,
 .plain .char-literal,
 .plain .boolean-literal,
-.plain .constructor,
+.plain .data-constructor-reference,
 .plain .blank,
 .plain .var,
 .plain .data-type-params,
@@ -188,7 +188,7 @@ code a:active {
 .plain .term-reference,
 .plain .data-type-modifier,
 .plain .hash-qualifier,
-.plain .request,
+.plain .ability-constructor-reference,
 .plain .type-reference,
 .plain .op.cons,
 .plain .op.snoc,


### PR DESCRIPTION
## Overview
Integrate with the recent backend addition to merge `Constructor` into
`TermReference` with a referent. Do so by parsing the hash into
`SyntaxElement.AbilityConstructorReference`,
`SyntaxElement.DataConstructorReference`, and
`SyntaxElement.TermReference`, while getting rid of
`SyntaxElement.Constructor` and `SyntaxElement.Request`.

Closes https://github.com/unisonweb/codebase-ui/issues/105