### PR TITLE
Support FQNs in Routes

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,6 +11,7 @@
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
             "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
             "elm/regex": "1.0.0",
             "elm/svg": "1.0.1",
             "elm/url": "1.0.0",
@@ -27,7 +28,6 @@
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
-            "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.2",

--- a/src/App.elm
+++ b/src/App.elm
@@ -55,7 +55,7 @@ init env route navKey =
     let
         ( workspace, workspaceCmd ) =
             case route of
-                Route.ByReference _ ref ->
+                Route.Definition _ ref ->
                     Workspace.init env (Just ref)
 
                 _ ->
@@ -221,7 +221,7 @@ handleWorkspaceOutMsg model out =
             ( model, Route.navigateToByReference model.navKey model.route ref )
 
         Workspace.Emptied ->
-            ( model, Route.navigateToLatestCodebase model.navKey )
+            ( model, Route.navigateToCurrentPerspective model.navKey model.route )
 
 
 keydown : Model -> KeyboardEvent -> ( Model, Cmd Msg )

--- a/src/CodebaseTree.elm
+++ b/src/CodebaseTree.elm
@@ -189,17 +189,17 @@ viewDefinitionListing listing =
             viewListingRow (Just (OpenDefinitionListing ref)) (unqualifiedName fqn)
     in
     case listing of
-        TypeListing hash fqn category ->
-            viewDefRow (TypeReference (HashOnly hash)) fqn (Category.name category) (Category.icon category)
+        TypeListing _ fqn category ->
+            viewDefRow (TypeReference (NameOnly fqn)) fqn (Category.name category) (Category.icon category)
 
-        TermListing hash fqn category ->
-            viewDefRow (TermReference (HashOnly hash)) fqn (Category.name category) (Category.icon category)
+        TermListing _ fqn category ->
+            viewDefRow (TermReference (NameOnly fqn)) fqn (Category.name category) (Category.icon category)
 
-        DataConstructorListing hash fqn ->
-            viewDefRow (DataConstructorReference (HashOnly hash)) fqn "constructor" Icon.dataConstructor
+        DataConstructorListing _ fqn ->
+            viewDefRow (DataConstructorReference (NameOnly fqn)) fqn "constructor" Icon.dataConstructor
 
-        AbilityConstructorListing hash fqn ->
-            viewDefRow (AbilityConstructorReference (HashOnly hash)) fqn "constructor" Icon.abilityConstructor
+        AbilityConstructorListing _ fqn ->
+            viewDefRow (AbilityConstructorReference (NameOnly fqn)) fqn "constructor" Icon.abilityConstructor
 
         PatchListing _ ->
             viewListingRow Nothing "Patch" "patch" Icon.patch

--- a/src/Finder.elm
+++ b/src/Finder.elm
@@ -11,7 +11,6 @@ import Definition.Term exposing (Term(..))
 import Definition.Type exposing (Type(..))
 import Env exposing (AppContext(..), Env)
 import Finder.FinderMatch as FinderMatch exposing (FinderMatch)
-import Hash
 import HashQualified exposing (HashQualified(..))
 import Html
     exposing
@@ -416,30 +415,30 @@ viewMatch keyboardShortcut match isFocused shortcut =
                 ]
     in
     case match.item of
-        FinderMatch.TypeItem (Type hash category { name, namespace, source }) ->
+        FinderMatch.TypeItem (Type _ category { fqn, name, namespace, source }) ->
             viewMatch_
-                (TypeReference (HashOnly hash))
+                (TypeReference (NameOnly fqn))
                 (Category.icon (Category.Type category))
                 (viewMarkedNaming match.matchPositions namespace name)
                 (Source.viewTypeSource Source.Monochrome source)
 
-        FinderMatch.TermItem (Term hash category { name, namespace, signature }) ->
+        FinderMatch.TermItem (Term _ category { fqn, name, namespace, signature }) ->
             viewMatch_
-                (TermReference (HashOnly hash))
+                (TermReference (NameOnly fqn))
                 (Category.icon (Category.Term category))
                 (viewMarkedNaming match.matchPositions namespace name)
                 (Source.viewTermSignature Source.Monochrome signature)
 
-        FinderMatch.DataConstructorItem (DataConstructor hash { name, namespace, signature }) ->
+        FinderMatch.DataConstructorItem (DataConstructor _ { fqn, name, namespace, signature }) ->
             viewMatch_
-                (DataConstructorReference (HashOnly hash))
+                (DataConstructorReference (NameOnly fqn))
                 Icon.dataConstructor
                 (viewMarkedNaming match.matchPositions namespace name)
                 (Source.viewTermSignature Source.Monochrome signature)
 
