### PR TITLE
Doc: Ensure we render emojis in callouts

### DIFF
--- a/src/Definition/Doc.elm
+++ b/src/Definition/Doc.elm
@@ -433,10 +433,10 @@ view refToMsg toggleFoldMsg docFoldToggles document =
                     let
                         ( cls, ico ) =
                             case icon of
-                                Just (Word emoji) ->
-                                    ( class "callout callout-with-icon", div [ class "callout-icon" ] [ text emoji ] )
+                                Just emoji ->
+                                    ( class "callout callout-with-icon", div [ class "callout-icon" ] [ text (toString "" emoji) ] )
 
-                                _ ->
+                                Nothing ->
                                     ( class "callout", UI.nothing )
                     in
                     div [ cls ]


### PR DESCRIPTION
## Overview
Callouts seems to have emojis inside of a Span. Use the toString
function to grab the text out of any doc element that is textural in
nature regardless of depth.

<img width="732" alt="CleanShot 2021-11-09 at 23 25 24@2x" src="https://user-images.githubusercontent.com/2371/141049587-69d14ecd-1409-41fb-a9bc-9ae644ab50a0.png">

Fixes: https://github.com/unisonweb/codebase-ui/issues/272

Related https://github.com/unisonweb/unison/pull/2619