### PR TITLE
Drive perspective changes off of Route changes

### DIFF
--- a/src/Definition/Reference.elm
+++ b/src/Definition/Reference.elm
@@ -1,6 +1,7 @@
 module Definition.Reference exposing (..)
 
 import FullyQualifiedName exposing (FQN)
+import Hash exposing (Hash)
 import HashQualified as HQ exposing (HashQualified)
 import UI.Icon as Icon exposing (Icon)
 import Url.Parser
@@ -36,6 +37,47 @@ urlParser toRef =
 -- HELPERS
 
 
+equals : Reference -> Reference -> Bool
+equals a b =
+    case ( a, b ) of
+        ( TermReference aHq, TermReference bHq ) ->
+            HQ.equals aHq bHq
+
+        ( TypeReference aHq, TypeReference bHq ) ->
+            HQ.equals aHq bHq
+
+        ( AbilityConstructorReference aHq, AbilityConstructorReference bHq ) ->
+            HQ.equals aHq bHq
+
+        ( DataConstructorReference aHq, DataConstructorReference bHq ) ->
+            HQ.equals aHq bHq
+
+        _ ->
+            False
+
+
+{-| Like `equals`, but compares deeper such that a HashQualified with the same
+Hash as a HashOnly are considered the same
+-}
+same : Reference -> Reference -> Bool
+same a b =
+    case ( a, b ) of
+        ( TermReference aHq, TermReference bHq ) ->
+            HQ.same aHq bHq
+
+        ( TypeReference aHq, TypeReference bHq ) ->
+            HQ.same aHq bHq
+
+        ( AbilityConstructorReference aHq, AbilityConstructorReference bHq ) ->
+            HQ.same aHq bHq
+
+        ( DataConstructorReference aHq, DataConstructorReference bHq ) ->
+            HQ.same aHq bHq
+
+        _ ->
+            False
+
+
 hashQualified : Reference -> HashQualified
 hashQualified ref =
     case ref of
@@ -55,6 +97,11 @@ hashQualified ref =
 fqn : Reference -> Maybe FQN
 fqn =
     hashQualified >> HQ.name
+
+
+hash : Reference -> Maybe Hash
+hash =
+    hashQualified >> HQ.hash
 
 
 

