### PR TITLE
Add a button in the sidebar to change perspective

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -166,6 +166,11 @@ update msg ({ env } as model) =
 
                         CodebaseTree.OpenDefinition ref ->
                             openDefinition model2 ref
+
+                        CodebaseTree.ChangePerspectiveToNamespace fqn ->
+                            fqn
+                                |> Perspective.toNamespacePerspective model.env.perspective
+                                |> replacePerspective model
             in
             ( model3, Cmd.batch [ cmd, Cmd.map CodebaseTreeMsg cCmd ] )
 

--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -3,6 +3,7 @@ module UI.Button exposing
     , Size(..)
     , Type(..)
     , button
+    , contained
     , danger
     , default
     , icon
@@ -16,6 +17,7 @@ module UI.Button exposing
     , primaryMono
     , share
     , small
+    , uncontained
     , view
     , withSize
     , withType
@@ -42,6 +44,7 @@ type alias Button msg =
     { action : Action msg
     , content : Content msg
     , type_ : Type
+    , color : Color
     , size : Size
     }
 
@@ -54,7 +57,8 @@ button : clickMsg -> String -> Button clickMsg
 button clickMsg label =
     { action = OnClick clickMsg
     , content = Label label
-    , type_ = Default
+    , type_ = Contained
+    , color = Default
     , size = Medium
     }
 
@@ -63,7 +67,8 @@ icon : msg -> I.Icon msg -> Button msg
 icon msg icon_ =
     { action = OnClick msg
     , content = Icon icon_
-    , type_ = Default
+    , type_ = Contained
+    , color = Default
     , size = Medium
     }
 
@@ -72,7 +77,8 @@ iconThenLabel : msg -> I.Icon msg -> String -> Button msg
 iconThenLabel msg icon_ label =
     { action = OnClick msg
     , content = IconThenLabel icon_ label
-    , type_ = Default
+    , type_ = Contained
+    , color = Default
     , size = Medium
     }
 
@@ -84,7 +90,8 @@ link : String -> String -> Button clickMsg
 link url label =
     { action = Href url
     , content = Label label
-    , type_ = Default
+    , type_ = Uncontained
+    , color = Default
     , size = Medium
     }
 
@@ -93,7 +100,8 @@ linkIcon : String -> I.Icon msg -> Button msg
 linkIcon url icon_ =
     { action = Href url
     , content = Icon icon_
-    , type_ = Default
+    , type_ = Uncontained
+    , color = Default
     , size = Medium
     }
 
@@ -102,13 +110,14 @@ linkIconThenLabel : String -> I.Icon msg -> String -> Button msg
 linkIconThenLabel url icon_ label =
     { action = Href url
     , content = IconThenLabel icon_ label
-    , type_ = Default
+    , type_ = Uncontained
+    , color = Default
     , size = Medium
     }
 
 
 view : Button clickMsg -> Html clickMsg
-view { content, type_, action, size } =
+view { content, type_, color, action, size } =
     let
         ( contentType, content_ ) =
             case content of