-        FinderMatch.AbilityConstructorItem (AbilityConstructor hash { name, namespace, signature }) ->
+        FinderMatch.AbilityConstructorItem (AbilityConstructor _ { fqn, name, namespace, signature }) ->
             viewMatch_
-                (AbilityConstructorReference (HashOnly hash))
+                (AbilityConstructorReference (NameOnly fqn))
                 Icon.abilityConstructor
                 (viewMarkedNaming match.matchPositions namespace name)
                 (Source.viewTermSignature Source.Monochrome signature)

--- a/src/Finder/FinderMatch.elm
+++ b/src/Finder/FinderMatch.elm
@@ -94,17 +94,17 @@ namespace fm =
 reference : FinderMatch -> Reference
 reference fm =
     case fm.item of
-        TypeItem (Type h _ _) ->
-            TypeReference (HashOnly h)
+        TypeItem (Type _ _ { fqn }) ->
+            TypeReference (NameOnly fqn)
 
-        TermItem (Term h _ _) ->
-            TermReference (HashOnly h)
+        TermItem (Term _ _ { fqn }) ->
+            TermReference (NameOnly fqn)
 
-        DataConstructorItem (DataConstructor h _) ->
-            DataConstructorReference (HashOnly h)
+        DataConstructorItem (DataConstructor _ { fqn }) ->
+            DataConstructorReference (NameOnly fqn)
 
-        AbilityConstructorItem (AbilityConstructor h _) ->
-            AbilityConstructorReference (HashOnly h)
+        AbilityConstructorItem (AbilityConstructor _ { fqn }) ->
+            AbilityConstructorReference (NameOnly fqn)
 
 
 matchSegmentsToMatchPositions : MatchSegments -> NEL.Nonempty Int

--- a/src/FullyQualifiedName.elm
+++ b/src/FullyQualifiedName.elm
@@ -3,6 +3,7 @@ module FullyQualifiedName exposing
     , decode
     , decodeFromParent
     , equals
+    , fromList
     , fromParent
     , fromString
     , fromUrlString
@@ -33,6 +34,13 @@ type FQN
 -}
 fromString : String -> FQN
 fromString rawFqn =
+    rawFqn
+        |> String.split "."
+        |> fromList
+
+
+fromList : List String -> FQN
+fromList segments_ =
     let
         rootEmptyToDot i s =
             if i == 0 && String.isEmpty s then
@@ -41,8 +49,7 @@ fromString rawFqn =
             else
                 s
     in
-    rawFqn
-        |> String.split "."
+    segments_
         |> List.map String.trim
         |> List.indexedMap rootEmptyToDot
         |> List.filter (\s -> String.length s > 0)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -82,8 +82,13 @@ update msg model =
                         env =
                             Env.init preEnv.flags perspective
 
+                        newRoute =
+                            perspective
+                                |> Perspective.toParams
+                                |> Route.updatePerspectiveParams preEnv.route
+
                         ( app, cmd ) =
-                            App.init env preEnv.route preEnv.navKey
+                            App.init env newRoute preEnv.navKey
                     in
                     ( Initialized app, Cmd.map AppMsg cmd )
 

