### PR TITLE
Enable folding definition source

### DIFF
--- a/src/Definition/Doc.elm
+++ b/src/Definition/Doc.elm
@@ -48,6 +48,7 @@ import Set exposing (Set)
 import Syntax exposing (Syntax)
 import TreePath exposing (TreePath)
 import UI
+import UI.FoldToggle as FoldToggle
 import UI.Icon as Icon
 import UI.Tooltip as Tooltip
 
@@ -222,18 +223,14 @@ viewFolded : List (Attribute msg) -> IsFolded msg -> Html msg
 viewFolded attrs isFolded_ =
     case isFolded_ of
         Disabled summary ->
-            div (class "folded is-folded disabled" :: attrs)
-                [ a [ class "fold-toggle" ] [ Icon.view Icon.caretDown ]
+            div (class "folded is-folded" :: attrs)
+                [ FoldToggle.disabled |> FoldToggle.view
                 , div [ class "folded-content" ] [ summary ]
                 ]
 
         IsFolded { toggleFoldMsg, content, foldId, isFolded } ->
             div (classList [ ( "folded", True ), ( "is-folded", isFolded ) ] :: attrs)
-                -- Caret orientation for folded/unfolded is rotated
-                -- by CSS such that it can be animated
-                [ a
-                    [ class "fold-toggle", onClick (toggleFoldMsg foldId) ]
-                    [ Icon.view Icon.caretDown ]
+                [ FoldToggle.foldToggle (toggleFoldMsg foldId) |> FoldToggle.isOpen (not isFolded) |> FoldToggle.view
                 , div [ class "folded-content" ] content
                 ]
 

--- a/src/Definition/Source.elm
+++ b/src/Definition/Source.elm
@@ -2,8 +2,10 @@ module Definition.Source exposing
     ( Source(..)
     , ViewConfig(..)
     , numTermLines
+    , numTermSignatureLines
     , numTypeLines
     , view
+    , viewNamedTermSignature
     , viewTermSignature
     , viewTermSource
     , viewTypeSource
@@ -51,8 +53,18 @@ numTermLines source =
         Term.Source _ syntax ->
             Syntax.numLines syntax
 
-        Term.Builtin (TermSignature syntax) ->
-            Syntax.numLines syntax
+        Term.Builtin (TermSignature signature) ->
+            Syntax.numLines signature
+
+
+numTermSignatureLines : TermSource -> Int
+numTermSignatureLines source =
+    case source of
+        Term.Source (TermSignature signature) _ ->
+            Syntax.numLines signature
+
+        Term.Builtin (TermSignature signature) ->
+            Syntax.numLines signature
 
 
 
@@ -92,6 +104,21 @@ viewTermSignature viewConfig (TermSignature syntax) =
     viewCode viewConfig (viewSyntax viewConfig syntax)
 
 
+viewNamedTermSignature : ViewConfig msg -> String -> TermSignature -> Html msg
+viewNamedTermSignature viewConfig termName signature =
+    viewCode viewConfig (viewNamedTermSignature_ viewConfig termName signature)
+
+
+viewNamedTermSignature_ : ViewConfig msg -> String -> TermSignature -> Html msg
+viewNamedTermSignature_ viewConfig termName (TermSignature syntax) =
+    span
+        []
+        [ span [ class "hash-qualifier" ] [ text termName ]
+        , span [ class "type-ascription-colon" ] [ text " : " ]
+        , viewSyntax viewConfig syntax
+        ]
+
+
 viewTermSource : ViewConfig msg -> String -> TermSource -> Html msg
 viewTermSource viewConfig termName source =
     let
@@ -100,13 +127,8 @@ viewTermSource viewConfig termName source =
                 Term.Source _ syntax ->
                     viewSyntax viewConfig syntax
 
-                Term.Builtin (TermSignature syntax) ->
-                    span
-                        []
-                        [ span [ class "hash-qualifier" ] [ text termName ]
-                        , span [ class "type-ascription-colon" ] [ text " : " ]
-                        , viewSyntax viewConfig syntax
-                        ]
+                Term.Builtin signature ->
+                    viewNamedTermSignature viewConfig termName signature
     in
     viewCode viewConfig content
 

--- a/src/Definition/Term.elm
+++ b/src/Definition/Term.elm
@@ -9,6 +9,7 @@ module Definition.Term exposing
     , decodeSignature
     , decodeTermCategory
     , decodeTermSource
+    , termSignature
     )
 
 import Definition.Info exposing (Info)
@@ -57,6 +58,20 @@ type alias TermSummary =
 
 type alias TermListing =
     Term FQN
+
+
+
+-- HELPERS
+
+
+termSignature : TermSource -> TermSignature
+termSignature source =
+    case source of
+        Source sig _ ->
+            sig
+
+        Builtin sig ->
+            sig
 
 
 

--- a/src/UI/FoldToggle.elm
+++ b/src/UI/FoldToggle.elm
@@ -1,0 +1,108 @@
+module UI.FoldToggle exposing (..)
+
+import Html exposing (Html, div)
+import Html.Attributes exposing (classList)
+import Html.Events exposing (onClick)
+import UI.Icon as Icon
+
+
+type Position
+    = Opened
+    | Closed
+
+
+type Toggleable msg
+    = OnToggle msg
+    | Disabled
+
+
+type alias FoldToggle msg =
+    { toggleable : Toggleable msg
+    , position : Position
+    }
+
+
+
+-- CREATE
+
+
+foldToggle : msg -> FoldToggle msg
+foldToggle toggleMsg =
+    FoldToggle (OnToggle toggleMsg) Closed
+
+
+disabled : FoldToggle msg
+disabled =
+    FoldToggle Disabled Closed
+
+
+
+-- MODIFY
+
+
+withPosition : Position -> FoldToggle msg -> FoldToggle msg
+withPosition position toggle =
+    { toggle | position = position }
+
+
+withToggleable : Toggleable msg -> FoldToggle msg -> FoldToggle msg
+withToggleable toggleable toggle =
+    { toggle | toggleable = toggleable }
+
+
+isOpen : Bool -> FoldToggle msg -> FoldToggle msg
+isOpen isOpen_ toggle =
+    let
+        position =
+            if isOpen_ then
+                Opened
+
+            else
+                Closed
+    in
+    { toggle | position = position }
+
+
+open : FoldToggle msg -> FoldToggle msg
+open toggle =
+    withPosition Opened toggle
+
+
+isDisabled : Bool -> FoldToggle msg -> FoldToggle msg
+isDisabled isDisabled_ toggle =
+    if isDisabled_ then
+        withToggleable Disabled toggle
+
+    else
+        toggle
+
+
+
+-- VIEW
+
+
+view : FoldToggle msg -> Html msg
+view toggle =
+    let
+        isOpen_ =
+            toggle.position == Opened
+
+        ( onClickAttrs, isDisabled_ ) =
+            case toggle.toggleable of
+                OnToggle msg ->
+                    ( [ onClick msg ], False )
+
+                Disabled ->
+                    ( [], True )
+    in
+    div
+        (classList
+            [ ( "fold-toggle", True )
+            , ( "folded-open", isOpen_ )
+            , ( "disabled", isDisabled_ )
+            ]
+            :: onClickAttrs
+        )
+        -- Caret orientation for folded/unfolded is rotated
+        -- by CSS such that it can be animated
+        [ Icon.view Icon.caretRight ]

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -100,9 +100,17 @@ update env msg ({ workspaceItems } as model) =
                             WorkspaceItem.Failure ref e
 
                         Ok i ->
+                            let
+                                zoom =
+                                    if WorkspaceItem.isDocItem i then
+                                        Zoom.Medium
+
+                                    else
+                                        Zoom.Near
+                            in
                             WorkspaceItem.Success ref
                                 { item = i
-                                , zoom = Zoom.Medium
+                                , zoom = zoom
                                 , docFoldToggles = Doc.emptyDocFoldToggles
                                 }
 

--- a/src/Workspace/Zoom.elm
+++ b/src/Workspace/Zoom.elm
@@ -14,8 +14,7 @@ cycle z =
             Medium
 
         Medium ->
-            -- TODO: Support source zoom
-            Far
+            Near
 
         Near ->
             Far

--- a/src/css/definition-doc.css
+++ b/src/css/definition-doc.css
@@ -19,6 +19,7 @@
   --color-doc-subtle-fg: var(--color-doc-focus-subtle-fg);
   --color-doc-source-bg: var(--color-doc-focus-source-bg);
   --color-doc-source-mg: var(--color-doc-focus-source-mg);
+  --color-doc-fold-hover-fg: var(--color-doc-focus-fold-hover-fg);
   --color-doc-fold-hover-bg: var(--color-doc-focus-fold-hover-bg);
   --color-doc-link: var(--color-doc-focus-link);
   --color-doc-link-active: var(--color-doc-focus-link-active);
@@ -43,6 +44,10 @@
   scrollbar-width: auto;
   scrollbar-color: var(--color-workspace-item-subtle-fg) transparent;
   overflow: auto;
+}
+
+.definition-doc .folded-sources .source {
+  padding: 0.5rem;
 }
 
 .definition-doc .source.code::-webkit-scrollbar,
@@ -202,11 +207,6 @@
   white-space: wrap;
 }
 
