### PR TITLE
Ensure that builtin hashes aren't shortened

### DIFF
--- a/src/Workspace/WorkspaceItem.elm
+++ b/src/Workspace/WorkspaceItem.elm
@@ -191,11 +191,11 @@ viewInfoItems hash_ info =
             else
                 UI.nothing
 
-        formatHash h =
-            h |> Hash.toString |> String.dropLeft 1 |> String.left 8
+        formattedHash =
+            hash_ |> Hash.toShortString |> Hash.stripHashPrefix
 
         hash =
-            Tooltip.tooltip (viewInfoItem Icon.hash (formatHash hash_)) (Tooltip.Text (Hash.toString hash_))
+            Tooltip.tooltip (viewInfoItem Icon.hash formattedHash) (Tooltip.Text (Hash.toString hash_))
                 |> Tooltip.withArrow Tooltip.Start
                 |> Tooltip.view
     in

--- a/tests/HashTests.elm
+++ b/tests/HashTests.elm
@@ -21,19 +21,56 @@ equals =
         ]
 
 
-toString : Test
-toString =
-    describe "Hash.toString"
-        [ test "Extracts the raw hash value" <|
+toShortString : Test
+toShortString =
+    describe "Hash.toShortString"
+        [ test "Returns a short version of the hash" <|
             \_ ->
                 let
                     result =
-                        "#foo"
+                        "#abc123def456"
                             |> Hash.fromString
-                            |> Maybe.map Hash.toString
+                            |> Maybe.map Hash.toShortString
                             |> Maybe.withDefault "fail"
                 in
-                Expect.equal "#foo" result
+                Expect.equal "#abc123de" result
+        , test "doesn't shorten for builtins" <|
+            \_ ->
+                let
+                    result =
+                        "##IO.socketSend.impl"
+                            |> Hash.fromString
+                            |> Maybe.map Hash.toShortString
+                            |> Maybe.withDefault "fail"
+                in
+                Expect.equal "##IO.socketSend.impl" result
+        ]
+
+
+stripHashPrefix : Test
+stripHashPrefix =
+    describe "Hash.stripHashPrefix"
+        [ test "removes the prefix of the hash" <|
+            \_ ->
+                let
+                    result =
+                        Hash.stripHashPrefix "#abc123def456"
+                in
+                Expect.equal "abc123def456" result
+        , test "removes both hash prefixes for builtins" <|
+            \_ ->
+                let
+                    result =
+                        Hash.stripHashPrefix "##IO.socketSend.impl"
+                in
+                Expect.equal "IO.socketSend.impl" result
+        , test "ignores non hashes" <|
+            \_ ->
+                let
+                    result =
+                        Hash.stripHashPrefix "thisis#not##ahash"
+                in
+                Expect.equal "thisis#not##ahash" result
         ]
 
 


### PR DESCRIPTION
## Overview
Fix a bug where hashes for builtins were being shorted when displayed in
for a WorkspaceItem such that `##IO.socketSend.impl` would become
`#IO.socke`.

<img width="555" alt="Screen Shot 2021-09-07 at 10 15 42" src="https://user-images.githubusercontent.com/2371/132360894-3dd6f6da-8433-4ab4-ad41-45fdc494a10e.png">

Fixes https://github.com/unisonweb/codebase-ui/issues/213#issuecomment-913222721

## Implementation notes
Added a few helper functions in the `Hash` module to make this a little more streamlined.