### PR TITLE
Prefer "latest" route

### DIFF
--- a/src/Route.elm
+++ b/src/Route.elm
@@ -197,17 +197,17 @@ toUrlString route =
 
                 ByNamespace Relative fqn ->
                     if includeNamespacesSuffix then
-                        "latest" :: NEL.toList (FQN.segments fqn) ++ [ namespaceSuffix ]
+                        "latest" :: "namespaces" :: NEL.toList (FQN.segments fqn) ++ [ namespaceSuffix ]
 
                     else
-                        "latest" :: NEL.toList (FQN.segments fqn)
+                        "latest" :: "namespaces" :: NEL.toList (FQN.segments fqn)
 
-                ByNamespace (Absolute hash) fqn ->
+                ByNamespace (Absolute _) fqn ->
                     if includeNamespacesSuffix then
-                        [ Hash.toUrlString hash, "namespaces" ] ++ NEL.toList (FQN.segments fqn) ++ [ namespaceSuffix ]
+                        "latest" :: "namespaces" :: NEL.toList (FQN.segments fqn) ++ [ namespaceSuffix ]
 
                     else
-                        [ Hash.toUrlString hash, "namespaces" ] ++ NEL.toList (FQN.segments fqn)
+                        "latest" :: "namespaces" :: NEL.toList (FQN.segments fqn)
 
         path =
             case route of


### PR DESCRIPTION
## Overview
This change ensures that we always use the "latest" route.

## Loose ends
Note that this fix is a bit of a hack in that the datamodel doesn't
reflect the new URL preference, a bigger re-org to mirror that should be
done shortly.