### PR TITLE
Catalog: Fetch catalog doc and projects and render

### DIFF
--- a/src/Hash.elm
+++ b/src/Hash.elm
@@ -13,6 +13,7 @@ module Hash exposing
     , toShortString
     , toString
     , toUrlString
+    , unsafeFromString
     , urlParser
     , urlPrefix
     )
@@ -92,6 +93,14 @@ fromString raw =
 
     else
         Nothing
+
+
+{-| !! Don't use this function outside of testing. It provides no guarantees
+for the correctness of the Hash.
+-}
+unsafeFromString : String -> Hash
+unsafeFromString raw =
+    Hash raw
 
 
 isRawHash : String -> Bool

--- a/src/UnisonShare/App.elm
+++ b/src/UnisonShare/App.elm
@@ -76,7 +76,7 @@ init env route navKey =
                 |> Maybe.map (Api.perform env.apiBasePath)
                 |> Maybe.withDefault Cmd.none
 
-        ( catalog, _ ) =
+        ( catalog, catalogCmd ) =
             Catalog.init env
 
         model =
@@ -96,6 +96,7 @@ init env route navKey =
     , Cmd.batch
         [ Cmd.map CodebaseTreeMsg codebaseTreeCmd
         , Cmd.map WorkspaceMsg workspaceCmd
+        , Cmd.map CatalogMsg catalogCmd
         , fetchNamespaceDetailsCmd
         ]
     )
@@ -153,7 +154,7 @@ update msg ({ env } as model) =
                         ( catalog, cmd ) =
                             Catalog.init model.env
                     in
-                    ( { model | catalog = catalog }, Cmd.map CatalogMsg cmd )
+                    ( { model2 | catalog = catalog }, Cmd.map CatalogMsg cmd )
 
                 Route.Definition params ref ->
                     let

--- a/src/UnisonShare/Catalog.elm
+++ b/src/UnisonShare/Catalog.elm
@@ -1,0 +1,84 @@
+module UnisonShare.Catalog exposing (..)
+
+import Dict exposing (Dict)
+import FullyQualifiedName as FQN
+import Json.Decode as Decode
+import Project exposing (ProjectListing)
+import UnisonShare.Catalog.CatalogMask as CatalogMask exposing (CatalogMask)
+
+
+type Catalog
+    = Catalog (Dict String (List ProjectListing))
+
+
+
+-- CREATE
+
+
+empty : Catalog
+empty =
+    Catalog Dict.empty
+
+
+catalog : CatalogMask -> List ProjectListing -> Catalog
+catalog mask projectListings_ =
+    let
+        catalog_ project ((Catalog dict) as acc) =
+            let
+                projectName =
+                    project
+                        |> Project.slug
+                        |> FQN.toString
+
+                categoryName =
+                    CatalogMask.categoryOf projectName mask
+
+                set old =
+                    case old of
+                        Just ps ->
+                            Just (ps ++ [ project ])
+
+                        Nothing ->
+                            Just [ project ]
+            in
+            case categoryName of
+                Just c ->
+                    Catalog (Dict.update c set dict)
+
+                Nothing ->
+                    acc
+    in
+    List.foldl catalog_ empty projectListings_
+
+
+
+-- HELPERS
+
+
+isEmpty : Catalog -> Bool
+isEmpty (Catalog dict) =
+    Dict.isEmpty dict
+
+
+categories : Catalog -> List String
+categories (Catalog dict) =
+    Dict.keys dict
+
+
+projectListings : Catalog -> List ProjectListing
+projectListings (Catalog dict) =
+    List.concat (Dict.values dict)
+
+
+toList : Catalog -> List ( String, List ProjectListing )
+toList (Catalog dict) =
+    Dict.toList dict
+
+
+
+-- DECODE
+
+
+decodeCatalogMask : Decode.Decoder CatalogMask
+decodeCatalogMask =
+    CatalogMask.decode

