### PR TITLE
Update zoom to cycle correctly for different items

### DIFF
--- a/src/Definition/Source.elm
+++ b/src/Definition/Source.elm
@@ -1,6 +1,7 @@
 module Definition.Source exposing
     ( Source(..)
     , ViewConfig(..)
+    , isBuiltin
     , numTermLines
     , numTermSignatureLines
     , numTypeLines
@@ -35,6 +36,19 @@ type
 
 
 -- HELPERS
+
+
+isBuiltin : Source -> Bool
+isBuiltin source =
+    case source of
+        Type Type.Builtin ->
+            True
+
+        Term _ (Term.Builtin _) ->
+            True
+
+        _ ->
+            False
 
 
 numTypeLines : TypeSource -> Int

--- a/src/Definition/Term.elm
+++ b/src/Definition/Term.elm
@@ -9,6 +9,8 @@ module Definition.Term exposing
     , decodeSignature
     , decodeTermCategory
     , decodeTermSource
+    , isBuiltin
+    , isBuiltinSource
     , termSignature
     )
 
@@ -62,6 +64,21 @@ type alias TermListing =
 
 
 -- HELPERS
+
+
+isBuiltin : TermDetail d -> Bool
+isBuiltin (Term _ _ d) =
+    isBuiltinSource d.source
+
+
+isBuiltinSource : TermSource -> Bool
+isBuiltinSource source =
+    case source of
+        Source _ _ ->
+            False
+
+        Builtin _ ->
+            True
 
 
 termSignature : TermSource -> TermSignature

--- a/src/Definition/Type.elm
+++ b/src/Definition/Type.elm
@@ -7,6 +7,8 @@ module Definition.Type exposing
     , TypeSummary
     , decodeTypeCategory
     , decodeTypeSource
+    , isBuiltin
+    , isBuiltinSource
     )
 
 import Definition.Info exposing (Info)
@@ -50,6 +52,25 @@ type alias TypeSummary =
 
 type alias TypeListing =
     Type FQN
+
+
+
+-- HELPERS
+
+
+isBuiltin : TypeDetail d -> Bool
+isBuiltin (Type _ _ d) =
+    isBuiltinSource d.source
+
+
+isBuiltinSource : TypeSource -> Bool
+isBuiltinSource source =
+    case source of
+        Source _ ->
+            False
+
+        Builtin ->
+            True
 
 
 

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -27,7 +27,6 @@ import Task
 import UI.Button as Button
 import Workspace.WorkspaceItem as WorkspaceItem exposing (Item, WorkspaceItem(..))
 import Workspace.WorkspaceItems as WorkspaceItems exposing (WorkspaceItems)
-import Workspace.Zoom as Zoom
 
 
 
@@ -344,21 +343,8 @@ handleKeyboardShortcut ({ workspaceItems } as model) shortcut =
 
         Sequence _ Space ->
             let
-                cycleZoom items ref =
-                    let
-                        mapper item =
-                            case item of
-                                Success r data ->
-                                    if r == ref then
-                                        Success r { data | zoom = Zoom.cycle data.zoom }
-
-                                    else
-                                        item
-
-                                _ ->
-                                    item
-                    in
-                    WorkspaceItems.map mapper items
+                cycleZoom wItems ref =
+                    WorkspaceItems.updateData WorkspaceItem.cycleZoom ref wItems
 
                 cycled =
                     model.workspaceItems

--- a/src/Workspace/WorkspaceItem.elm
+++ b/src/Workspace/WorkspaceItem.elm
@@ -27,7 +27,7 @@ import UI.FoldToggle as FoldToggle
 import UI.Icon as Icon exposing (Icon)
 import UI.Tooltip as Tooltip
 import Util
-import Workspace.Zoom exposing (Zoom(..))
+import Workspace.Zoom as Zoom exposing (Zoom(..))
 
 
 type WorkspaceItem
@@ -126,6 +126,18 @@ reference item =
             r
 
 
+{-| Builtins and Types can't be expanded, so we can skip the Medium Zoom level entirely
+TODO: Remove isTypeItem from this conditional when we can collapse types (TypeSummary)
+-}
+cycleZoom : ItemData -> ItemData
+cycleZoom data =
+    if isBuiltinItem data.item || isTypeItem data.item || not (hasDoc data.item) then
+        { data | zoom = Zoom.cycleEdges data.zoom }
+
+    else
+        { data | zoom = Zoom.cycle data.zoom }
+
+
 isSameReference : WorkspaceItem -> Reference -> Bool
 isSameReference item ref =
     reference item == ref
@@ -134,6 +146,59 @@ isSameReference item ref =
 isSameByReference : WorkspaceItem -> WorkspaceItem -> Bool
 isSameByReference a b =
     reference a == reference b
+
+
+isBuiltinItem : Item -> Bool
+isBuiltinItem item =
+    case item of
+        TermItem term ->
+            Term.isBuiltin term
+
+        TypeItem type_ ->
+            Type.isBuiltin type_
+
+        _ ->
+            False
+
+
+isTypeItem : Item -> Bool
+isTypeItem item =
+    case item of
+        TypeItem _ ->
+            True
+
+        _ ->
+            False
+
+
+isTermItem : Item -> Bool
+isTermItem item =
+    case item of
+        TermItem _ ->
+            True
+
+        _ ->
+            False
+
+
+isDataConstructorItem : Item -> Bool
+isDataConstructorItem item =
+    case item of
+        DataConstructorItem _ ->
+            True
+
+        _ ->
+            False
+
+
+isAbilityConstructorItem : Item -> Bool
+isAbilityConstructorItem item =
+    case item of
+        AbilityConstructorItem _ ->
+            True
+
+        _ ->
+            False
 
 
 isDocItem : Item -> Bool

--- a/src/Workspace/Zoom.elm
+++ b/src/Workspace/Zoom.elm
@@ -18,3 +18,16 @@ cycle z =
 
         Near ->
             Far
+
+
+cycleEdges : Zoom -> Zoom
+cycleEdges z =
+    case z of
+        Far ->
+            Near
+
+        Medium ->
+            Far
+
+        Near ->
+            Far


### PR DESCRIPTION
## Overview
Builtin items, types and terms without docs should skip the Medium Zoom
level when cycling zoom. Move this logic into WorkspaceItem and
correctly determine the next zoom in the cycle based on the item.

## Loose ends
I'd love to test this, but actually constructing real WorkspaceItems is a huge hassle. I created a ticket (https://github.com/unisonweb/ui-core/issues/8) to track this.