--- a/src/HashQualified.elm
+++ b/src/HashQualified.elm
@@ -1,9 +1,11 @@
 module HashQualified exposing
     ( HashQualified(..)
+    , equals
     , fromString
     , fromUrlString
     , hash
     , name
+    , same
     , toString
     , toUrlString
     , urlParser
@@ -75,6 +77,54 @@ urlParser =
 
 
 -- HELPERS
+
+
+equals : HashQualified -> HashQualified -> Bool
+equals a b =
+    case ( a, b ) of
+        ( NameOnly aFqn, NameOnly bFqn ) ->
+            FQN.equals aFqn bFqn
+
+        ( HashOnly aH, HashOnly bH ) ->
+            Hash.equals aH bH
+
+        ( HashQualified aFqn aH, HashQualified bFqn bH ) ->
+            FQN.equals aFqn bFqn && Hash.equals aH bH
+
+        _ ->
+            False
+
+
+{-| Like `equals`, but compares deeper such that a HashQualified with the same
+Hash as a HashOnly are considered the same, and HashQualified with the same FQN
+as a NameOnly are considered the same.
+-}
+same : HashQualified -> HashQualified -> Bool
+same a b =
+    case ( a, b ) of
+        ( NameOnly aFqn, NameOnly bFqn ) ->
+            FQN.equals aFqn bFqn
+
+        ( HashOnly aH, HashOnly bH ) ->
+            Hash.equals aH bH
+
+        ( HashQualified aFqn aH, HashQualified bFqn bH ) ->
+            FQN.equals aFqn bFqn && Hash.equals aH bH
+
+        ( HashQualified _ aH, HashOnly bH ) ->
+            Hash.equals aH bH
+
+        ( HashOnly aH, HashQualified _ bH ) ->
+            Hash.equals aH bH
+
+        ( HashQualified aFqn _, NameOnly bFqn ) ->
+            FQN.equals aFqn bFqn
+
+        ( NameOnly aFqn, HashQualified bFqn _ ) ->
+            FQN.equals aFqn bFqn
+
+        _ ->
+            False
 
 
 name : HashQualified -> Maybe FQN

--- a/src/Workspace/WorkspaceItem.elm
+++ b/src/Workspace/WorkspaceItem.elm
@@ -132,10 +132,10 @@ reference item =
 toHashReference : WorkspaceItem -> WorkspaceItem
 toHashReference workspaceItem =
     let
-        toHashOnly hash hq =
+        toHashOnly hash_ hq =
             case hq of
                 HQ.NameOnly _ ->
-                    HQ.HashOnly hash
+                    HQ.HashOnly hash_
 
                 HQ.HashOnly h ->
                     HQ.HashOnly h
@@ -252,6 +252,26 @@ hasDoc item =
 
         _ ->
             False
+
+
+{-| Attempt to get the Hash of a WorkspaceItem. First by checking if the
+Reference includes the Hash, secondly by checking the item data itself.
+-}
+hash : WorkspaceItem -> Maybe Hash
+hash wItem =
+    let
+        itemHash_ =
+            case wItem of
+                Success _ d ->
+                    Just (itemHash d.item)
+
+                _ ->
+                    Nothing
+    in
+    wItem
+        |> reference
+        |> Reference.hash
+        |> MaybeE.orElse itemHash_
 
 
 itemHash : Item -> Hash
@@ -387,21 +407,21 @@ viewInfoItems hash_ info =
         formattedHash =
             hash_ |> Hash.toShortString |> Hash.stripHashPrefix
 
-        hash =
+        hashTooltip =
             Tooltip.tooltip (viewInfoItem Icon.hash formattedHash) (Tooltip.Text (Hash.toString hash_))
                 |> Tooltip.withArrow Tooltip.Start
                 |> Tooltip.view
     in
-    div [ class "info-items" ] [ hash, namespace, otherNames ]
+    div [ class "info-items" ] [ hashTooltip, namespace, otherNames ]
 
 
 viewInfo : Zoom -> Msg -> Hash -> Info -> Category -> Html Msg
-viewInfo zoom onClick_ hash info category =
+viewInfo zoom onClick_ hash_ info category =
     div [ class "info" ]
         [ FoldToggle.foldToggle onClick_ |> FoldToggle.isOpen (zoom /= Far) |> FoldToggle.view
         , div [ class "category-icon" ] [ Icon.view (Category.icon category) ]
         , h3 [ class "name" ] [ FQN.view info.name ]
-        , viewInfoItems hash info
+        , viewInfoItems hash_ info
         ]
 
 

--- a/src/Workspace/WorkspaceItems.elm
+++ b/src/Workspace/WorkspaceItems.elm
@@ -18,8 +18,10 @@
 module Workspace.WorkspaceItems exposing (..)
 
 import Definition.Reference exposing (Reference)
+import Hash exposing (Hash)
 import List
 import List.Extra as ListE
+import Maybe.Extra as MaybeE
 import Workspace.WorkspaceItem as WorkspaceItem exposing (WorkspaceItem)
 
 
@@ -253,6 +255,14 @@ member items ref =
     items |> references |> List.member ref
 
 
+hashes : WorkspaceItems -> List Hash
+hashes items =
+    items
+        |> toList
+        |> List.map WorkspaceItem.hash
+        |> MaybeE.values
+
+
 references : WorkspaceItems -> List Reference
 references items =
     items
@@ -443,6 +453,27 @@ map f wItems =
                 , focus = f data.focus
                 , after = List.map f data.after
                 }
+
+
+find : (WorkspaceItem -> Bool) -> WorkspaceItems -> Maybe WorkspaceItem
+find pred wItems =
+    wItems
+        |> toList
+        |> ListE.find pred
+
+
+all : (WorkspaceItem -> Bool) -> WorkspaceItems -> Bool
+all pred wItems =
+    wItems
+        |> toList
+        |> List.all pred
+
+
+any : (WorkspaceItem -> Bool) -> WorkspaceItems -> Bool
+any pred wItems =
+    wItems
+        |> toList
+        |> List.any pred
 
 
 mapToList : (WorkspaceItem -> Bool -> a) -> WorkspaceItems -> List a


### PR DESCRIPTION
## Overview
Instead of changing perspectives directly and fetching details before changing the URL; first change the URL and then change the `Perspective`. Ensure that we don't fetch the `Perspective` when changing URLs to the same `Perspective` with a different definition and ensure we correctly dedupe `WorkspaceItems` when we change `Perspective`.

Fixes: https://github.com/unisonweb/codebase-ui/issues/195

## Implementation notes

To support this add a bunch of helper functions:

* Equality and sameness functions to `Reference`, `Perspective`, and `HashQualified`
* List-like functions; `find`, `any`, and `all` to `WorkspaceItems`

With regards to deduping `WorkspaceItems`, this is needed because when we change `Perspective` with any open defintions, we migrate the `WorkspaceItems` to be indexed by `Hash` instead of `FQN`, and then when the user subsequently uses the back button to the previous URL that was `FQN` based, we want to avoid re-fetching and duplicating the same item (their `Reference` are technically different in that one is `Hash` based and one is `FQN` based for the same `WorkspaceItem`). So as soon as we get the data back from the server and can see that it includes the `Hash` of an already fetched definition, we dedupe.