### PR TITLE
Unison Local Fix: Can't open definitions

### DIFF
--- a/tests/RouteTests.elm
+++ b/tests/RouteTests.elm
@@ -188,7 +188,7 @@ fromUrlBasePath =
             \_ ->
                 let
                     url =
-                        mkUrl "/latest/terms/@abc123"
+                        mkUrl "/some-token/ui/latest/terms/@abc123"
 
                     basePath =
                         "/some-token/ui/"


### PR DESCRIPTION
## Overview

Fixes https://github.com/unisonweb/codebase-ui/issues/230

In environments like Unison Local, the UI is served with a base path.

This means that a route to a definition might look like:

- `"/:some-token/ui/latest/terms/base/List/map"`
    (where `"/:some-token/ui/"` is the base path.)

The base path is determined outside of the Elm app using the `<base>`  tag in the `<head>` section of the document. The Browser uses this tag to prefix all links.

The base path must end in a slash for links to work correctly, but our parser expects a path to starts with a slash.

The bug in question was due to a recent change in the url parser that now expects a starting slash. This meant opening a definition would load it and change the URL, but the parser wouldn't match the right route and continue to show the empty state, the `Perspective` route, instead of the `Definition` route.

## Implementation notes
To fix this we now ensure that there's always a slash in the beginning of the path before parsing.