-.definition-doc aside .source:last-child,
-.definition-doc aside p:last-child {
-  margin-bottom: 0;
-}
-
 .definition-doc .callout {
   background: var(--color-doc-callout-bg);
   padding: 0.5rem 0.75rem;
@@ -218,15 +218,6 @@
 
 .definition-doc .callout.callout-with-icon .callout-content {
   padding-top: 1px;
-}
-
-.definition-doc .callout .callout-content > section:first-child {
-  margin: 0;
-}
-
-.definition-doc .callout .source:last-child,
-.definition-doc .callout p:last-child {
-  margin-bottom: 0;
 }
 
 .definition-doc .callout .callout-icon {
@@ -249,58 +240,6 @@
   margin-bottom: 1rem;
   display: flex;
   flex-direction: row;
-}
-
-.definition-doc .folded .fold-toggle {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  margin-right: 0.25rem;
-  width: 1.2rem;
-  height: 1.2rem;
-  line-height: 1rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--border-radius-base);
-  transition: all 0.2s;
-}
-
-.definition-doc .folded .icon {
-  color: var(--color-doc-subtle-fg);
-}
-
-.definition-doc .folded .fold-toggle:hover {
-  text-decoration: none;
-}
-
-.definition-doc .folded:not(.disabled) .fold-toggle:hover {
-  background: var(--color-doc-subtle-bg);
-}
-.definition-doc .folded:not(.disabled) .fold-toggle:hover .icon {
-  color: var(--color-doc-subtle-fg);
-}
-
-.definition-doc
-  .source.folded:not(.disabled)
-  .fold-toggle:hover
-  .fold-toggle-indicator {
-  background: var(--color-doc-fold-hover-bg);
-}
-
-.definition-doc .folded .icon {
-  font-size: 1rem;
-  cursor: pointer;
-  transition: transform 0.1s ease-out;
-}
-
-.definition-doc .folded.disabled .icon {
-  cursor: inherit;
-  opacity: 0.5;
-}
-
-.definition-doc .folded.is-folded .icon {
-  transform: rotate(-90deg);
 }
 
 .definition-doc .folded .folded-content {
@@ -338,9 +277,20 @@
   margin-bottom: 1em;
 }
 