--- a/src/Route/Parsers.elm
+++ b/src/Route/Parsers.elm
@@ -1,0 +1,118 @@
+{-
+
+   Route.Parsers
+   =============
+
+   Various parsing helpers to grab structured data like FQNs and Hashes out of
+   routes
+-}
+
+
+module Route.Parsers exposing (..)
+
+import Definition.Reference exposing (Reference(..))
+import FullyQualifiedName as FQN exposing (FQN)
+import Hash exposing (Hash)
+import HashQualified exposing (HashQualified(..))
+import Parser exposing ((|.), (|=), Parser, backtrackable, keyword, succeed)
+import Perspective exposing (CodebasePerspectiveParam(..), PerspectiveParams(..))
+
+
+
+-- Parsers --------------------------------------------------------------------
+
+
+fqn : Parser FQN
+fqn =
+    let
+        segment =
+            Parser.getChompedString <|
+                Parser.succeed ()
+                    |. Parser.chompWhile Char.isAlphaNum
+    in
+    Parser.map FQN.fromList
+        (Parser.sequence
+            { start = ""
+            , separator = "/"
+            , end = ""
+            , spaces = Parser.spaces
+            , item = segment
+            , trailing = Parser.Forbidden
+            }
+        )
+
+
+fqnEnd : Parser ()
+fqnEnd =
+    Parser.symbol "-"
+
+
+hash : Parser Hash
+hash =
+    let
+        handleMaybe mHash =
+            case mHash of
+                Just h ->
+                    Parser.succeed h
+
+                Nothing ->
+                    Parser.problem "Invalid hash"
+    in
+    Parser.chompUntilEndOr "/"
+        |> Parser.getChompedString
+        |> Parser.map Hash.fromUrlString
+        |> Parser.andThen handleMaybe
+
+
+hq : Parser HashQualified
+hq =
+    Parser.oneOf
+        [ b (succeed HashOnly |= hash)
+        , b (succeed NameOnly |= fqn)
+        ]
+
+
+reference : Parser Reference
+reference =
+    Parser.oneOf
+        [ b (succeed TermReference |. s "terms" |. slash |= hq)
+        , b (succeed TypeReference |. s "types" |. slash |= hq)
+        , b (succeed AbilityConstructorReference |. s "ability-constructors" |. slash |= hq)
+        , b (succeed DataConstructorReference |. s "data-constructors" |. slash |= hq)
+        ]
+
+
+codebaseRef : Parser CodebasePerspectiveParam
+codebaseRef =
+    Parser.oneOf
+        [ b (succeed Relative |. s "latest")
+        , b (succeed Absolute |= hash)
+        ]
+
+
+perspectiveParams : Parser PerspectiveParams
+perspectiveParams =
+    Parser.oneOf
+        [ b (succeed ByNamespace |= codebaseRef |. slash |. s "namespaces" |. slash |= fqn |. fqnEnd)
+        , b (succeed ByNamespace |= codebaseRef |. slash |. s "namespaces" |. slash |= fqn)
+        , b (succeed ByCodebase |= codebaseRef)
+        ]
+
+
+
+-- Helpers --------------------------------------------------------------------
+
+
+slash : Parser ()
+slash =
+    Parser.symbol "/"
+
+
+b : Parser a -> Parser a
+b =
+    backtrackable
+
+
+s : String -> Parser ()
+s =
+    keyword

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -14,7 +14,6 @@ import Browser.Dom as Dom
 import Definition.Doc as Doc
 import Definition.Reference as Reference exposing (Reference)
 import Env exposing (Env)
-import Hash
 import HashQualified exposing (HashQualified(..))
 import Html exposing (Html, a, article, div, h2, header, p, section, span, strong, text)
 import Html.Attributes exposing (class, href, id, rel, target)

--- a/tests/RouteTests.elm
+++ b/tests/RouteTests.elm
@@ -2,15 +2,165 @@ module RouteTests exposing (..)
 
 import Definition.Reference as Reference exposing (Reference(..))
 import Expect
+import FullyQualifiedName as FQN exposing (FQN)
+import Hash exposing (Hash)
 import Perspective exposing (CodebasePerspectiveParam(..), PerspectiveParams(..))
 import Route
 import Test exposing (..)
 import Url exposing (Url)
 
 
