### PR TITLE
Change the order of items to show code on top

### DIFF
--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -98,19 +98,7 @@ update env msg ({ workspaceItems } as model) =
                             WorkspaceItem.Failure ref e
 
                         Ok i ->
-                            let
-                                zoom =
-                                    if WorkspaceItem.isDocItem i then
-                                        Zoom.Medium
-
-                                    else
-                                        Zoom.Near
-                            in
-                            WorkspaceItem.Success ref
-                                { item = i
-                                , zoom = zoom
-                                , docFoldToggles = Doc.emptyDocFoldToggles
-                                }
+                            WorkspaceItem.fromItem ref i
 
                 nextWorkspaceItems =
                     WorkspaceItems.replace workspaceItems ref workspaceItem

--- a/src/css/workspace-item.css
+++ b/src/css/workspace-item.css
@@ -179,7 +179,6 @@
 }
 
 .workspace-item .content .workspace-item-definition-doc {
-  margin-bottom: 1.5rem;
   padding-left: 1.5rem;
   width: var(--workspace-content-width);
 }
@@ -196,6 +195,7 @@
 .workspace-item .content .definition-source {
   position: relative;
   padding-left: 1.5rem;
+  margin-bottom: 1.5rem;
   display: flex;
   flex-direction: row;
   background: var(--color-workspace-item-source-bg);


### PR DESCRIPTION
## Overview
Move the code to the top of workspace items and adjust the rules for
when the source is folded or not:

1. If the definition is a Doc, fold the source
2. If the definition has a Doc, fold the source
3. Otherwise unfold the source and show it in full

<img width="1252" alt="Screen Shot 2021-10-04 at 15 03 43" src="https://user-images.githubusercontent.com/2371/135909379-d736cf4f-94a8-4d52-956c-d21bf6eab40e.png">

Closes https://github.com/unisonweb/codebase-ui/issues/222
