### PR TITLE
WorkspaceItem: Prefer requested FQN

### DIFF
--- a/src/Definition/AbilityConstructor.elm
+++ b/src/Definition/AbilityConstructor.elm
@@ -33,7 +33,7 @@ type alias AbilityConstructorDetail =
 type alias AbilityConstructorSummary =
     AbilityConstructor
         { fqn : FQN
-        , name : String
+        , name : FQN
         , namespace : Maybe String
         , signature : TermSignature
         }

--- a/src/Definition/DataConstructor.elm
+++ b/src/Definition/DataConstructor.elm
@@ -33,7 +33,7 @@ type alias DataConstructorDetail =
 type alias DataConstructorSummary =
     DataConstructor
         { fqn : FQN
-        , name : String
+        , name : FQN
         , namespace : Maybe String
         , signature : TermSignature
         }

--- a/src/Definition/Reference.elm
+++ b/src/Definition/Reference.elm
@@ -1,5 +1,6 @@
 module Definition.Reference exposing (..)
 
+import FullyQualifiedName exposing (FQN)
 import HashQualified as HQ exposing (HashQualified)
 import UI.Icon as Icon exposing (Icon)
 import Url.Parser
@@ -49,6 +50,11 @@ hashQualified ref =
 
         DataConstructorReference hq ->
             hq
+
+
+fqn : Reference -> Maybe FQN
+fqn =
+    hashQualified >> HQ.name
 
 
 

--- a/src/Definition/Term.elm
+++ b/src/Definition/Term.elm
@@ -52,7 +52,7 @@ type alias TermDetail d =
 type alias TermSummary =
     Term
         { fqn : FQN
-        , name : String
+        , name : FQN
         , namespace : Maybe String
         , signature : TermSignature
         }

--- a/src/Definition/Type.elm
+++ b/src/Definition/Type.elm
@@ -44,7 +44,7 @@ type alias TypeDetail d =
 type alias TypeSummary =
     Type
         { fqn : FQN
-        , name : String
+        , name : FQN
         , namespace : Maybe String
         , source : TypeSource
         }

--- a/src/Finder.elm
+++ b/src/Finder.elm
@@ -12,7 +12,7 @@ import Definition.Type exposing (Type(..))
 import Env exposing (Env)
 import Finder.FinderMatch as FinderMatch exposing (FinderMatch)
 import Finder.SearchOptions as SearchOptions exposing (SearchOptions(..), WithinOption(..))
-import FullyQualifiedName exposing (FQN)
+import FullyQualifiedName as FQN exposing (FQN)
 import HashQualified exposing (HashQualified(..))
 import Html
     exposing
@@ -365,7 +365,7 @@ indexToShortcut index =
         n |> String.fromInt |> Key.fromString |> Just
 
 
-viewMarkedNaming : FinderMatch.MatchPositions -> Maybe String -> String -> Html msg
+viewMarkedNaming : FinderMatch.MatchPositions -> Maybe String -> FQN -> Html msg
 viewMarkedNaming matchedPositions namespace name =
     let
         namespaceMod =
@@ -383,6 +383,7 @@ viewMarkedNaming matchedPositions namespace name =
 
         markedName =
             name
+                |> FQN.toString
                 |> String.toList
                 |> List.map (List.singleton >> String.fromList)
                 |> List.indexedMap (mark_ namespaceMod)

--- a/src/Finder/FinderMatch.elm
+++ b/src/Finder/FinderMatch.elm
@@ -5,7 +5,7 @@ import Definition.DataConstructor as DataConstructor exposing (DataConstructor(.
 import Definition.Reference exposing (Reference(..))
 import Definition.Term as Term exposing (Term(..), TermSummary)
 import Definition.Type as Type exposing (Type(..), TypeSummary)
-import FullyQualifiedName as FQN
+import FullyQualifiedName as FQN exposing (FQN)
 import Hash
 import HashQualified exposing (HashQualified(..))
 import Json.Decode as Decode exposing (at, field, string)
@@ -59,7 +59,7 @@ finderMatch score matchSegments item =
 -- HELPERS
 
 
-name : FinderMatch -> String
+name : FinderMatch -> FQN
 name fm =
     case fm.item of
         TypeItem (Type _ _ summary) ->
@@ -159,7 +159,7 @@ decodeTypeItem =
             (Type.decodeTypeCategory [ "namedType", "typeTag" ])
             (Decode.map3 makeSummary
                 (at [ "namedType", "typeName" ] FQN.decode)
-                (field "bestFoundTypeName" string)
+                (field "bestFoundTypeName" FQN.decode)
                 (Type.decodeTypeSource [ "typeDef", "tag" ] [ "typeDef", "contents" ])
             )
         )
@@ -181,7 +181,7 @@ decodeTermItem =
             (Term.decodeTermCategory [ "namedTerm", "termTag" ])
             (Decode.map3 makeSummary
                 (at [ "namedTerm", "termName" ] FQN.decode)
-                (field "bestFoundTermName" string)
+                (field "bestFoundTermName" FQN.decode)
                 (Term.decodeSignature [ "namedTerm", "termType" ])
             )
         )