@@ -126,6 +135,7 @@ view { content, type_, action, size } =
             Html.button
                 [ class "button"
                 , class (typeToClassName type_)
+                , class (colorToClassName color)
                 , class (sizeToClassName size)
                 , class contentType
                 , onClick clickMsg
@@ -150,6 +160,11 @@ view { content, type_, action, size } =
 
 
 type Type
+    = Contained
+    | Uncontained
+
+
+type Color
     = Default
     | PrimaryMono
     | Primary
@@ -157,34 +172,49 @@ type Type
     | Danger
 
 
-default : Button clickMsg -> Button clickMsg
-default =
-    withType Default
+contained : Button clickMsg -> Button clickMsg
+contained button_ =
+    { button_ | type_ = Contained }
 
 
-primaryMono : Button clickMsg -> Button clickMsg
-primaryMono =
-    withType PrimaryMono
-
-
-primary : Button clickMsg -> Button clickMsg
-primary =
-    withType Primary
-
-
-share : Button clickMsg -> Button clickMsg
-share =
-    withType Share
-
-
-danger : Button clickMsg -> Button clickMsg
-danger =
-    withType Danger
+uncontained : Button clickMsg -> Button clickMsg
+uncontained button_ =
+    { button_ | type_ = Uncontained }
 
 
 withType : Type -> Button clickMsg -> Button clickMsg
 withType type_ button_ =
     { button_ | type_ = type_ }
+
+
+default : Button clickMsg -> Button clickMsg
+default =
+    withColor Default
+
+
+primaryMono : Button clickMsg -> Button clickMsg
+primaryMono =
+    withColor PrimaryMono
+
+
+primary : Button clickMsg -> Button clickMsg
+primary =
+    withColor Primary
+
+
+share : Button clickMsg -> Button clickMsg
+share =
+    withColor Share
+
+
+danger : Button clickMsg -> Button clickMsg
+danger =
+    withColor Danger
+
+
+withColor : Color -> Button clickMsg -> Button clickMsg
+withColor color_ button_ =
+    { button_ | color = color_ }
 
 
 
@@ -237,6 +267,16 @@ sizeToClassName size =
 typeToClassName : Type -> String
 typeToClassName type_ =
     case type_ of
+        Contained ->
+            "contained"
+
+        Uncontained ->
+            "uncontained"
+
+
+colorToClassName : Color -> String
+colorToClassName color =
+    case color of
         Default ->
             "default"
 

--- a/src/css/composites/codebase-tree.css
+++ b/src/css/composites/codebase-tree.css
@@ -70,12 +70,25 @@
   color: var(--color-sidebar-focus-fg);
 }
 
