### PR TITLE
Consolidate sidebar menu

### DIFF
--- a/src/UI/Button.elm
+++ b/src/UI/Button.elm
@@ -33,6 +33,8 @@ import Html.Events.Extra exposing (onClickPreventDefault, onClickPreventDefaultA
 import UI.Icon as I
 
 
+{-| TODO: Merge with UI.Click
+-}
 type Action clickMsg
     = OnClick clickMsg OnClickSettings
     | Href String

--- a/src/UI/Click.elm
+++ b/src/UI/Click.elm
@@ -1,0 +1,20 @@
+module UI.Click exposing (..)
+
+import Html exposing (Attribute, Html, a)
+import Html.Attributes exposing (href, rel, target)
+import Html.Events exposing (onClick)
+
+
+type Click msg
+    = ExternalHref String
+    | OnClick msg
+
+
+view : List (Attribute msg) -> List (Html msg) -> Click msg -> Html msg
+view attrs content click =
+    case click of
+        ExternalHref href_ ->
+            a (attrs ++ [ href href_, rel "noopener", target "_blank" ]) content
+
+        OnClick msg ->
+            a (attrs ++ [ onClick msg ]) content

--- a/src/UI/Tooltip.elm
+++ b/src/UI/Tooltip.elm
@@ -1,20 +1,21 @@
 module UI.Tooltip exposing
-    ( Action(..)
-    , Arrow(..)
+    ( Arrow(..)
     , Content(..)
     , MenuItem
     , Position(..)
     , Tooltip
+    , menu
+    , textMenu
     , tooltip
     , view
     , withArrow
     , withPosition
     )
 
-import Html exposing (Html, a, div, span, text)
-import Html.Attributes exposing (class, href, rel, target)
-import Html.Events exposing (onClick)
+import Html exposing (Html, div, span, text)
+import Html.Attributes exposing (class)
 import UI
+import UI.Click as Click exposing (Click)
 import UI.Icon as Icon exposing (Icon)
 
 
@@ -42,19 +43,28 @@ type Position
     | RightOf
 
 
-type Action msg
-    = OnClick msg
-    | Href String
-
-
 type alias MenuItem msg =
-    { icon : Maybe (Icon msg), label : String, action : Action msg }
+    { icon : Maybe (Icon msg), label : String, click : Click msg }
 
 
 type Content msg
     = Text String
     | Rich (Html msg)
     | Menu (List (MenuItem msg))
+
+
+menu : List ( Icon msg, String, Click msg ) -> Content msg
+menu items =
+    items
+        |> List.map (\( i, l, c ) -> MenuItem (Just i) l c)
+        |> Menu
+
+
+textMenu : List ( String, Click msg ) -> Content msg
+textMenu items =
+    items
+        |> List.map (\( l, c ) -> MenuItem Nothing l c)
+        |> Menu
 
 
 tooltip : Html msg -> Content msg -> Tooltip msg
@@ -89,12 +99,7 @@ view { arrow, content, trigger, position } =
                         Nothing ->
                             UI.nothing
             in
-            case item.action of
-                OnClick clickMsg ->
-                    a [ class "tooltip-menu-item", onClick clickMsg ] [ iconHtml, text item.label ]
-
-                Href url ->
-                    a [ class "tooltip-menu-item", href url, rel "noopener", target "_blank" ] [ iconHtml, text item.label ]
+            Click.view [ class "tooltip-menu-item" ] [ iconHtml, text item.label ] item.click
 
         content_ =
             case content of

--- a/src/Workspace/WorkspaceItem.elm
+++ b/src/Workspace/WorkspaceItem.elm
@@ -23,6 +23,7 @@ import Maybe.Extra as MaybeE
 import String.Extra exposing (pluralize)
 import UI
 import UI.Button as Button
+import UI.Click exposing (Click(..))
 import UI.FoldToggle as FoldToggle
 import UI.Icon as Icon exposing (Icon)
 import UI.Tooltip as Tooltip
@@ -302,12 +303,13 @@ viewInfoItems hash_ info =
                         ns =
                             FQN.toString fqn
 
-                        namespaceMenuItems =
-                            [ Tooltip.MenuItem (Just Icon.browse) ("Find within " ++ ns) (Tooltip.OnClick (FindWithinNamespace fqn))
-                            , Tooltip.MenuItem (Just Icon.intoFolder) ("Change perspective to " ++ ns) (Tooltip.OnClick (ChangePerspectiveToNamespace fqn))
-                            ]
+                        namespaceMenu =
+                            Tooltip.menu
+                                [ ( Icon.browse, "Find within " ++ ns, OnClick (FindWithinNamespace fqn) )
+                                , ( Icon.intoFolder, "Change perspective to " ++ ns, OnClick (ChangePerspectiveToNamespace fqn) )
+                                ]
                     in
-                    Tooltip.tooltip (viewInfoItem Icon.folderOutlined ns) (Tooltip.Menu namespaceMenuItems)
+                    Tooltip.tooltip (viewInfoItem Icon.folderOutlined ns) namespaceMenu
                         |> Tooltip.withArrow Tooltip.Start
                         |> Tooltip.view
 


### PR DESCRIPTION
## Overview
* Add a new subMenu, used in both collapsed and expanded version of the
  sidebar
* Add a new `UI.Click` module to track click behavior between modules
* Remove the s keybind for the sidebar

cc @hagl 