### PR TITLE
Finder: Retry search on option change

### DIFF
--- a/src/Perspective.elm
+++ b/src/Perspective.elm
@@ -16,6 +16,11 @@ type Perspective
         }
 
 
+toCodebasePerspective : Perspective -> Perspective
+toCodebasePerspective perspective =
+    Codebase (codebaseHash perspective)
+
+
 toNamespacePerspective : Perspective -> FQN -> Perspective
 toNamespacePerspective perspective fqn_ =
     Namespace { codebaseHash = codebaseHash perspective, fqn = fqn_, details = NotAsked }


### PR DESCRIPTION
## Overview
When the user chooses to remove a "within option", the search query
should be retried. If there are no "within options", the search should
be against the root branch.

Fixes https://github.com/unisonweb/codebase-ui/issues/267

https://user-images.githubusercontent.com/2371/139334105-6743163e-ea17-44ec-a552-641c3ca5d849.mp4


