### PR TITLE
Don't include . prefix in FQN decode

### DIFF
--- a/src/Api.elm
+++ b/src/Api.elm
@@ -33,9 +33,13 @@ type Endpoint
     = Endpoint (List String) (List QueryParameter)
 
 
-list : PerspectiveParams -> String -> Endpoint
+list : PerspectiveParams -> Maybe String -> Endpoint
 list perspectiveParams fqnOrHash =
-    Endpoint [ "list" ] (string "namespace" fqnOrHash :: perspectiveParamsToQueryParams perspectiveParams)
+    let
+        namespace =
+            Maybe.withDefault "." fqnOrHash
+    in
+    Endpoint [ "list" ] (string "namespace" namespace :: perspectiveParamsToQueryParams perspectiveParams)
 
 
 getDefinition : Perspective -> List String -> Endpoint

--- a/src/CodebaseTree.elm
+++ b/src/CodebaseTree.elm
@@ -144,21 +144,17 @@ update env msg model =
 
 fetchRootNamespaceListing : Perspective -> ApiRequest NamespaceListing Msg
 fetchRootNamespaceListing perspective =
-    let
-        rootFqn =
-            FQN.fromString "."
-    in
-    fetchNamespaceListing perspective rootFqn FetchRootNamespaceListingFinished
+    fetchNamespaceListing perspective Nothing FetchRootNamespaceListingFinished
 
 
 fetchSubNamespaceListing : Perspective -> FQN -> ApiRequest NamespaceListing Msg
 fetchSubNamespaceListing perspective fqn =
-    fetchNamespaceListing perspective fqn (FetchSubNamespaceListingFinished fqn)
+    fetchNamespaceListing perspective (Just fqn) (FetchSubNamespaceListingFinished fqn)
 
 
-fetchNamespaceListing : Perspective -> FQN -> (Result Http.Error NamespaceListing -> msg) -> ApiRequest NamespaceListing msg
+fetchNamespaceListing : Perspective -> Maybe FQN -> (Result Http.Error NamespaceListing -> msg) -> ApiRequest NamespaceListing msg
 fetchNamespaceListing perspective fqn toMsg =
-    Api.list (Perspective.toParams perspective) (FQN.toString fqn)
+    Api.list (Perspective.toParams perspective) (Maybe.map FQN.toString fqn)
         |> Api.toRequest (NamespaceListing.decode fqn) toMsg
 
 

--- a/src/PreApp.elm
+++ b/src/PreApp.elm
@@ -63,7 +63,7 @@ init flags url navKey =
 
 fetchPerspective : PreEnv -> ApiRequest Perspective Msg
 fetchPerspective preEnv =
-    Api.list (ByCodebase Relative) "."
+    Api.list (ByCodebase Relative) (Just ".")
         |> Api.toRequest (Perspective.decode preEnv.perspectiveParams) (FetchPerspectiveFinished preEnv)
 
 


### PR DESCRIPTION
## Overview
Fix a problem with the way FQNs were being deserialized, such that
they'd always include a . prefix. This lead to some strange URLs and
didn't buy us anything and was removed.

Extracted from https://github.com/unisonweb/codebase-ui/pull/205