### PR TITLE
typo causes square mobile viewport

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -243,7 +243,7 @@
   #app.sidebar-toggled #main-sidebar {
     display: flex;
     width: 100vw;
-    height: 100vw;
+    height: 100vh;
   }
 
   #app.sidebar-toggled #main-content {


### PR DESCRIPTION
## Overview
A typo in PR [248](https://github.com/unisonweb/codebase-ui/pull/248) caused a regression in the responsive view: 
![image](https://user-images.githubusercontent.com/1162118/137811152-6aacb1e4-a4a5-42fd-8430-909df2156d3a.png)
