### PR TITLE
Fix: When changing perspective, the tree is blank

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -15,6 +15,7 @@
             "elm/regex": "1.0.0",
             "elm/svg": "1.0.1",
             "elm/url": "1.0.0",
+            "elm-community/html-extra": "3.4.0",
             "elm-community/json-extra": "4.3.0",
             "elm-community/list-extra": "8.2.4",
             "elm-community/maybe-extra": "5.2.0",

--- a/src/CodebaseTree.elm
+++ b/src/CodebaseTree.elm
@@ -277,6 +277,7 @@ viewNamespaceListing expandedNamespaceListings (NamespaceListing _ name content)
 
         changePerspectiveTo =
             Button.icon (Out (ChangePerspectiveToNamespace name)) Icon.intoFolder
+                |> Button.stopPropagation
                 |> Button.uncontained
                 |> Button.small
                 |> Button.view


### PR DESCRIPTION
## Overview
Fix a bug that happened when changing the perspective and resulting the
in codebase tree in the sidebar to be blank right after. This was due
to both the change perspective click and the expand namespace events
were fired and the bug would happened conditionally on which request
would finish first.

Closes https://github.com/unisonweb/codebase-ui/issues/224

## Implementation notes
Fix this by adding stopPropagation to the change perspective click via
extensions to the Button module to support configurations off this kind.