### PR TITLE
Add Hacktoberfest promotion

### DIFF
--- a/src/UI/AppHeader.elm
+++ b/src/UI/AppHeader.elm
@@ -1,0 +1,84 @@
+module UI.AppHeader exposing (..)
+
+import Html exposing (Html, a, header, section, span)
+import Html.Attributes exposing (class, id)
+import Html.Events exposing (onClick)
+import UI
+import UI.Banner as Banner exposing (Banner)
+import UI.Button as Button exposing (Button)
+import UI.Icon as Icon
+
+
+type AppTitle msg
+    = Clickable msg (Html msg)
+    | Disabled (Html msg)
+
+
+type alias MenuToggle msg =
+    { onClick : msg }
+
+
+type alias AppHeader msg =
+    { menuToggle : Maybe msg
+    , appTitle : AppTitle msg
+    , banner : Maybe (Banner msg)
+    , rightButton : Maybe (Button msg)
+    }
+
+
+appHeader : AppTitle msg -> AppHeader msg
+appHeader appTitle =
+    { menuToggle = Nothing
+    , appTitle = appTitle
+    , banner = Nothing
+    , rightButton = Nothing
+    }
+
+
+view : AppHeader msg -> Html msg
+view appHeader_ =
+    let
+        menuToggle =
+            case appHeader_.menuToggle of
+                Nothing ->
+                    UI.nothing
+
+                Just toggle ->
+                    a
+                        [ class "menu-toggle", onClick toggle ]
+                        [ Icon.view Icon.list ]
+
+        banner =
+            case appHeader_.banner of
+                Nothing ->
+                    UI.nothing
+
+                Just banner_ ->
+                    Banner.view banner_
+
+        rightButton =
+            appHeader_.rightButton
+                |> Maybe.map Button.small
+                |> Maybe.map Button.view
+                |> Maybe.withDefault UI.nothing
+    in
+    view_
+        [ menuToggle
+        , viewAppTitle appHeader_.appTitle
+        , section [ class "right" ] [ banner, rightButton ]
+        ]
+
+
+viewAppTitle : AppTitle msg -> Html msg
+viewAppTitle title =
+    case title of
+        Clickable clickMsg content ->
+            a [ class "app-title", onClick clickMsg ] [ content ]
+
+        Disabled content ->
+            span [ class "app-title" ] [ content ]
+
+
+view_ : List (Html msg) -> Html msg
+view_ content =
+    header [ id "app-header" ] content

--- a/src/UI/Banner.elm
+++ b/src/UI/Banner.elm
@@ -1,0 +1,43 @@
+module UI.Banner exposing (..)
+
+import Html exposing (Html, a, span, text)
+import Html.Attributes exposing (class)
+import Html.Events exposing (onClick)
+
+
+type Banner msg
+    = Info { content : String }
+    | Promotion { promotionId : String, content : String, ctaMsg : msg, ctaLabel : String }
+
+
+info : String -> Banner msg
+info content =
+    Info { content = content }
+
+
+promotion : String -> String -> msg -> String -> Banner msg
+promotion promotionId content ctaMsg ctaLabel =
+    Promotion
+        { promotionId = promotionId
+        , content = content
+        , ctaMsg = ctaMsg
+        , ctaLabel = ctaLabel
+        }
+
+
+view : Banner msg -> Html msg
+view banner_ =
+    case banner_ of
+        Info i ->
+            span [ class "banner", class "info" ] [ text i.content ]
+
+        Promotion p ->
+            a
+                [ class "banner"
+                , class "promotion"
+                , class p.promotionId
+                , onClick p.ctaMsg
+                ]
+                [ text p.content
+                , span [ class "banner-cta" ] [ text p.ctaLabel ]
+                ]

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -2,10 +2,10 @@
 
 #app {
   display: grid;
-  grid-template-rows: var(--main-header-height) auto;
+  grid-template-rows: var(--app-header-height) auto;
   grid-template-columns: var(--main-sidebar-width) auto;
   grid-template-areas:
-    "main-header main-header"
+    "app-header app-header"
     "main-sidebar main-content";
 }
 
@@ -24,67 +24,6 @@
   color: var(--color-main-alert);
 }
 
