### PR TITLE
Close sidebar on mobile when opening a definition

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -216,7 +216,9 @@ update msg ({ env } as model) =
                             ( model2, Cmd.none )
 
                         CodebaseTree.OpenDefinition ref ->
-                            openDefinition model2 ref
+                            -- reset sidebarToggled to close it on mobile, but keep it open on desktop
+                            let model4 = { model2 | sidebarToggled = False }
+                            in openDefinition model4 ref
 
                         CodebaseTree.ChangePerspectiveToNamespace fqn ->
                             fqn


### PR DESCRIPTION
Fixes #176
Toggling the sidebar is currently not possible on desktop, but the comment for `sidebarToggled` suggests that it might be possible at some point. In that case, this code would work as well: If the user selects a definition from the open (=untoggled) sidebar, the sidebar will stay open.