### PR TITLE
Improve the rendering of FQNs

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -499,7 +499,7 @@ viewPerspective env =
             header
                 [ class "perspective" ]
                 [ div [ class "namespace-slug" ] []
-                , h2 [] [ text fqnText ]
+                , h2 [] [ FQN.view fqn ]
                 , back
                 ]
 

--- a/src/Definition/Info.elm
+++ b/src/Definition/Info.elm
@@ -14,13 +14,13 @@ import List.Nonempty as NEL
 
 
 type alias Info =
-    { name : String
+    { name : FQN
     , namespace : Maybe FQN
     , otherNames : List FQN
     }
 
 
-makeInfo : String -> NEL.Nonempty FQN -> Info
+makeInfo : FQN -> NEL.Nonempty FQN -> Info
 makeInfo name_ allFqns =
     let
         ( namespace, otherNames ) =
@@ -33,12 +33,13 @@ makeInfo name_ allFqns =
 -- Helpers
 
 
-namespaceAndOtherNames : String -> NEL.Nonempty FQN -> ( Maybe FQN, List FQN )
+namespaceAndOtherNames : FQN -> NEL.Nonempty FQN -> ( Maybe FQN, List FQN )
 namespaceAndOtherNames suffixName fqns =
     let
         fqnWithin =
             fqns
-                |> NEL.filter (FQN.isSuffixOf suffixName) (NEL.head fqns)
+                |> NEL.filter (FQN.isSuffixOf (FQN.toString suffixName)) (NEL.head fqns)
+                |> NEL.sortBy FQN.numSegments
                 |> NEL.head
 
         fqnsWithout =

--- a/src/Definition/Source.elm
+++ b/src/Definition/Source.elm
@@ -15,6 +15,7 @@ module Definition.Source exposing
 import Definition.Reference exposing (Reference)
 import Definition.Term as Term exposing (TermSignature(..), TermSource)
 import Definition.Type as Type exposing (TypeSource)
+import FullyQualifiedName as FQN exposing (FQN)
 import Html exposing (Html, span, text)
 import Html.Attributes exposing (class)
 import Syntax
@@ -30,7 +31,7 @@ type ViewConfig msg
 type
     Source
     -- Term name source
-    = Term String TermSource
+    = Term FQN TermSource
     | Type TypeSource
 
 
@@ -118,22 +119,22 @@ viewTermSignature viewConfig (TermSignature syntax) =
     viewCode viewConfig (viewSyntax viewConfig syntax)
 
 
-viewNamedTermSignature : ViewConfig msg -> String -> TermSignature -> Html msg
+viewNamedTermSignature : ViewConfig msg -> FQN -> TermSignature -> Html msg
 viewNamedTermSignature viewConfig termName signature =
     viewCode viewConfig (viewNamedTermSignature_ viewConfig termName signature)
 
 
-viewNamedTermSignature_ : ViewConfig msg -> String -> TermSignature -> Html msg
+viewNamedTermSignature_ : ViewConfig msg -> FQN -> TermSignature -> Html msg
 viewNamedTermSignature_ viewConfig termName (TermSignature syntax) =
     span
         []
-        [ span [ class "hash-qualifier" ] [ text termName ]
+        [ span [ class "hash-qualifier" ] [ text (FQN.toString termName) ]
         , span [ class "type-ascription-colon" ] [ text " : " ]
         , viewSyntax viewConfig syntax
         ]
 
 
-viewTermSource : ViewConfig msg -> String -> TermSource -> Html msg
+viewTermSource : ViewConfig msg -> FQN -> TermSource -> Html msg
 viewTermSource viewConfig termName source =
     let
         content =

--- a/src/FullyQualifiedName.elm
+++ b/src/FullyQualifiedName.elm
@@ -14,14 +14,18 @@ module FullyQualifiedName exposing
     , isValidUrlSegmentChar
     , namespace
     , namespaceOf
+    , numSegments
     , segments
     , toString
     , toUrlSegments
     , toUrlString
     , unqualifiedName
     , urlParser
+    , view
     )
 
+import Html exposing (Html, span, text)
+import Html.Attributes exposing (class)
 import Json.Decode as Decode
 import List.Extra as ListE
 import List.Nonempty as NEL
@@ -137,6 +141,11 @@ segments (FQN segments_) =
     segments_
 
 
+numSegments : FQN -> Int
+numSegments (FQN segments_) =
+    NEL.length segments_
+
+
 fromParent : FQN -> String -> FQN
 fromParent (FQN parentParts) childName =
     FQN (NEL.append parentParts (NEL.fromElement childName))
@@ -201,6 +210,23 @@ namespaceOf suffixName fqn =
 
     else
         Nothing
+
+
+view : FQN -> Html msg
+view fqn =
+    let
+        viewSegment seg =
+            span [ class "fully-qualified-name-segment" ] [ text seg ]
+
+        viewSep =
+            span [ class "fully-qualified-name-separator" ] [ text "." ]
+    in
+    fqn
+        |> segments
+        |> NEL.toList
+        |> List.map viewSegment
+        |> List.intersperse viewSep
+        |> span [ class "fully-qualified-name" ]
 
 
 

--- a/src/PerspectiveLanding.elm
+++ b/src/PerspectiveLanding.elm
@@ -144,7 +144,7 @@ viewEmptyStateNamespace fqn =
             FQN.toString fqn
     in
     viewEmptyState
-        (text fqn_)
+        (FQN.view fqn)
         [ p [] [ text "Browse, search, read docs, open definitions, and explore" ] ]
         (Button.iconThenLabel Find Icon.search ("Find Definitions in " ++ fqn_)
             |> Button.primaryMono

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -25,6 +25,7 @@ import KeyboardShortcut.KeyboardEvent as KeyboardEvent exposing (KeyboardEvent)
 import Perspective exposing (Perspective)
 import Task
 import UI.Button as Button
+import UI.Icon as Icon
 import Workspace.WorkspaceItem as WorkspaceItem exposing (Item, WorkspaceItem(..))
 import Workspace.WorkspaceItems as WorkspaceItems exposing (WorkspaceItems)
 
@@ -446,7 +447,7 @@ view model =
             article [ id "workspace" ]
                 [ header
                     [ id "workspace-toolbar" ]
-                    [ Button.button Find "Find" |> Button.view
+                    [ Button.iconThenLabel Find Icon.search "Find Definition" |> Button.small |> Button.view
                     ]
                 , section
                     [ id "workspace-content" ]

--- a/src/Workspace/WorkspaceItem.elm
+++ b/src/Workspace/WorkspaceItem.elm
@@ -232,13 +232,13 @@ hasDoc item =
 -- VIEW
 
 
-viewBuiltinBadge : String -> Category -> Html msg
+viewBuiltinBadge : FQN -> Category -> Html msg
 viewBuiltinBadge name_ category =
     let
         content =
             span
                 []
-                [ strong [] [ text name_ ]
+                [ strong [] [ text (FQN.toString name_) ]
                 , text " is a "
                 , strong [] [ text ("built-in " ++ Category.name category) ]
                 , text " provided by the Unison runtime"
@@ -349,7 +349,7 @@ viewInfo zoom onClick_ hash info category =
     div [ class "info" ]
         [ FoldToggle.foldToggle onClick_ |> FoldToggle.isOpen (zoom /= Far) |> FoldToggle.view
         , div [ class "category-icon" ] [ Icon.view (Category.icon category) ]
-        , h3 [ class "name" ] [ text info.name ]
+        , h3 [ class "name" ] [ FQN.view info.name ]
         , viewInfoItems hash info
         ]
 
@@ -615,7 +615,7 @@ decodeDocs fieldName =
 decodeTypeDetails :
     Decode.Decoder
         { category : TypeCategory
-        , name : String
+        , name : FQN
         , otherNames : NEL.Nonempty FQN
         , source : TypeSource
         , doc : Maybe Doc
@@ -632,7 +632,7 @@ decodeTypeDetails =
     in
     Decode.map5 make
         (Type.decodeTypeCategory [ "defnTypeTag" ])
-        (field "bestTypeName" Decode.string)
+        (field "bestTypeName" FQN.decode)
         (field "typeNames" (Util.decodeNonEmptyList FQN.decode))
         (Type.decodeTypeSource [ "typeDefinition", "tag" ] [ "typeDefinition", "contents" ])
         (decodeDocs "typeDocs")
@@ -655,7 +655,7 @@ decodeTypes =
 decodeTermDetails :
     Decode.Decoder
         { category : TermCategory
-        , name : String
+        , name : FQN
         , otherNames : NEL.Nonempty FQN
         , source : TermSource
         , doc : Maybe Doc
@@ -672,7 +672,7 @@ decodeTermDetails =
     in
     Decode.map5 make
         (Term.decodeTermCategory [ "defnTermTag" ])
-        (field "bestTermName" Decode.string)
+        (field "bestTermName" FQN.decode)
         (field "termNames" (Util.decodeNonEmptyList FQN.decode))
         (Term.decodeTermSource
             [ "termDefinition", "tag" ]

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -40,6 +40,9 @@
   scrollbar-width: thin;
   scrollbar-color: var(--color-sidebar-subtle-fg) var(--color-sidebar-bg);
 
+  --color-main-fg: var(--color-sidebar-fg);
+  --color-main-subtle-fg: var(--color-sidebar-subtle-fg);
+
   --color-button-default-fg: var(--color-sidebar-button-default-fg);
   --color-button-default-bg: var(--color-sidebar-button-default-bg);
   --color-button-default-hover-fg: var(--color-sidebar-button-default-hover-fg);
@@ -120,7 +123,7 @@
 }
 
 #main-sidebar .collapse-sidebar-header button {
-  margin-left : auto;
+  margin-left: auto;
   justify-self: flex-end;
 }
 
@@ -131,7 +134,7 @@
 /* -- Perspective -------------------------------------------------------- */
 
 #main-sidebar .perspective {
-  margin-bottom: 3rem;
+  padding: 1rem 0;
   display: flex;
   flex-direction: column;
   flex-direction: row;
@@ -266,7 +269,6 @@
 /* -- Responsive ----------------------------------------------------------- */
 
 @media only screen and (min-width: 1025px) {
-
   #app.sidebar-toggled {
     grid-template-columns: var(--main-sidebar-collapsed-width) auto;
   }
@@ -275,7 +277,7 @@
     padding: 1rem 1.5rem;
   }
 
-  #app.sidebar-toggled #main-sidebar .collapsed  {
+  #app.sidebar-toggled #main-sidebar .collapsed {
     display: block;
   }
 
@@ -283,7 +285,7 @@
   #app.sidebar-toggled .sidebar-section,
   #app.sidebar-toggled .perspective,
   #app.sidebar-toggled nav > a {
-    display: none
+    display: none;
   }
 }
 

--- a/src/css/elements.css
+++ b/src/css/elements.css
@@ -183,3 +183,4 @@ hr {
 @import "./elements/button.css";
 @import "./elements/tooltip.css";
 @import "./elements/fold-toggle.css";
+@import "./elements/fully-qualified-name.css";

--- a/src/css/elements/fully-qualified-name.css
+++ b/src/css/elements/fully-qualified-name.css
@@ -1,0 +1,14 @@
+.fully-qualified-name {
+  display: inline-flex;
+  align-items: center;
+  height: 1.5rem;
+  font-weight: bold;
+  color: var(--color-main-fg);
+}
+.fully-qualified-name .fully-qualified-name-separator {
+  /* em instead of rem to have the margin be relative to the font-size of
+   * .fully-qualified-name
+  */
+  margin: 0 0.25em;
+  color: var(--color-main-subtle-fg);
+}


### PR DESCRIPTION
## Overview
Render FQNs with a more subtle and spacious treatment to the separator
between segments. Also prefer the shortest FQN for picking the namespace
of a suffixed FQN. This mitigates some of the weird cases where forks
were of libraries were picked over the actual libraries, but wouldn't
work if the length of the segments happen to be equal (longer term
solution is to pick the FQN that was used to query the definition).

<img width="241" alt="Screen Shot 2021-10-21 at 16 02 12" src="https://user-images.githubusercontent.com/2371/138352570-f7907b01-6abc-45e6-9e27-8e8a807c609d.png">
<img width="134" alt="Screen Shot 2021-10-21 at 16 32 04" src="https://user-images.githubusercontent.com/2371/138352576-0e65da1c-4318-46af-9771-00a9b9357231.png">
<img width="582" alt="Screen Shot 2021-10-21 at 16 32 08" src="https://user-images.githubusercontent.com/2371/138352583-b8b9d1f2-f6f9-4d83-a702-c76391736a74.png">

Also adjusted the Find Definition button slightly in size to match
latest designs.

Fixes https://github.com/unisonweb/codebase-ui/issues/256

cc @hagl 