### PR TITLE
Enable Finder debounce for both Share and Local

### DIFF
--- a/src/Finder.elm
+++ b/src/Finder.elm
@@ -117,12 +117,7 @@ update : Env -> Msg -> Model -> ( Model, Cmd Msg, OutMsg )
 update env msg model =
     let
         debounceDelay =
-            case env.appContext of
-                UnisonShare ->
-                    300
-
-                Ucm ->
-                    0
+            300
 
         exit =
             ( model, Cmd.none, Exit )


### PR DESCRIPTION
## Overview
Unison Local search has gotten too slow to allow requests on each keystroke (see https://github.com/unisonweb/unison/issues/2045#issuecomment-897533515).

Enable the same debounce that exists on Unison Share for Unison Local.

## Notes
There are some slow downs that occurred when we switched to rootBranch—it seems that all requests with a rootBranch is about 2-3 sec slower than without—but even before this slow down, searches would take more than 1 sec.