-/* -- Main Header ---------------------------------------------------------- */
-
-#main-header {
-  grid-area: main-header;
-  padding: 0 1rem 0 1.5rem;
-  background: var(--color-main-header-bg);
-  color: var(--color-main-header-fg);
-  border-bottom: 1px solid var(--color-main-header-border);
-  display: flex;
-  align-items: center;
-  font-size: 1rem;
-}
-
-#main-header .sidebar-toggle {
-  display: none; /* enabled on mobile */
-  line-height: 1.5rem;
-  margin-right: 0.5rem;
-}
-
-#main-header .sidebar-toggle .icon {
-  color: var(--color-main-header-subtle-fg);
-  font-size: 1.5rem;
-}
-#main-header .sidebar-toggle:hover .icon {
-  color: var(--color-main-header-subtle-fg-em);
-}
-
-#main-header .app-title {
-  font-size: var(--font-size-base);
-  display: inline-flex;
-  flex-direction: row;
-  align-items: center;
-  color: var(--color-main-header-fg);
-}
-
-#main-header .app-title h1 {
-  font-size: var(--font-size-base);
-}
-
-#main-header .app-title:hover {
-  text-decoration: none;
-  transform: translate(0, 0.1rem);
-}
-
-#main-header .app-title .context {
-  margin-left: 0.375rem;
-}
-
-#main-header .app-title .unison-share {
-  color: var(--color-main-header-context-unison-share-fg);
-}
-
-#main-header .app-title .ucm {
-  color: var(--color-main-header-context-ucm-fg);
-}
-
-#main-header .right {
-  margin-left: auto;
-  justify-self: flex-end;
-}
-
 /* -- Main Sidebar --------------------------------------------------------- */
 
 #main-sidebar {
@@ -92,7 +31,7 @@
   display: flex;
   flex-direction: column;
   overflow: auto;
-  height: calc(100vh - var(--main-header-height));
+  height: calc(100vh - var(--app-header-height));
   background: var(--color-sidebar-bg);
   color: var(--color-sidebar-fg);
   border-right: 1px solid var(--color-sidebar-border);
@@ -281,16 +220,8 @@
     grid-template-rows: 3.5rem auto;
     grid-template-columns: auto auto;
     grid-template-areas:
-      "main-header main-header"
+      "app-header app-header"
       "main-content main-content";
-  }
-
-  #main-header {
-    padding: 0 1rem;
-  }
-
-  #main-header .sidebar-toggle {
-    display: flex;
   }
 
   #main-sidebar {
@@ -305,13 +236,14 @@
     grid-template-rows: 3.5rem auto;
     grid-template-columns: auto auto;
     grid-template-areas:
-      "main-header main-header"
+      "app-header app-header"
       "main-sidebar main-sidebar";
   }
 
   #app.sidebar-toggled #main-sidebar {
     display: flex;
     width: 100vw;
+    height: 100vw;
   }
 
   #app.sidebar-toggled #main-content {

--- a/src/css/composites.css
+++ b/src/css/composites.css
@@ -1,3 +1,4 @@
+@import "./composites/app-header.css";
 @import "./composites/modal.css";
 @import "./composites/codebase-tree.css";
 @import "./composites/readme.css";

--- a/src/css/composites/app-header.css
+++ b/src/css/composites/app-header.css
@@ -1,0 +1,82 @@
+/* -- App Header ---------------------------------------------------------- */
+
+#app-header {
+  grid-area: app-header;
+  padding: 0 1rem 0 1.5rem;
+  background: var(--color-app-header-bg);
+  color: var(--color-app-header-fg);
+  border-bottom: 1px solid var(--color-app-header-border);
+  display: flex;
+  align-items: center;
+  font-size: 1rem;
+  height: 3.5rem;
+}
+
+#app-header .menu-toggle {
+  display: none; /* enabled on mobile */
+  line-height: 1.5rem;
+  margin-right: 0.5rem;
+}
+
+#app-header .menu-toggle .icon {
+  color: var(--color-app-header-subtle-fg);
+  font-size: 1.5rem;
+}
+#app-header .menu-toggle:hover .icon {
+  color: var(--color-app-header-subtle-fg-em);
+}
+
+#app-header .app-title {
+  font-size: var(--font-size-base);
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  color: var(--color-app-header-fg);
+}
+
+#app-header .app-title h1 {
+  font-size: var(--font-size-base);
+}
+
+#app-header .app-title:hover {
+  text-decoration: none;
+  transform: translate(0, 0.1rem);
+}
+
+#app-header .app-title .context {
+  margin-left: 0.375rem;
+}
+
+#app-header .app-title .unison-share {
+  color: var(--color-app-header-context-unison-share-fg);
+}
+
+#app-header .app-title .ucm {
+  color: var(--color-app-header-context-ucm-fg);
+}
+
+#app-header .right {
+  margin-left: auto;
+  justify-self: flex-end;
+  align-items: center;
+}
+
+#app-header .right .banner {
+  margin-right: 0.75rem;
+}
+
+/* -- Responsive ----------------------------------------------------------- */
+
+@media only screen and (max-width: 1024px) {
+  #app-header {
+    padding: 0 1rem;
+  }
+
+  #app-header .menu-toggle {
+    display: flex;
+  }
+
+  #app-header .banner {
+    display: none;
+  }
+}