--- a/src/UnisonShare/Catalog/CatalogMask.elm
+++ b/src/UnisonShare/Catalog/CatalogMask.elm
@@ -1,0 +1,132 @@
+module UnisonShare.Catalog.CatalogMask exposing
+    ( CatalogMask
+    , categories
+    , categoryOf
+    , decode
+    , empty
+    , fromDoc
+    , fromList
+    , isEmpty
+    , projectNames
+    , toList
+    )
+
+import Definition.Doc as Doc exposing (Doc)
+import Dict exposing (Dict)
+import Json.Decode as Decode exposing (field, index)
+import List.Extra as ListE
+
+
+{-| CatalogMask is used to create the Catalog and map ProjectListings to their
+categories.
+
+Indexed by project to category "unison.http" -> "Web & Networking"
+
+-}
+type CatalogMask
+    = CatalogMask (Dict String String)
+
+
+
+-- Create
+
+
+empty : CatalogMask
+empty =
+    CatalogMask Dict.empty
+
+
+fromList : List ( String, String ) -> CatalogMask
+fromList categories_ =
+    CatalogMask (Dict.fromList categories_)
+
+
+{-| For right now, a CatalogMask is fetched as a Doc from the server and as
+such we can parse that into a CatalogMask if it has the right shape (if not,
+its an empty mask)
+-}
+fromDoc : Doc -> CatalogMask
+fromDoc doc =
+    let
+        category_ d =
+            case d of
+                Doc.Section category content ->
+                    case content of
+                        [ Doc.BulletedList projects ] ->
+                            List.map (\p -> ( Doc.toString "" p, Doc.toString " " category )) projects
+
+                        _ ->
+                            []
+
+                _ ->
+                    []
+
+        categories_ =
+            case doc of
+                Doc.UntitledSection ds ->
+                    List.concatMap category_ ds
+
+                _ ->
+                    []
+    in
+    fromList categories_
+
+
+
+-- Helpers
+
+
+isEmpty : CatalogMask -> Bool
+isEmpty (CatalogMask mask) =
+    Dict.isEmpty mask
+
+
+categoryOf : String -> CatalogMask -> Maybe String
+categoryOf projectName (CatalogMask mask) =
+    Dict.get projectName mask
+
+
+categories : CatalogMask -> List String
+categories (CatalogMask mask) =
+    Dict.values mask |> ListE.unique
+
+
+projectNames : CatalogMask -> List String
+projectNames (CatalogMask mask) =
+    Dict.keys mask
+
+
+toList : CatalogMask -> List ( String, String )
+toList (CatalogMask mask) =
+    Dict.toList mask
+
+
+
+-- Decode
+
+
+decode : Decode.Decoder CatalogMask
+decode =
+    Decode.map fromDoc decodeCatalogDoc
+
+
+decodeCatalogDoc : Decode.Decoder Doc
+decodeCatalogDoc =
+    let
+        decodeDoc : Decode.Decoder Doc
+        decodeDoc =
+            field "termDocs" (index 0 (index 2 Doc.decode))
+
+        decodeTermDocs : Decode.Decoder (List Doc)
+        decodeTermDocs =
+            Decode.keyValuePairs decodeDoc |> Decode.map (List.map Tuple.second)
+
+        decodeList : Decode.Decoder (List Doc)
+        decodeList =
+            field "termDefinitions" decodeTermDocs
+    in
+    Decode.map List.head decodeList
+        |> Decode.andThen
+            (Maybe.map Decode.succeed
+                >> Maybe.withDefault (Decode.fail "Empty list")
+            )

--- a/tests/ProjectTests.elm
+++ b/tests/ProjectTests.elm
@@ -1,0 +1,30 @@
+module ProjectTests exposing (..)
+
+import Expect
+import FullyQualifiedName as FQN
+import Hash
+import Project
+import Test exposing (..)
+
+
+slug : Test
+slug =
+    describe "Project.slug"
+        [ test "Returns the slug of a project by owner and name" <|
+            \_ ->
+                Expect.equal
+                    "unison.http"
+                    (Project.slug project |> FQN.toString)
+        ]
+
+
+
+-- Helpers
+
+
+project : Project.ProjectListing
+project =
+    { owner = Project.Owner "unison"
+    , name = FQN.fromString "http"
+    , hash = Hash.unsafeFromString "##unison.http"
+    }

