### PR TITLE
Use root relative FQNs in CodebaseTree perspective

### DIFF
--- a/src/FullyQualifiedName.elm
+++ b/src/FullyQualifiedName.elm
@@ -1,5 +1,6 @@
 module FullyQualifiedName exposing
     ( FQN
+    , append
     , decode
     , decodeFromParent
     , equals
@@ -162,6 +163,11 @@ namespace (FQN segments_) =
 equals : FQN -> FQN -> Bool
 equals a b =
     toString a == toString b
+
+
+append : FQN -> FQN -> FQN
+append (FQN a) (FQN b) =
+    FQN (NEL.append a b)
 
 
 {-| This is passed through a string as a suffix name can include

--- a/tests/FullyQualifiedNameTests.elm
+++ b/tests/FullyQualifiedNameTests.elm
@@ -6,6 +6,32 @@ import List.Nonempty as NEL
 import Test exposing (..)
 
 
+append : Test
+append =
+    describe "FullyQualifiedName.append"
+        [ test "Appends 2 FQNs" <|
+            \_ ->
+                let
+                    a =
+                        FQN.fromString "base"
+
+                    b =
+                        FQN.fromString "List"
+                in
+                Expect.equal [ "base", "List" ] (segments (FQN.append a b))
+        , test "Appending doesn't attempt to dedupe" <|
+            \_ ->
+                let
+                    a =
+                        FQN.fromString "base"
+
+                    b =
+                        FQN.fromString "base.List"
+                in
+                Expect.equal [ "base", "base", "List" ] (segments (FQN.append a b))
+        ]
+
+
 fromString : Test
 fromString =
     describe "FullyQualifiedName.fromString"


### PR DESCRIPTION
## Overview
Fix a bug that would use a relative to the current NamespacePerspective
FQN when setting the perspective to a sub namespace of the current
perspective, causing the codebase tree to appear blank (because it
requested a namespace listing with a partial FQN).

Fixes: https://github.com/unisonweb/codebase-ui/issues/216

## Implementation notes
Fix this by appending the current namespace perspective FQN with the new
one being set.