+.definition-doc ol:last-child,
+.definition-doc ul:last-child {
+  margin-bottom: 0;
+}
+
 .definition-doc section {
   margin-bottom: 1rem;
   margin-top: 1rem;
+}
+.definition-doc section:first-child {
+  margin-top: 0;
+}
+.definition-doc section:last-child {
+  margin-bottom: 0;
 }
 
 :is(.definition-doc h1, .definition-doc h2, .definition-doc h3, .definition-doc
@@ -353,6 +303,9 @@
   font-size: 1.25rem;
   margin-top: 1.5rem;
   margin-bottom: 0.75rem;
+}
+.definition-doc h1:first-child {
+  margin-top: 0;
 }
 
 .definition-doc h2 {
@@ -383,25 +336,6 @@
   font-size: 0.875rem;
   margin-top: 1.25rem;
   margin-bottom: 0.5rem;
-}
-
-/* A bunch of margin-top reset to deal with the very top of the doc. We don't
- * want any margin there and there might be a strange combination of sections
- * */
-.definition-doc > section:first-child,
-.definition-doc > section:first-child > section:first-child,
-.definition-doc
-  > section:first-child
-  > section:first-child
-  > section:first-child,
-.definition-doc > section:first-child > h1:first-child,
-.definition-doc > section:first-child > section:first-child > h1:first-child,
-.definition-doc
-  > section:first-child
-  > section:first-child
-  > section:first-child
-  > h1:first-child {
-  margin-top: 0;
 }
 
 .definition-doc img {

--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -181,3 +181,4 @@ hr {
 @import "./elements/icon.css";
 @import "./elements/button.css";
 @import "./elements/tooltip.css";
+@import "./elements/fold-toggle.css";

--- a/src/css/elements/fold-toggle.css
+++ b/src/css/elements/fold-toggle.css
@@ -1,0 +1,38 @@
+.fold-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-right: 0.25rem;
+  line-height: 1;
+  border-radius: var(--border-radius-base);
+  transition: all 0.2s;
+  cursor: pointer;
+  background: var(--color-fold-toggle-bg);
+}
+
+.fold-toggle.disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+/* ▶ */
+.fold-toggle .icon {
+  color: var(--color-fold-toggle-fg);
+  transition: color 0.2s, transform 0.1s ease-out;
+}
+
+/* rotate ▶ to ▼ */
+.fold-toggle.folded-open {
+  transform: rotate(90deg);
+}
+
+.fold-toggle:not(.disabled):hover {
+  background: var(--color-fold-toggle-hover-bg);
+}
+
+.fold-toggle:not(.disabled):hover .icon {
+  color: var(--color-fold-toggle-hover-fg);
+}

--- a/src/css/themes/unison/colors.css
+++ b/src/css/themes/unison/colors.css
@@ -37,6 +37,8 @@
   --color-blue-1: #225ebe;
   --color-blue-2: #5695f4;
   --color-blue-3: #9ec5ff;
+  --color-blue-4: #cbe0ff;
+  --color-blue-5: #ecf2fa;
 
   /* Oranges */
   --color-orange-1: #ff8800;

--- a/src/css/themes/unison/light.css
+++ b/src/css/themes/unison/light.css
@@ -88,10 +88,11 @@
   --color-doc-bg: var(--color-gray-lighten-100);
   --color-doc-aside-bg: var(--color-gray-lighten-60);
   --color-doc-aside-source-bg: var(--color-gray-lighten-55);
-  --color-doc-callout-bg: var(--color-gray-lighten-55);
+  --color-doc-callout-bg: var(--color-blue-5);
   --color-doc-subtle-fg: var(--color-gray-lighten-30);
   --color-doc-source-bg: var(--color-gray-lighten-60);
   --color-doc-source-mg: var(--color-gray-lighten-45);
+  --color-doc-fold-hover-fg: var(--color-gray-base);
   --color-doc-fold-hover-bg: var(--color-gray-lighten-45);
   --color-doc-link: var(--color-blue-1);
   --color-doc-link-active: var(--color-pink-1);
@@ -102,10 +103,11 @@
   --color-doc-focus-bg: var(--color-gray-lighten-60);
   --color-doc-focus-aside-bg: var(--color-gray-lighten-55);
   --color-doc-focus-aside-source-bg: var(--color-gray-lighten-50);
-  --color-doc-focus-callout-bg: var(--color-gray-lighten-50);
+  --color-doc-focus-callout-bg: var(--color-blue-5);
   --color-doc-focus-subtle-fg: var(--color-gray-lighten-30);
   --color-doc-focus-source-bg: var(--color-gray-lighten-55);
   --color-doc-focus-source-mg: var(--color-gray-lighten-45);
+  --color-doc-focus-fold-hover-fg: var(--color-gray-base);
   --color-doc-focus-fold-hover-bg: var(--color-gray-lighten-45);
   --color-doc-focus-link: var(--color-blue-1);
   --color-doc-focus-link-active: var(--color-pink-1);
@@ -143,6 +145,13 @@
   --color-icon-ability-constructor: var(--color-pink-1);
   --color-icon-doc: var(--color-orange-2);
   --color-icon-patch: var(--color-blue-2);
+
+  /* FoldToggle */
+
+  --color-fold-toggle-fg: var(--color-gray-lighten-30);
+  --color-fold-toggle-bg: transparent;
+  --color-fold-toggle-hover-fg: var(--color-gray-base);
+  --color-fold-toggle-hover-bg: var(--color-gray-lighten-45);
 
   /* Buttons */
 

--- a/src/css/workspace-item.css
+++ b/src/css/workspace-item.css
@@ -18,16 +18,11 @@
   flex-direction: row;
 }
 
