### PR TITLE
Move perspective out of scrollable sidebar area

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -492,8 +492,8 @@ viewPerspective env =
                 back =
                     Tooltip.tooltip
                         (Button.icon (ChangePerspective (Codebase codebaseHash)) Icon.arrowLeftUp |> Button.small |> Button.uncontained |> Button.view)
-                        (Tooltip.Text ("You're currently viewing a subset of " ++ context ++ " (" ++ fqnText ++ "), click to view everything."))
-                        |> Tooltip.withArrow Tooltip.End
+                        (Tooltip.Text ("You're currently viewing a subset of " ++ context ++ " (" ++ fqnText ++ "), click to reveal everything."))
+                        |> Tooltip.withArrow Tooltip.Start
                         |> Tooltip.view
             in
             header
@@ -580,9 +580,9 @@ viewMainSidebar model =
     in
     Sidebar.view
         [ viewMainSidebarCollapseButton model
+        , viewPerspective model.env
         , div [ class "sidebar-scroll-area" ]
-            [ viewPerspective model.env
-            , sidebarContent
+            [ sidebarContent
             , Sidebar.section
                 "Namespaces and Definitions"
                 [ Html.map CodebaseTreeMsg (CodebaseTree.view model.codebaseTree) ]

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -130,6 +130,7 @@
   position: absolute;
   right: -0.75rem;
   top: 1rem;
+  z-index: var(--layer-popover);
 }
 
 #main-sidebar .collapsed {
@@ -139,10 +140,26 @@
 /* -- Perspective -------------------------------------------------------- */
 
 #main-sidebar .perspective {
-  padding: 1rem 0;
+  padding: 1rem 1.5rem;
+  margin-bottom: 0.5rem;
   display: flex;
   flex-direction: column;
   flex-direction: row;
+  position: relative;
+}
+
+#main-sidebar .perspective:after {
+  position: absolute;
+  left: 1.5rem;
+  right: 1.5rem;
+  bottom: -2rem;
+  height: 3rem;
+  content: "";
+  background: linear-gradient(
+    var(--color-sidebar-bg),
+    var(--color-sidebar-bg),
+    var(--color-transparent)
+  );
 }
 
 #main-sidebar .perspective .namespace-slug {
@@ -156,19 +173,15 @@
   height: 1.5rem;
 }
 
-#main-sidebar .perspective .tooltip-trigger {
-  margin-left: auto;
-  align-self: flex-end;
-}
-
-#main-sidebar .perspective .tooltip {
-  right: -0.3rem;
-  min-width: calc(var(--main-sidebar-width) - 1.5rem);
+#main-sidebar .perspective .tooltip-bubble {
+  width: 16rem;
 }
 
 #main-sidebar .perspective .button {
   opacity: 0.5;
+  margin-left: 0.375rem;
 }
+
 #main-sidebar .perspective .button:hover {
   opacity: 1;
 }
@@ -278,7 +291,7 @@
   #app.sidebar-toggled {
     grid-template-columns: var(--main-sidebar-collapsed-width) auto;
   }
-  #app.sidebar-toggled .sidebar-scroll-area{
+  #app.sidebar-toggled .sidebar-scroll-area {
     overflow: visible;
   }
 

--- a/src/css/workspace.css
+++ b/src/css/workspace.css
@@ -12,7 +12,8 @@
 
 #workspace-toolbar {
   height: var(--workspace-toolbar-height);
-  padding: 0.75rem 1rem;
+  padding-left: 2.625rem;
+  padding-right: 1rem;
   font-size: var(--font-size-medium);
   background: var(--color-workspace-item-bg);
   border-bottom: 1px solid var(--color-workspace-border);


### PR DESCRIPTION
## Overview
Adjust the scrollable sidebar area to no longer include the perspective.
This means scrolling acts a lot better when the collapse button is
shown.

Also update the workspace toolbar with more left margin to give room to
the collapse button as well as the "remove perspective" button.

cc @hagl 

https://user-images.githubusercontent.com/2371/138520721-b3d4d837-009d-4def-9c6e-dd8816b73c6a.mp4



