### PR TITLE
Improve overflowing sidebar labels

### DIFF
--- a/src/CodebaseTree.elm
+++ b/src/CodebaseTree.elm
@@ -13,7 +13,6 @@ import Definition.Reference exposing (Reference(..))
 import Env exposing (Env)
 import FullyQualifiedName as FQN exposing (FQN, unqualifiedName)
 import FullyQualifiedNameSet as FQNSet exposing (FQNSet)
-import Hash
 import HashQualified exposing (HashQualified(..))
 import Html exposing (Html, a, div, h2, label, span, text)
 import Html.Attributes exposing (class, title)
@@ -177,9 +176,14 @@ viewListingRow clickMsg label_ category icon =
     in
     container
         [ Icon.view icon
-        , label [] [ text label_ ]
+        , viewListingLabel label_
         , span [ class "definition-category" ] [ text category ]
         ]
+
+
+viewListingLabel : String -> Html msg
+viewListingLabel label_ =
+    label [ title label_ ] [ text label_ ]
 
 
 viewDefinitionListing : DefinitionListing -> Html Msg
@@ -257,7 +261,7 @@ viewNamespaceListing expandedNamespaceListings (NamespaceListing _ fqn content) 
             , onClick (ToggleExpandedNamespaceListing fqn)
             ]
             [ Icon.caretRight |> Icon.withClassList [ ( "expanded", isExpanded ) ] |> Icon.view
-            , label [] [ text (unqualifiedName fqn) ]
+            , viewListingLabel (unqualifiedName fqn)
             ]
         , namespaceContent
         ]

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -159,6 +159,7 @@
   text-align: center;
   margin-right: 0.5rem;
   transition: transform 0.1s ease-out;
+  flex-shrink: 0;
 }
 
 .codebase-tree .namespace-tree .node .icon.expanded {
@@ -177,6 +178,8 @@
   color: var(--color-sidebar-fg);
   transition: all 0.2s;
   cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .codebase-tree .namespace-tree .node .definition-category {
@@ -184,6 +187,7 @@
   color: var(--color-sidebar-subtle-fg);
   margin-left: 0.375rem;
   font-size: 0.75rem;
+  margin-top: 0.25rem;
 }
 
 .codebase-tree .namespace-tree .node:hover label {


### PR DESCRIPTION
## Overview
Update sidebar to add ellipsis and a tooltip for overflowing items.
Also fix an alignment issue with the category text.

Fixes: https://github.com/unisonweb/codebase-ui/issues/147

## Loose ends
Note that the ideal behavior would be for the category to disappear when
the label is overflowing - this commit doesn't attempt to do that.