--- a/tests/UnisonShare/Catalog/CatalogMaskTests.elm
+++ b/tests/UnisonShare/Catalog/CatalogMaskTests.elm
@@ -1,0 +1,114 @@
+module UnisonShare.Catalog.CatalogMaskTests exposing (..)
+
+import Definition.Doc as Doc
+import Expect
+import Test exposing (..)
+import UnisonShare.Catalog.CatalogMask as CatalogMask
+
+
+fromDoc : Test
+fromDoc =
+    describe "CatalogMask.fromDoc"
+        [ test "Creates a CatalogMask from a Doc" <|
+            \_ ->
+                Expect.equal (List.sort rawMask)
+                    (CatalogMask.fromDoc doc |> CatalogMask.toList |> List.sort)
+        ]
+
+
+fromList : Test
+fromList =
+    describe "CatalogMask.fromList"
+        [ test "Creates a CatalogMask from a List" <|
+            \_ ->
+                let
+                    catalogMask =
+                        CatalogMask.fromList rawMask
+                in
+                Expect.equal (List.sort rawMask)
+                    (CatalogMask.toList catalogMask |> List.sort)
+        ]
+
+
+categoryOf : Test
+categoryOf =
+    describe "CatalogMask.categoryOf"
+        [ test "given a project, returns its category " <|
+            \_ ->
+                let
+                    catalogMask =
+                        CatalogMask.fromList rawMask
+                in
+                Expect.equal (Just "Featured") (CatalogMask.categoryOf "unison.base" catalogMask)
+        ]
+
+
+categories : Test
+categories =
+    describe "CatalogMask.categories"
+        [ test "Returns all categories in a Mask" <|
+            \_ ->
+                let
+                    catalogMask =
+                        CatalogMask.fromList rawMask
+                in
+                Expect.equal
+                    (List.sort
+                        [ "Featured"
+                        , "Web & Networking"
+                        , "Parsers & Text Manipulation"
+                        , "Datatypes"
+                        ]
+                    )
+                    (CatalogMask.categories catalogMask |> List.sort)
+        ]
+
+
+projectNames : Test
+projectNames =
+    describe "CatalogMask.projectNames"
+        [ test "Returns all project names in a Mask" <|
+            \_ ->
+                let
+                    catalogMask =
+                        CatalogMask.fromList rawMask
+                in
+                Expect.equal
+                    (List.sort
+                        [ "unison.base"
+                        , "unison.distributed"
+                        , "unison.http"
+                        , "hojberg.textExtra"
+                        , "hojberg.nanoid"
+                        ]
+                    )
+                    (CatalogMask.projectNames catalogMask |> List.sort)
+        ]
+
+
+
+-- HELPERS
+
+
+rawMask : List ( String, String )
+rawMask =
+    [ ( "unison.base", "Featured" )
+    , ( "unison.distributed", "Featured" )
+    , ( "unison.http", "Web & Networking" )
+    , ( "hojberg.textExtra", "Parsers & Text Manipulation" )
+    , ( "hojberg.nanoid", "Datatypes" )
+    ]
+
+
+doc : Doc.Doc
+doc =
+    Doc.UntitledSection
+        [ Doc.Section (Doc.Word "Featured")
+            [ Doc.BulletedList [ Doc.Word "unison.base", Doc.Word "unison.distributed" ] ]
+        , Doc.Section (Doc.Word "Web & Networking")
+            [ Doc.BulletedList [ Doc.Word "unison.http" ] ]
+        , Doc.Section (Doc.Word "Parsers & Text Manipulation")
+            [ Doc.BulletedList [ Doc.Word "hojberg.textExtra" ] ]
+        , Doc.Section (Doc.Word "Datatypes")
+            [ Doc.BulletedList [ Doc.Word "hojberg.nanoid" ] ]
+        ]