-.codebase-tree .namespace-tree .node label {
+.codebase-tree .namespace-tree .node > label {
   color: var(--color-sidebar-fg);
   transition: all 0.2s;
   cursor: pointer;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.codebase-tree .namespace-tree .node > .tooltip-trigger {
+  margin-left: auto;
+  opacity: 0;
+}
+
+.codebase-tree .namespace-tree .node:hover > .tooltip-trigger {
+  opacity: 1;
+}
+.codebase-tree .namespace-tree .node:hover .tooltip {
+  right: -0.3rem;
+  min-width: calc(var(--main-sidebar-width) - 1.5rem);
 }
 
 .codebase-tree .namespace-tree .node .definition-category {

--- a/src/css/elements/button.css
+++ b/src/css/elements/button.css
@@ -26,6 +26,8 @@ a.button:hover {
   transform: translate(0, 0.1rem);
 }
 
+/* -- Sizes ---------------------------------------------------------------- */
+
 .button.small {
   height: 1.5rem;
   font-size: var(--font-size-small);
@@ -65,86 +67,161 @@ a.button:hover {
   margin-right: 0.5rem;
 }
 
-.button.default {
+/* -- Contained & Colors --------------------------------------------------- */
+
+.button.contained.default {
   color: var(--color-button-default-fg);
   background: var(--color-button-default-bg);
 }
-.button.default .icon {
+.button.contained.default .icon {
   color: var(--color-button-default-fg);
 }
 
-.button.default:hover {
+.button.contained.default:hover {
   color: var(--color-button-default-hover-fg);
   background: var(--color-button-default-hover-bg);
 }
 
-.button.default:hover .icon {
+.button.contained.default:hover .icon {
   color: var(--color-button-default-hover-fg);
 }
 
-.button.primary-mono {
+.button.contained.primary-mono {
   color: var(--color-button-primary-mono-fg);
   background: var(--color-button-primary-mono-bg);
 }
 
-.button.primary-mono .icon {
+.button.contained.primary-mono .icon {
   color: var(--color-button-primary-mono-fg);
 }
 
-.button.primary-mono:hover {
+.button.contained.primary-mono:hover {
   color: var(--color-button-primary-mono-hover-fg);
   background: var(--color-button-primary-mono-hover-bg);
 }
-.button.primary-mono:hover .icon {
+.button.contained.primary-mono:hover .icon {
   color: var(--color-button-primary-mono-hover-fg);
 }
 
-.button.primary {
+.button.contained.primary {
   color: var(--color-button-primary-fg);
   background: var(--color-button-primary-bg);
 }
-.button.primary .icon {
+.button.contained.primary .icon {
   color: var(--color-button-primary-fg);
 }
 
-.button.primary:hover {
+.button.contained.primary:hover {
   color: var(--color-button-primary-hover-fg);
   background: var(--color-button-primary-hover-bg);
 }
-.button.primary:hover .icon {
+.button.contained.primary:hover .icon {
   color: var(--color-button-primary-hover-fg);
 }
 
-.button.share {
+.button.contained.share {
   color: var(--color-button-share-fg);
   background: var(--color-button-share-bg);
 }
 
-.button.share .icon {
+.button.contained.share .icon {
   color: var(--color-button-share-fg);
 }
 
-.button.share:hover {
+.button.contained.share:hover {
   color: var(--color-button-share-hover-fg);
   background: var(--color-button-share-hover-bg);
 }
 
-.button.share:hover .icon {
+.button.contained.share:hover .icon {
   color: var(--color-button-share-hover-fg);
 }
 
-.button.danger {
+.button.contained.danger {
   color: var(--color-button-danger-fg);
   background: var(--color-button-danger-bg);
 }
-.button.danger .icon {
+.button.contained.danger .icon {
   color: var(--color-button-danger-fg);
 }
 
-.button.danger:hover {
+.button.contained.danger:hover {
   color: var(--color-button-danger-fg);
   background: var(--color-button-danger-bg);
 }
-.button.danger:hover .icon {
+.button.contained.danger:hover .icon {
+  color: var(--color-button-danger-fg);
+}
+
+/* -- Uncontained & Colors ------------------------------------------------- */
+.button.uncontained {
+  background: transparent;
+}
+
+.button.uncontained.default,
+.button.uncontained.default .icon {
+  color: var(--color-button-default-fg);
+}
+
+.button.uncontained.default:hover {
+  color: var(--color-button-default-hover-fg);
+  background: var(--color-button-default-hover-bg);
+}
+
+.button.uncontained.default:hover .icon {
+  color: var(--color-button-default-hover-fg);
+}
+
+.button.uncontained.primary-mono,
+.button.uncontained.primary-mono .icon {
+  color: var(--color-button-primary-mono-fg);
+}
+
+.button.uncontained.primary-mono:hover {
+  color: var(--color-button-primary-mono-hover-fg);
+  background: var(--color-button-primary-mono-hover-bg);
+}
+
+.button.uncontained.primary-mono:hover .icon {
+  color: var(--color-button-primary-mono-hover-fg);
+}
+
+.button.uncontained.primary,
+.button.uncontained.primary .icon {
+  color: var(--color-button-primary-fg);
+}
+
+.button.uncontained.primary:hover {
+  color: var(--color-button-primary-hover-fg);
+  background: var(--color-button-primary-hover-bg);
+}
+.button.uncontained.primary:hover .icon {
+  color: var(--color-button-primary-hover-fg);
+}
+
+.button.uncontained.share,
+.button.uncontained.share .icon {
+  color: var(--color-button-share-fg);
+}
+
+.button.uncontained.share:hover {
+  color: var(--color-button-share-hover-fg);
+  background: var(--color-button-share-hover-bg);
+}
+
+.button.uncontained.share:hover .icon {
+  color: var(--color-button-share-hover-fg);
+}
+
+.button.uncontained.danger,
+.button.uncontained.danger .icon {
+  color: var(--color-button-danger-fg);
+}
+
+.button.uncontained.danger:hover {
+  color: var(--color-button-danger-fg);
+  background: var(--color-button-danger-bg);
+}
+.button.uncontained.danger:hover .icon {
   color: var(--color-button-danger-fg);
 }


### PR DESCRIPTION
## Overview

Add a small button on the right side of the sidebar on namespace items
that allows users to change the perspective to that namespace.

To support this add a new notion of buttons: "contained": regular
looking buttons, and "uncontained": buttons that have a transparent
background until hovered, a pattern seen most often in Google's Material
UI Design System.

<img width="263" alt="Screen Shot 2021-08-21 at 12 52 45" src="https://user-images.githubusercontent.com/2371/130329285-3c91ca22-ba0f-45f6-9621-3bd970841930.png">

## Loose ends
We show a `.` prefix quite often in FQNs and I'm not sure it does anything else but confuse users. Will need to look at this some more.

It's meant to indicate an absolute name, but they really are all relative to the perspective and we only deal in partial FQNs when we are also showing the remaining full FQN close by (like shortest suffix name for open definitions, which shows the namespace detail right next to it).