### PR TITLE
Crop long definition docs

### DIFF
--- a/src/Workspace/WorkspaceItems.elm
+++ b/src/Workspace/WorkspaceItems.elm
@@ -399,6 +399,28 @@ prev items =
 -- TRANFORM
 
 
+updateData :
+    (WorkspaceItem.ItemData -> WorkspaceItem.ItemData)
+    -> Reference
+    -> WorkspaceItems
+    -> WorkspaceItems
+updateData f ref wItems =
+    let
+        update_ workspaceItem =
+            case workspaceItem of
+                WorkspaceItem.Success r d ->
+                    if ref == r then
+                        WorkspaceItem.Success r (f d)
+
+                    else
+                        workspaceItem
+
+                _ ->
+                    workspaceItem
+    in
+    map update_ wItems
+
+
 map :
     (WorkspaceItem -> WorkspaceItem)
     -> WorkspaceItems

--- a/src/css/definition-doc.css
+++ b/src/css/definition-doc.css
@@ -306,6 +306,7 @@
 }
 .definition-doc h1:first-child {
   margin-top: 0;
+  line-height: 1.1;
 }
 
 .definition-doc h2 {

--- a/src/css/themes/unison/light.css
+++ b/src/css/themes/unison/light.css
@@ -68,6 +68,12 @@
   --color-workspace-item-fg: var(--color-gray-darken-30);
   --color-workspace-item-mg: var(--color-gray-lighten-60);
   --color-workspace-item-bg: var(--color-gray-lighten-100);
+  --color-workspace-item-bg-faded: rgba(
+    255,
+    255,
+    255,
+    0.5
+  ); /* 50% gray-lighten-100 */
   --color-workspace-item-source-bg: transparent;
   --color-workspace-item-subtle-fg: var(--color-gray-lighten-30);
   --color-workspace-item-subtle-bg: var(--color-gray-lighten-60);
@@ -85,6 +91,12 @@
   --color-workspace-item-focus-mg: var(--color-gray-lighten-55);
   --color-workspace-item-focus-source-bg: transparent;
   --color-workspace-item-focus-bg: var(--color-gray-lighten-60);
+  --color-workspace-item-focus-bg-faded: rgba(
+    250,
+    250,
+    251,
+    0.5
+  ); /* 50% gray-lighten-60 */
   --color-workspace-item-focus-bg-em: var(--color-gray-lighten-50);
   --color-workspace-item-focus-content-border: var(--color-gray-lighten-50);
   --color-workspace-item-focus-border: var(--color-gray-lighten-50);

--- a/src/css/themes/unison/light.css
+++ b/src/css/themes/unison/light.css
@@ -88,6 +88,8 @@
   --color-workspace-item-focus-bg-em: var(--color-gray-lighten-50);
   --color-workspace-item-focus-content-border: var(--color-gray-lighten-50);
   --color-workspace-item-focus-border: var(--color-gray-lighten-50);
+  --color-workspace-item-cropped-control-border: var(--color-gray-lighten-30);
+  --color-workspace-item-cropped-control-shadow: var(--color-gray-lighten-45);
 
   --color-doc-fg: var(--color-gray-darken-30);
   --color-doc-bg: var(--color-gray-lighten-100);

--- a/src/css/workspace-item.css
+++ b/src/css/workspace-item.css
@@ -195,6 +195,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-shrink: 0;
   width: 1.25rem;
   height: 1.25rem;
   margin-right: 0.25rem;
@@ -220,37 +221,24 @@
 .workspace-item .content .workspace-item-definition-doc .show-full-doc {
   position: relative;
   background: var(--color-workspace-item-bg);
-  padding: 1rem 1.5rem;
+  padding: 0 1.5rem;
 }
 
-/* Gradient border */
-.workspace-item .content .workspace-item-definition-doc .show-full-doc:after {
-  position: absolute;
-  top: -1px;
-  left: 0;
-  right: 0;
-  content: " ";
-  height: 1px;
-  background: linear-gradient(
-    90deg,
-    var(--color-workspace-item-bg) 0%,
-    var(--color-workspace-item-cropped-control-border) 20%,
-    var(--color-workspace-item-bg) 80%,
-    var(--color-workspace-item-bg) 100%
-  );
-}
-/* Shadow */
+/* overlapping gradient for the content to peek out behind, indicating more is
+ * below the fold */
 .workspace-item .content .workspace-item-definition-doc .show-full-doc:before {
   position: absolute;
-  top: -16px;
+  top: -4.5rem;
   left: 0;
   right: 0;
-  content: " ";
-  height: 1rem;
-  background: radial-gradient(
-    ellipse at 16.6rem bottom,
-    var(--color-workspace-item-cropped-control-shadow) 0%,
-    transparent 50%
+  content: "";
+  margin: 0;
+  height: 4.5rem;
+  background: linear-gradient(
+    0deg,
+    var(--color-workspace-item-bg) 20%,
+    var(--color-workspace-item-bg-faded) 80%,
+    rgba(255, 255, 255, 0)
   );
 }
 
@@ -333,6 +321,7 @@
 .workspace-item.focused {
   --color-workspace-item-fg: var(--color-workspace-item-focus-fg);
   --color-workspace-item-bg: var(--color-workspace-item-focus-bg);
+  --color-workspace-item-bg-faded: var(--color-workspace-item-focus-bg-faded);
   --color-workspace-item-subtle-fg: var(--color-workspace-item-focus-subtle-fg);
   --color-workspace-item-subtle-bg: var(--color-workspace-item-focus-subtle-bg);
   --color-workspace-item-content-border: var(

--- a/src/css/workspace-item.css
+++ b/src/css/workspace-item.css
@@ -1,4 +1,4 @@
-/* -- WorkspaceItem ---------------------------------------------------------- */
+/* -- WorkspaceItem -------------------------------------------------------- */
 
 .workspace-item {
   position: relative;
@@ -179,8 +179,79 @@
 }
 
 .workspace-item .content .workspace-item-definition-doc {
-  padding-left: 1.5rem;
   width: var(--workspace-content-width);
+}
+
+.workspace-item
+  .content
+  .workspace-item-definition-doc
+  .definition-doc-columns {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+}
+
+.workspace-item .content .workspace-item-definition-doc .icon-column {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-right: 0.25rem;
+}
+
+.workspace-item .content .workspace-item-definition-doc .icon-column .icon.doc {
+  color: var(--color-workspace-item-subtle-fg);
+}
+
+.workspace-item .content .workspace-item-definition-doc .doc-column {
+  max-height: 12rem;
+  overflow: hidden;
+}
+
+.workspace-item
+  .content
+  .workspace-item-definition-doc.shown-in-full
+  .doc-column {
+  overflow: visible;
+  max-height: fit-content;
+}
+
+.workspace-item .content .workspace-item-definition-doc .show-full-doc {
+  position: relative;
+  background: var(--color-workspace-item-bg);
+  padding: 1rem 1.5rem;
+}
+
+/* Gradient border */
+.workspace-item .content .workspace-item-definition-doc .show-full-doc:after {
+  position: absolute;
+  top: -1px;
+  left: 0;
+  right: 0;
+  content: " ";
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    var(--color-workspace-item-bg) 0%,
+    var(--color-workspace-item-cropped-control-border) 20%,
+    var(--color-workspace-item-bg) 80%,
+    var(--color-workspace-item-bg) 100%
+  );
+}
+/* Shadow */
+.workspace-item .content .workspace-item-definition-doc .show-full-doc:before {
+  position: absolute;
+  top: -16px;
+  left: 0;
+  right: 0;
+  content: " ";
+  height: 1rem;
+  background: radial-gradient(
+    ellipse at 16.6rem bottom,
+    var(--color-workspace-item-cropped-control-shadow) 0%,
+    transparent 50%
+  );
 }
 
 .workspace-item .content .built-in {


### PR DESCRIPTION
## Overview
When definition docs are very long (and the definition isn't a doc itself), crop the doc and provide an affordance to show the full doc.

Closes https://github.com/unisonweb/codebase-ui/issues/187

<img width="1464" alt="Screen Shot 2021-10-05 at 15 45 54" src="https://user-images.githubusercontent.com/2371/136093303-b6a586f2-4fa1-4900-8c15-66f98280f4fa.png">

## Implementation notes
To determine if the doc is very long, render it in an `overflow: hidden`
container and query the dom to see if that container has content that is
cropped.