@@ -202,7 +202,7 @@ decodeAbilityConstructorItem =
             (at [ "namedTerm", "termHash" ] Hash.decode)
             (Decode.map3 makeSummary
                 (at [ "namedTerm", "termName" ] FQN.decode)
-                (field "bestFoundTermName" string)
+                (field "bestFoundTermName" FQN.decode)
                 (AbilityConstructor.decodeSignature [ "namedTerm", "termType" ])
             )
         )
@@ -223,7 +223,7 @@ decodeDataConstructorItem =
             (at [ "namedTerm", "termHash" ] Hash.decode)
             (Decode.map3 makeSummary
                 (at [ "namedTerm", "termName" ] FQN.decode)
-                (field "bestFoundTermName" string)
+                (field "bestFoundTermName" FQN.decode)
                 (DataConstructor.decodeSignature [ "namedTerm", "termType" ])
             )
         )

--- a/src/FullyQualifiedName.elm
+++ b/src/FullyQualifiedName.elm
@@ -183,15 +183,15 @@ append (FQN a) (FQN b) =
 namespaces like List.map (where the FQN would be
 base.List.map)
 -}
-isSuffixOf : String -> FQN -> Bool
+isSuffixOf : FQN -> FQN -> Bool
 isSuffixOf suffixName fqn =
-    String.endsWith suffixName (toString fqn)
+    String.endsWith (toString suffixName) (toString fqn)
 
 
 {-| TODO: We should distinquish between FQN, Namespace and SuffixName on a type
 level, or rename the FQN type to Name
 -}
-namespaceOf : String -> FQN -> Maybe String
+namespaceOf : FQN -> FQN -> Maybe String
 namespaceOf suffixName fqn =
     let
         dropLastDot s =
@@ -204,7 +204,7 @@ namespaceOf suffixName fqn =
     if isSuffixOf suffixName fqn then
         fqn
             |> toString
-            |> String.dropRight (String.length suffixName)
+            |> String.dropRight (String.length (toString suffixName))
             |> StringE.nonEmpty
             |> Maybe.map dropLastDot
 

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -384,7 +384,7 @@ fetchDefinition perspective ref =
     in
     [ definitionHash ]
         |> Api.getDefinition perspective
-        |> Api.toRequest WorkspaceItem.decodeItem (FetchItemFinished ref)
+        |> Api.toRequest (WorkspaceItem.decodeItem ref) (FetchItemFinished ref)
 
 
 isDocCropped : Reference -> Cmd Msg

--- a/tests/FullyQualifiedNameTests.elm
+++ b/tests/FullyQualifiedNameTests.elm
@@ -157,7 +157,7 @@ isSuffixOf =
             \_ ->
                 let
                     suffix =
-                        "List.map"
+                        FQN.fromString "List.map"
 
                     fqn =
                         FQN.fromString "base.List.map"
@@ -167,7 +167,7 @@ isSuffixOf =
             \_ ->
                 let
                     suffix =
-                        "List.foldl"
+                        FQN.fromString "List.foldl"
 
                     fqn =
                         FQN.fromString "base.List.map"
@@ -183,7 +183,7 @@ namespaceOf =
             \_ ->
                 let
                     suffix =
-                        "List.map"
+                        FQN.fromString "List.map"
 
                     fqn =
                         FQN.fromString "base.List.map"
@@ -193,7 +193,7 @@ namespaceOf =
             \_ ->
                 let
                     suffix =
-                        "base.List.map"
+                        FQN.fromString "base.List.map"
 
                     fqn =
                         FQN.fromString "base.List.map"
@@ -203,7 +203,7 @@ namespaceOf =
             \_ ->
                 let
                     suffix =
-                        "List.map.foldl"
+                        FQN.fromString "List.map.foldl"
 
                     fqn =
                         FQN.fromString "base.List.map"
@@ -213,7 +213,7 @@ namespaceOf =
             \_ ->
                 let
                     suffix =
-                        "Map"
+                        FQN.fromString "Map"
 
                     fqn =
                         FQN.fromString "base.Map.Map"


### PR DESCRIPTION
## Overview
When requesting a definition for the Workspace by name, we should prefer
that name (if the best name is a suffix of it), otherwise, prefer the
shortest name.

Fixes: https://github.com/unisonweb/codebase-ui/issues/253