--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -179,6 +179,7 @@ hr {
 }
 
 @import "./elements/icon.css";
+@import "./elements/banner.css";
 @import "./elements/button.css";
 @import "./elements/tooltip.css";
 @import "./elements/fold-toggle.css";

--- a/src/css/elements/banner.css
+++ b/src/css/elements/banner.css
@@ -1,0 +1,44 @@
+.banner {
+  display: inline-flex;
+  height: 1.5rem;
+  border-radius: calc(1.5rem / 2);
+  border: 1px solid var(--banner-border);
+  background: var(--banner-bg);
+  color: var(--banner-fg);
+  padding: 0 0.75rem;
+  line-height: 1;
+  align-items: center;
+  font-size: var(--font-size-small);
+}
+
+.banner:hover {
+  text-decoration: none;
+  transform: translate(0, 0.1rem);
+}
+
+.banner.info {
+  --banner-fg: var(--banner-info-fg);
+  --banner-bg: var(--banner-info-bg);
+  --banner-fg-em: var(--banner-info-fg-em);
+  --banner-border: var(--banner-info-border);
+}
+
+/* Seasonal Promotion */
+.banner.hacktoberfest {
+  --banner-fg: var(--color-orange-3);
+  --banner-bg: rgba(255, 136, 0, 0.2); /* color-orange-1 20% */
+  --banner-fg-em: var(--color-orange-5);
+  --banner-border: var(--color-orange-1);
+  text-shadow: 0 1px rgba(0, 0, 0, 0.25);
+}
+
+.banner .banner-cta {
+  color: var(--banner-fg-em);
+  border-left: 1px solid var(--banner-border);
+  display: inline-flex;
+  height: 1.5rem;
+  align-items: center;
+  font-weight: bold;
+  margin-left: 0.75rem;
+  padding-left: 0.75rem;
+}

--- a/src/css/themes/unison/colors.css
+++ b/src/css/themes/unison/colors.css
@@ -51,6 +51,8 @@
   --color-orange-1: #ff8800;
   --color-orange-2: #ffc41f;
   --color-orange-3: #ffe08b;
+  --color-orange-4: #ffeebe;
+  --color-orange-5: #fff7df;
 
   /* Purples */
   --color-purple-1: #55377b;

--- a/src/css/themes/unison/light.css
+++ b/src/css/themes/unison/light.css
@@ -17,13 +17,13 @@
   --color-main-mark-fg: var(--color-blue-2);
   --color-main-mark-bg: var(--color-transparent);
 
-  --color-main-header-fg: var(--color-gray-lighten-100);
-  --color-main-header-bg: var(--color-gray-darken-10);
-  --color-main-header-subtle-fg: var(--color-gray-lighten-20);
-  --color-main-header-subtle-fg-em: var(--color-gray-lighten-50);
-  --color-main-header-context-unison-share-fg: var(--color-purple-4);
-  --color-main-header-context-ucm-fg: var(--color-pink-3);
-  --color-main-header-border: var(--color-gray-base);
+  --color-app-header-fg: var(--color-gray-lighten-100);
+  --color-app-header-bg: var(--color-gray-darken-10);
+  --color-app-header-subtle-fg: var(--color-gray-lighten-20);
+  --color-app-header-subtle-fg-em: var(--color-gray-lighten-50);
+  --color-app-header-context-unison-share-fg: var(--color-purple-4);
+  --color-app-header-context-ucm-fg: var(--color-pink-3);
+  --color-app-header-border: var(--color-gray-base);
 
   --color-keyboard-shortcut-key-fg: var(--color-gray-base);
   --color-keyboard-shortcut-key-bg: var(--color-gray-lighten-50);


### PR DESCRIPTION
## Overview
Add a new UI concept: Banner to support a hacktoberfest promotion and
also refactor the app header into its own AppHeader module (also part of
the UI design system) and give it specific slots for configuration.

(though the screenshot says Unison Local, this will only appear on Unison Share). 

<img width="1139" alt="Screen Shot 2021-10-18 at 11 33 56" src="https://user-images.githubusercontent.com/2371/137764268-b5bbe529-8a4a-4402-91af-1f515a5c73ac.png">

## Notes
⚠️ Don't merge until the `unison.hacktoberfest` namespace exists on Unison Share.