--- a/tests/UnisonShare/CatalogTests.elm
+++ b/tests/UnisonShare/CatalogTests.elm
@@ -1,0 +1,140 @@
+module UnisonShare.CatalogTests exposing (..)
+
+import Expect
+import FullyQualifiedName as FQN
+import Hash
+import Project
+import Test exposing (..)
+import UnisonShare.Catalog as Catalog
+import UnisonShare.Catalog.CatalogMask as CatalogMask
+
+
+catalog : Test
+catalog =
+    describe "Catalog.catalog"
+        [ describe "Create a Catalog from a CatalogMask and ProjectListings"
+            [ test "It retains only the overlapping items between the mask and the listings" <|
+                \_ ->
+                    let
+                        projectListings_ =
+                            [ baseListing, distributedListing, textExtraListing, nanoidListing ]
+
+                        catalog_ =
+                            Catalog.catalog catalogMask projectListings_
+                    in
+                    Expect.equal
+                        [ ( "Featured", [ baseListing, distributedListing ] )
+                        , ( "Parsers & Text Manipulation", [ textExtraListing ] )
+                        ]
+                        (Catalog.toList catalog_)
+            ]
+        ]
+
+
+categories : Test
+categories =
+    describe "Catalog.categories"
+        [ test "Extracts the categories of a Catalog that exist in both the mask and the project listings" <|
+            \_ ->
+                let
+                    projectListings_ =
+                        [ baseListing, distributedListing, textExtraListing ]
+
+                    catalog_ =
+                        Catalog.catalog catalogMask projectListings_
+                in
+                Expect.equal [ "Featured", "Parsers & Text Manipulation" ] (Catalog.categories catalog_)
+        ]
+
+
+projectListings : Test
+projectListings =
+    describe "Catalog.projectListings"
+        [ test "Extracts the projectListings of a Catalog that exist in both the mask and the project listings" <|
+            \_ ->
+                let
+                    projectListings_ =
+                        [ baseListing, textExtraListing, nanoidListing ]
+
+                    catalog_ =
+                        Catalog.catalog catalogMask projectListings_
+                in
+                Expect.equal [ baseListing, textExtraListing ] (Catalog.projectListings catalog_)
+        ]
+
+
+toList : Test
+toList =
+    describe "Catalog.toList"
+        [ test "Returns the Catalog as a List" <|
+            \_ ->
+                let
+                    projectListings_ =
+                        [ baseListing, distributedListing, textExtraListing, nanoidListing ]
+
+                    catalog_ =
+                        Catalog.catalog catalogMask projectListings_
+                in
+                Expect.equal
+                    [ ( "Featured", [ baseListing, distributedListing ] )
+                    , ( "Parsers & Text Manipulation", [ textExtraListing ] )
+                    ]
+                    (Catalog.toList catalog_)
+        ]
+
+
+
+-- helpers
+
+
+catalogMask : CatalogMask.CatalogMask
+catalogMask =
+    CatalogMask.fromList
+        [ ( "unison.base", "Featured" )
+        , ( "unison.distributed", "Featured" )
+        , ( "unison.http", "Web & Networking" )
+        , ( "hojberg.textExtra", "Parsers & Text Manipulation" )
+        , ( "hojberg.money", "Datatypes" )
+        ]
+
+
+baseListing : Project.ProjectListing
+baseListing =
+    { owner = Project.Owner "unison"
+    , name = FQN.fromString "base"
+    , hash = Hash.unsafeFromString "##unison.base"
+    }
+
+
+distributedListing : Project.ProjectListing
+distributedListing =
+    { owner = Project.Owner "unison"
+    , name = FQN.fromString "distributed"
+    , hash = Hash.unsafeFromString "##unison.distributed"
+    }
+
+
+httpListing : Project.ProjectListing
+httpListing =
+    { owner = Project.Owner "unison"
+    , name = FQN.fromString "http"
+    , hash = Hash.unsafeFromString "##unison.http"
+    }
+
+
+textExtraListing : Project.ProjectListing
+textExtraListing =
+    { owner = Project.Owner "hojberg"
+    , name = FQN.fromString "textExtra"
+    , hash = Hash.unsafeFromString "##hojberg.textExtra"
+    }
+
+
+{-| Note: does purposely not exist in mask
+-}
+nanoidListing : Project.ProjectListing
+nanoidListing =
+    { owner = Project.Owner "hojberg"
+    , name = FQN.fromString "nanoid"
+    , hash = Hash.unsafeFromString "##hojberg.nanoid"
+    }


### PR DESCRIPTION
## Problem
Part of the new Catalog page https://github.com/unisonweb/codebase-ui/issues/144

## Solution
Fetch the full catalog for the Catalog page by fetching the special
catalog doc and parsing it into a CatalogMask which is used to
categorize projects which are now also fetched.

With the data in hand the page renders a series of `UI.Card` components
for each category with their projects.

![CleanShot 2021-12-17 at 13 19 25@2x](https://user-images.githubusercontent.com/2371/146590130-965b5f47-2859-440c-98db-92e2e70835f5.png)


## Caveats/Notes
Note that the categories are not currently sorted, but we'll want them
to be in the future.