-.workspace-item .icon.caret-right {
-  color: var(--color-workspace-item-subtle-fg);
-  transition: color 0.2s, transform 0.1s ease-out;
-}
-
 .workspace-item .gutter {
   display: flex;
   justify-content: center;
   width: 2rem;
-  margin-right: 0.375rem;
+  margin-right: 0.25rem;
   color: var(--color-workspace-item-subtle-fg);
 }
 
@@ -88,30 +83,17 @@
   height: 1.5rem;
 }
 
-.workspace-item header .toggle-zoom {
-  display: flex;
-  flex-direction: row;
+.workspace-item header .fold-toggle {
+  margin: 0;
+}
+
+.workspace-item header .category-icon {
+  display: inline-flex;
   align-items: center;
-  height: 1.5rem;
-}
-
-.workspace-item header .toggle-zoom:hover {
-  text-decoration: none;
-}
-.workspace-item header .toggle-zoom:hover .icon.caret-right {
-  color: var(--color-workspace-item-subtle-fg);
-}
-
-.workspace-item header .info .toggle-zoom .icon {
-  margin-right: 0.375rem;
-}
-
-.workspace-item header .info .toggle-zoom .icon.caret-right {
-  margin-right: 0.25rem;
-}
-
-.workspace-item header .icon.caret-right:hover {
-  color: red;
+  justify-content: center;
+  flex-direction: row;
+  width: 1.5rem;
+  line-height: 1;
 }
 
 .workspace-item header .info .name {
@@ -202,14 +184,13 @@
 
 .workspace-item .content .workspace-item-definition-doc {
   margin-bottom: 1.5rem;
-  margin-left: 1.25rem;
-  width: calc(var(--workspace-content-width) - 1.25rem);
+  padding-left: 1.5rem;
+  width: var(--workspace-content-width);
 }
 
 .workspace-item .content .built-in {
   margin-bottom: 1.5rem;
-  /* TODO: Renable with source toggle */
-  /*margin-left: 1.25rem;*/
+  margin-left: 1.25rem;
 }
 
 .workspace-item .content .badge {
@@ -217,41 +198,36 @@
 }
 
 .workspace-item .content .definition-source {
+  position: relative;
+  padding-left: 1.5rem;
   display: flex;
   flex-direction: row;
   background: var(--color-workspace-item-source-bg);
+  border-radius: var(--border-radius-base);
   width: var(--workspace-content-width);
   overflow: auto;
   scrollbar-width: auto;
   scrollbar-color: var(--color-workspace-item-subtle-fg) transparent;
 }
+
+.workspace-item .content .definition-source .fold-toggle {
+  position: absolute;
+  left: 0;
+  top: 1px;
+}
+
 .workspace-item .content .definition-source::-webkit-scrollbar {
+  width: 0.25rem;
   height: 0.375rem;
 }
+
 .workspace-item .content .definition-source::-webkit-scrollbar-track {
   background: transparent;
 }
+
 .workspace-item .content .definition-source::-webkit-scrollbar-thumb {
   background-color: var(--color-workspace-item-subtle-fg);
   border-radius: var(--border-radius-base);
-}
-
-.workspace-item .content .definition-source .source-toggle {
-  height: 1.5rem;
-  display: flex;
-  align-items: center;
-  margin-right: 0.375rem;
-  padding-top: 0.1rem;
-  /* TODO: Renable source toggle */
-  display: none;
-}
-
-.workspace-item .content .definition-source .source-toggle .icon {
-  color: var(--color-workspace-item-subtle-fg);
-}
-
-.workspace-item .content .definition-source .source-toggle.disabled {
-  opacity: 0.5;
 }
 
 /* Definition Row: Loading */
@@ -279,19 +255,6 @@
 .workspace-item.zoom-level-far .content {
   opacity: 0;
   height: 0;
-}
-
-.workspace-item.zoom-level-medium .info .icon.caret-right {
-  transform: rotate(90deg);
-}
-
-.workspace-item.zoom-level-medium .source-detail {
-  opacity: 0;
-  height: 0;
-}
-
-.workspace-item.zoom-level-near .source .icon.caret-right {
-  transform: rotate(90deg);
 }
 
 /* When .workspace-item is focused and has a
@@ -334,6 +297,6 @@
 
   .workspace-item .content .definition-source {
     width: calc(100vw - 2rem);
-    overflow: scroll;
+    overflow: auto;
   }
 }

--- a/src/css/workspace.css
+++ b/src/css/workspace.css
@@ -7,7 +7,7 @@
   color: var(--color-workspace-fg);
 
   --workspace-toolbar-height: 3.5rem;
-  --workspace-content-width: 43rem;
+  --workspace-content-width: 45.5rem;
 }
 
 #workspace-toolbar {
@@ -41,6 +41,7 @@
 
 #workspace-content::-webkit-scrollbar {
   width: 0.5rem;
+  height: 0.5rem;
 }
 
 #workspace-content::-webkit-scrollbar-track {


### PR DESCRIPTION
## Overview
Add a new FoldToggle UI module to consolidate various folding mechanisms
and use it in docs, source, and the main definition fold.

https://user-images.githubusercontent.com/2371/133824670-6f5df016-fa0f-419d-847a-67ad6386af5a.mp4

Closes https://github.com/unisonweb/codebase-ui/issues/112

## Implementation notes
With this definition source can now be folded and is part of the Zoom
cycle. Most definitions start with their source folded open, except for
docs that start with it closed.

Also clean up how margins are handled for first and last elements in
docs.

## Lose ends
This doesn't support collapsing types. There's some work @pchiusano did to summaries types and abilities that need to be ported to the `/getDefinition` endpoint.