### PR TITLE
Ensure Definitions are opened via Route changes

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -134,10 +134,20 @@ update msg ({ env } as model) =
             ( model, Cmd.none )
 
         UrlChanged url ->
-            -- URL changes happen when setting focus on a definitions.
-            -- Currently, the URL change is a result of that as oppose to focus
-            -- being a result of a URL change
-            ( { model | route = Route.fromUrl env.basePath url }, Cmd.none )
+            let
+                route =
+                    Route.fromUrl env.basePath url
+            in
+            case route of
+                Route.Definition _ ref ->
+                    let
+                        ( workspace, cmd ) =
+                            Workspace.open env model.workspace ref
+                    in
+                    ( { model | route = route, workspace = workspace }, Cmd.map WorkspaceMsg cmd )
+
+                _ ->
+                    ( { model | route = route }, Cmd.none )
 
         ChangePerspective perspective ->
             replacePerspective model perspective
@@ -165,7 +175,7 @@ update msg ({ env } as model) =
             keydown model event
 
         OpenDefinition ref ->
-            openDefinition model ref
+            navigateToDefinition model ref
 
         ShowModal modal ->
             ( { model | modal = modal }, Cmd.none )
@@ -200,7 +210,7 @@ update msg ({ env } as model) =
             in
             case outMsg of
                 PerspectiveLanding.OpenDefinition ref ->
-                    openDefinition model2 ref
+                    navigateToDefinition model2 ref
 
                 PerspectiveLanding.ShowFinderRequest ->
                     showFinder model2 Nothing
@@ -227,7 +237,7 @@ update msg ({ env } as model) =
                                 model4 =
                                     { model2 | sidebarToggled = False }
                             in
-                            openDefinition model4 ref
+                            navigateToDefinition model4 ref
 
                         CodebaseTree.ChangePerspectiveToNamespace fqn ->
                             fqn
@@ -251,7 +261,7 @@ update msg ({ env } as model) =
                             ( { model | modal = NoModal }, Cmd.none )
 
                         Finder.OpenDefinition ref ->
-                            openDefinition { model | modal = NoModal } ref
+                            navigateToDefinition { model | modal = NoModal } ref
 
                 _ ->
                     ( model, Cmd.none )
@@ -268,19 +278,9 @@ update msg ({ env } as model) =
 -- UPDATE HELPERS
 
 
-openDefinition : Model -> Reference -> ( Model, Cmd Msg )
-openDefinition model ref =
-    let
-        ( workspace, wCmd, outMsg ) =
-            Workspace.open model.env model.workspace ref
-
-        model2 =
-            { model | workspace = workspace }
-
-        ( model3, cmd ) =
-            handleWorkspaceOutMsg model2 outMsg
-    in
-    ( model3, Cmd.batch [ cmd, Cmd.map WorkspaceMsg wCmd ] )
+navigateToDefinition : Model -> Reference -> ( Model, Cmd Msg )
+navigateToDefinition model ref =
+    ( model, Route.navigateToDefinition model.navKey model.route ref )
 
 
 replacePerspective : Model -> Perspective -> ( Model, Cmd Msg )
@@ -333,7 +333,7 @@ handleWorkspaceOutMsg model out =
             showFinder model withinNamespace
 
         Workspace.Focused ref ->
-            ( model, Route.navigateToByReference model.navKey model.route ref )
+            ( model, Route.navigateToDefinition model.navKey model.route ref )
 
         Workspace.Emptied ->
             ( model, Route.navigateToCurrentPerspective model.navKey model.route )

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -2,8 +2,8 @@ module Route exposing
     ( Route(..)
     , fromUrl
     , navigate
-    , navigateToByReference
     , navigateToCurrentPerspective
+    , navigateToDefinition
     , navigateToLatestCodebase
     , navigateToPerspective
     , perspectiveParams
@@ -263,8 +263,8 @@ navigateToLatestCodebase navKey =
     navigateToPerspective navKey (ByCodebase Relative)
 
 
-navigateToByReference : Nav.Key -> Route -> Reference -> Cmd msg
-navigateToByReference navKey currentRoute reference =
+navigateToDefinition : Nav.Key -> Route -> Reference -> Cmd msg
+navigateToDefinition navKey currentRoute reference =
     navigate navKey (toDefinition currentRoute reference)
 
 


### PR DESCRIPTION
## Problem
We want the URL to be main way definitions are opened and fetched.
Previously this was an afterthought such that we fetched a definition
and then changed the URL, resulting in broken back-button behavior.

## Solution
This changes how we load definitions such that a URL is changed which,
in a route handler, causes the Workspace to open and fetch that
definition, with 1 exception: when a definition is opened from another
definition, it is important that we open the new definition relative to the
originating definition (above it or below it). In this case we open the
definition, then change the URL, which subsequently tries to open the
definition again; seeing that the definition has been opened already the
fetch attempt is cancelled.

Fixes https://github.com/unisonweb/codebase-ui/issues/236 and part of https://github.com/unisonweb/codebase-ui/issues/195 (back button still does not work for perspectives)
