### PR TITLE
Organize the routing model to favor "latest"

### DIFF
--- a/src/CodebaseTree.elm
+++ b/src/CodebaseTree.elm
@@ -175,7 +175,7 @@ fetchSubNamespaceListing perspective fqn =
 
 fetchNamespaceListing : Perspective -> Maybe FQN -> (Result Http.Error NamespaceListing -> msg) -> ApiRequest NamespaceListing msg
 fetchNamespaceListing perspective fqn toMsg =
-    Api.list (Perspective.toParams perspective) (Maybe.map FQN.toString fqn)
+    Api.list perspective (Maybe.map FQN.toString fqn)
         |> Api.toRequest (NamespaceListing.decode fqn) toMsg
 
 

--- a/src/Perspective.elm
+++ b/src/Perspective.elm
@@ -46,14 +46,18 @@ fqn perspective =
             d.fqn
 
 
+{-| Even when we have a Codebase hash, we always constructor Relative params.
+Absolute is currently not supported (until Unison Share includes historic
+codebase), though the model allows it.
+-}
 toParams : Perspective -> PerspectiveParams
 toParams perspective =
     case perspective of
-        Codebase hash ->
-            ByCodebase (Absolute hash)
+        Codebase _ ->
+            ByCodebase Relative
 
         Namespace d ->
-            ByNamespace (Absolute d.codebaseHash) d.fqn
+            ByNamespace Relative d.fqn
 
 
 fromParams : PerspectiveParams -> Maybe Perspective

--- a/src/PreApp.elm
+++ b/src/PreApp.elm
@@ -7,7 +7,7 @@ import Browser.Navigation as Nav
 import Env exposing (Flags)
 import Html
 import Http
-import Perspective exposing (CodebasePerspectiveParam(..), Perspective, PerspectiveParams(..))
+import Perspective exposing (Perspective, PerspectiveParams)
 import Route exposing (Route)
 import Url exposing (Url)
 
@@ -63,8 +63,7 @@ init flags url navKey =
 
 fetchPerspective : PreEnv -> ApiRequest Perspective Msg
 fetchPerspective preEnv =
-    Api.list (ByCodebase Relative) (Just ".")
-        |> Api.toRequest (Perspective.decode preEnv.perspectiveParams) (FetchPerspectiveFinished preEnv)
+    Api.codebaseHash |> Api.toRequest (Perspective.decode preEnv.perspectiveParams) (FetchPerspectiveFinished preEnv)
 
 
 type Msg

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -202,12 +202,17 @@ toUrlString route =
                     else
                         "latest" :: "namespaces" :: NEL.toList (FQN.segments fqn)
 
-                ByNamespace (Absolute _) fqn ->
+                -- Currently the model supports Absolute URLs (aka Permalinks),
+                -- but we don't use it since Unison Share does not support any
+                -- history, meaning that everytime we deploy Unison Share, the
+                -- previous versions of the codebase are lost.
+                -- It's fully intended for this feature to be brought back
+                ByNamespace (Absolute hash) fqn ->
                     if includeNamespacesSuffix then
-                        "latest" :: "namespaces" :: NEL.toList (FQN.segments fqn) ++ [ namespaceSuffix ]
+                        Hash.toUrlString hash :: "namespaces" :: NEL.toList (FQN.segments fqn) ++ [ namespaceSuffix ]
 
                     else
-                        "latest" :: "namespaces" :: NEL.toList (FQN.segments fqn)
+                        Hash.toUrlString hash :: "namespaces" :: NEL.toList (FQN.segments fqn)
 
         path =
             case route of


### PR DESCRIPTION
## Overview
Ensure that we use Relative everywhere and disable Absolute URLs until we are ready to support them.

Closes https://github.com/unisonweb/codebase-ui/issues/242

## Implementation notes
Add comments to communicate why this is done (Share doesn't support history) and change PreApp to fetch the perspective information from Api.codebaseHash instead of Api.list (so we can limit Api to only use Perspective instead of PerspectiveParams).

## Loose ends
Down the line (when Share again supports historic codebases), we should design a "permalink" like feature for absolute urls similar to what we see on GitHub.
