### PR TITLE
FQN: Add support for special characters

### DIFF
--- a/src/HashQualified.elm
+++ b/src/HashQualified.elm
@@ -48,7 +48,7 @@ fromString str =
     str
         |> Hash.fromString
         |> Maybe.map HashOnly
-        |> MaybeE.orElse (hashQualifiedFromString Hash.prefix str)
+        |> MaybeE.orElse (hashQualifiedFromString FQN.fromString Hash.prefix str)
         |> Maybe.withDefault (NameOnly (FQN.fromString str))
 
 
@@ -57,7 +57,7 @@ fromUrlString str =
     str
         |> Hash.fromUrlString
         |> Maybe.map HashOnly
-        |> MaybeE.orElse (hashQualifiedFromString Hash.urlPrefix str)
+        |> MaybeE.orElse (hashQualifiedFromString FQN.fromUrlString Hash.urlPrefix str)
         |> Maybe.withDefault (NameOnly (FQN.fromUrlString str))
 
 
@@ -142,8 +142,8 @@ isRawHashQualified str =
     not (Hash.isRawHash str) && String.contains Hash.urlPrefix str
 
 
-hashQualifiedFromString : String -> String -> Maybe HashQualified
-hashQualifiedFromString sep str =
+hashQualifiedFromString : (String -> FQN) -> String -> String -> Maybe HashQualified
+hashQualifiedFromString toFQN sep str =
     if isRawHashQualified str then
         let
             parts =
@@ -161,7 +161,7 @@ hashQualifiedFromString sep str =
 
             name_ :: unprefixedHash :: [] ->
                 Hash.fromString (Hash.prefix ++ unprefixedHash)
-                    |> Maybe.map (HashQualified (FQN.fromString name_))
+                    |> Maybe.map (HashQualified (toFQN name_))
 
             _ ->
                 Nothing

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -152,13 +152,13 @@ toUrlString route =
         hqToPath hq =
             case hq of
                 NameOnly fqn ->
-                    NEL.toList (FQN.segments fqn)
+                    fqn |> FQN.toUrlSegments |> NEL.toList
 
                 HashOnly h ->
                     [ Hash.toUrlString h ]
 
                 HashQualified fqn h ->
-                    String.split "/" (FQN.toUrlString fqn ++ Hash.toUrlString h)
+                    NEL.toList (FQN.toUrlSegments fqn) ++ [ Hash.toUrlString h ]
 
         perspectiveParamsToPath pp includeNamespacesSuffix =
             case pp of

--- a/tests/HashQualifiedTests.elm
+++ b/tests/HashQualifiedTests.elm
@@ -71,20 +71,20 @@ fromUrlString =
                         Maybe.map HashQualified.HashOnly hash_
                 in
                 Expect.equal expected (Just (HashQualified.fromUrlString "@testhash"))
-        , test "HashQualified when called with a string and name" <|
+        , test "HashQualified when called with a name and hash" <|
             \_ ->
                 let
                     expected =
-                        Maybe.map (HashQualified.HashQualified name_) hash_
+                        Maybe.map (HashQualified.HashQualified urlName_) hash_
                 in
-                Expect.equal expected (Just (HashQualified.fromUrlString "test.name@testhash"))
+                Expect.equal expected (Just (HashQualified.fromUrlString "/test/;./name/@testhash"))
         , test "NameOnly when called with a name" <|
             \_ ->
                 let
                     expected =
-                        HashQualified.NameOnly name_
+                        HashQualified.NameOnly urlName_
                 in
-                Expect.equal expected (HashQualified.fromUrlString "test.name")
+                Expect.equal expected (HashQualified.fromUrlString "test/;./name")
         ]
 
 
@@ -95,6 +95,11 @@ fromUrlString =
 name_ : FQN
 name_ =
     FQN.fromString "test.name"
+
+
+urlName_ : FQN
+urlName_ =
+    FQN.fromString "test...name"
 
 
 hash_ : Maybe Hash


### PR DESCRIPTION
## Overview
* Support special characters in FQNs like `"."` and `"/"` and correctly parse
  them from the URL using URL encoding and a special Unison specific
  encoding with `";."` for `"."`.
* Also update the namespace/definition url separator from `"/-/"` to `"/;/"`.
* Add a bunch of parser test coverage.

This fixes https://github.com/unisonweb/codebase-ui/issues/196