### PR TITLE
Fix github buttons not having background

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -383,7 +383,7 @@ viewPerspective env =
 
                 back =
                     Tooltip.tooltip
-                        (Button.icon (ChangePerspective (Codebase codebaseHash)) Icon.arrowLeftUp |> Button.small |> Button.view)
+                        (Button.icon (ChangePerspective (Codebase codebaseHash)) Icon.arrowLeftUp |> Button.small |> Button.uncontained |> Button.view)
                         (Tooltip.Text ("You're currently viewing a subset of " ++ context ++ " (" ++ fqnText ++ "), click to view everything."))
                         |> Tooltip.withArrow Tooltip.End
                         |> Tooltip.view
@@ -486,7 +486,10 @@ viewHelpModal os keyboardShortcut =
 
 githubLinkButton : String -> Html msg
 githubLinkButton repo =
-    Button.linkIconThenLabel ("https://github.com/" ++ repo) Icon.github repo |> Button.small |> Button.view
+    Button.linkIconThenLabel ("https://github.com/" ++ repo) Icon.github repo
+        |> Button.small
+        |> Button.contained
+        |> Button.view
 
 
 viewPublishModal : Html Msg

--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -129,30 +129,21 @@ view { content, type_, color, action, size } =
 
                 Label l ->
                     ( "content-label", [ text l ] )
+
+        attrs =
+            [ class "button"
+            , class (typeToClassName type_)
+            , class (colorToClassName color)
+            , class (sizeToClassName size)
+            , class contentType
+            ]
     in
     case action of
         OnClick clickMsg ->
-            Html.button
-                [ class "button"
-                , class (typeToClassName type_)
-                , class (colorToClassName color)
-                , class (sizeToClassName size)
-                , class contentType
-                , onClick clickMsg
-                ]
-                content_
+            Html.button (onClick clickMsg :: attrs) content_
 
         Href url ->
-            a
-                [ class "button"
-                , class (typeToClassName type_)
-                , class (sizeToClassName size)
-                , class contentType
-                , href url
-                , rel "noopener"
-                , target "_blank"
-                ]
-                content_
+            a (attrs ++ [ href url, rel "noopener", target "_blank" ]) content_
 
 
 

--- a/src/css/help-modal.css
+++ b/src/css/help-modal.css
@@ -28,6 +28,7 @@
 
 #help-modal .shortcuts h3 {
   height: 1.5rem;
+  margin-bottom: 1rem;
   display: flex;
   align-items: center;
 }


### PR DESCRIPTION
## Overview
The Github link buttons weren't rendered as contained (meaning it wasn't
getting a background). This caused weirdness in the ReportBugModal
and PublishModal.

Additional minor fixes:
* Make the "up" button on perspectives uncontained to make it feel
  lighter and have less attention.
* Fix h3 margin on help modal

Before
<img width="579" alt="Screen Shot 2021-09-02 at 11 32 54" src="https://user-images.githubusercontent.com/2371/131874413-86cc828e-f2eb-47eb-a28f-9645badea7e0.png">

After
<img width="589" alt="Screen Shot 2021-09-02 at 11 40 42" src="https://user-images.githubusercontent.com/2371/131874521-c6c98946-e02d-4450-aa05-91ab4c9a9cfe.png">
