### PR TITLE
Fix overflowing docs in Firefox

### DIFF
--- a/src/css/workspace-item.css
+++ b/src/css/workspace-item.css
@@ -215,6 +215,7 @@
   .workspace-item-definition-doc.shown-in-full
   .doc-column {
   overflow: visible;
+  max-height: -moz-fit-content;
   max-height: fit-content;
 }
 


### PR DESCRIPTION
## Overview
fit-content required browser prefix in firefox: https://caniuse.com/?search=fit-content

fixes https://github.com/unisonweb/codebase-ui/issues/251