-fromUrl : Test
-fromUrl =
-    describe "Route.fromUrl"
+perspectiveRoute : Test
+perspectiveRoute =
+    describe "Route.fromUrl : perspective route"
+        [ test "Matches root to relative codease perspective" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/"
+
+                    expected =
+                        Route.Perspective (ByCodebase Relative)
+                in
+                Expect.equal expected (Route.fromUrl "" url)
+        , test "Matches a codebase relative perspective" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/latest"
+
+                    expected =
+                        Route.Perspective (ByCodebase Relative)
+                in
+                Expect.equal expected (Route.fromUrl "" url)
+        , test "Matches a codebase relative perspective with namespace" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/latest/namespaces/base/List"
+
+                    expected =
+                        Route.Perspective (ByNamespace Relative (fqn "base.List"))
+                in
+                Expect.equal expected (Route.fromUrl "" url)
+        , test "Matches a codebase absolute perspective" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/@codebasehash"
+
+                    expected =
+                        hash "@codebasehash"
+                            |> Maybe.map (\h -> Route.Perspective (ByCodebase (Absolute h)))
+                in
+                Expect.equal expected (Just (Route.fromUrl "" url))
+        , test "Matches a codebase absolute perspective with namespace" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/@codebasehash/namespaces/base/List"
+
+                    expected =
+                        hash "@codebasehash"
+                            |> Maybe.map (\h -> Route.Perspective (ByNamespace (Absolute h) (fqn "base.List")))
+                in
+                Expect.equal expected (Just (Route.fromUrl "" url))
+        ]
+
+
+definitionRoute : Test
+definitionRoute =
+    describe "Route.fromUrl : definition route"
+        [ test "Matches a codebase relative and relative definition" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/latest/terms/base/List/map"
+
+                    expected =
+                        Route.Definition (ByCodebase Relative) (Reference.fromString TermReference "base.List.map")
+                in
+                Expect.equal expected (Route.fromUrl "" url)
+        , test "Matches a codebase relative and relative definition within a namespace" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/latest/namespaces/base/List/-/terms/map"
+
+                    expected =
+                        Route.Definition (ByNamespace Relative (fqn "base.List")) (Reference.fromString TermReference "map")
+                in
+                Expect.equal expected (Route.fromUrl "" url)
+        , test "Matches a codebase relative and absolute definition" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/latest/terms/@definitionhash"
+
+                    expected =
+                        Route.Definition (ByCodebase Relative) (Reference.fromString TermReference "#definitionhash")
+                in
+                Expect.equal expected (Route.fromUrl "" url)
+        , test "Matches a codebase relative and absolute definition within a namespace" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/latest/namespaces/base/List/-/terms/@definitionhash"
+
+                    expected =
+                        Route.Definition (ByNamespace Relative (fqn "base.List")) (Reference.fromString TermReference "#definitionhash")
+                in
+                Expect.equal expected (Route.fromUrl "" url)
+        , test "Matches a codebase absolute and relative definition " <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/@codebasehash/terms/base/List/map"
+
+                    expected =
+                        hash "@codebasehash"
+                            |> Maybe.map (\h -> Route.Definition (ByCodebase (Absolute h)) (Reference.fromString TermReference "base.List.map"))
+                in
+                Expect.equal expected (Just (Route.fromUrl "" url))
+        , test "Matches a codebase absolute and relative definition within a namespace" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/@codebasehash/namespaces/base/List/-/terms/map"
+
+                    expected =
+                        hash "@codebasehash"
+                            |> Maybe.map (\h -> Route.Definition (ByNamespace (Absolute h) (fqn "base.List")) (Reference.fromString TermReference "map"))
+                in
+                Expect.equal expected (Just (Route.fromUrl "" url))
+        , test "Matches a codebase absolute and absolute definition " <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/@codebasehash/terms/@definitionhash"
+
+                    expected =
+                        hash "@codebasehash"
+                            |> Maybe.map (\h -> Route.Definition (ByCodebase (Absolute h)) (Reference.fromString TermReference "#definitionhash"))
+                in
+                Expect.equal expected (Just (Route.fromUrl "" url))
+        , test "Matches a codebase absolute and absolute definition within a namespace" <|
+            \_ ->
+                let
+                    url =
+                        mkUrl "/@codebasehash/namespaces/base/List/-/terms/map"
+
+                    expected =
+                        hash "@codebasehash"
+                            |> Maybe.map (\h -> Route.Definition (ByNamespace (Absolute h) (fqn "base.List")) (Reference.fromString TermReference "map"))
+                in
+                Expect.equal expected (Just (Route.fromUrl "" url))
+        ]
+
+
+fromUrlBasePath : Test
+fromUrlBasePath =
+    describe "Route.fromUrl : basePath"
         [ test "Matches with a basePath prefix" <|
             \_ ->
                 let
@@ -21,7 +171,7 @@ fromUrl =
                         "/some-token/ui/"
 
                     expected =
-                        Route.ByReference (ByCodebase Relative) (Reference.fromString TermReference "#abc123")
+                        Route.Definition (ByCodebase Relative) (Reference.fromString TermReference "#abc123")
                 in
                 Expect.equal expected (Route.fromUrl basePath url)
         , test "Matches with a root basePath prefix" <|
@@ -34,10 +184,20 @@ fromUrl =
                         "/"
 
                     expected =
-                        Route.ByReference (ByCodebase Relative) (Reference.fromString TermReference "#abc123")
+                        Route.Definition (ByCodebase Relative) (Reference.fromString TermReference "#abc123")
                 in
                 Expect.equal expected (Route.fromUrl basePath url)
         ]
+
+
+fqn : String -> FQN
+fqn =
+    FQN.fromString
+
+
+hash : String -> Maybe Hash
+hash =
+    Hash.fromUrlString
 
 
 mkUrl : String -> Url


### PR DESCRIPTION
## Overview
Add support for nicer urls with FQNs, both for namespaces and definitions.

## Implementation notes
Update the Route parser to be based on the Parser library instead of
Url.Parser, which allows more control over identifiers that span
multiple Url path segments like FQNs.

Additionally update various links to definitions to use FQNs instead of
hashes.
