### PR TITLE
Catalog: ensure the catalog is sorted by category

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -20,6 +20,7 @@
             "elm-community/list-extra": "8.2.4",
             "elm-community/maybe-extra": "5.2.0",
             "elm-community/string-extra": "4.0.1",
+            "j-maas/elm-ordered-containers": "1.0.0",
             "krisajenkins/remotedata": "6.0.1",
             "mgold/elm-nonempty-list": "4.1.0",
             "stoeffel/set-extra": "1.2.3",

--- a/src/UnisonShare/Catalog/CatalogMask.elm
+++ b/src/UnisonShare/Catalog/CatalogMask.elm
@@ -12,9 +12,9 @@ module UnisonShare.Catalog.CatalogMask exposing
     )
 
 import Definition.Doc as Doc exposing (Doc)
-import Dict exposing (Dict)
 import Json.Decode as Decode exposing (field, index)
 import List.Extra as ListE
+import OrderedDict exposing (OrderedDict)
 
 
 {-| CatalogMask is used to create the Catalog and map ProjectListings to their
@@ -24,7 +24,7 @@ Indexed by project to category "unison.http" -> "Web & Networking"
 
 -}
 type CatalogMask
-    = CatalogMask (Dict String String)
+    = CatalogMask (OrderedDict String String)
 
 
 
@@ -33,12 +33,12 @@ type CatalogMask
 
 empty : CatalogMask
 empty =
-    CatalogMask Dict.empty
+    CatalogMask OrderedDict.empty
 
 
 fromList : List ( String, String ) -> CatalogMask
 fromList categories_ =
-    CatalogMask (Dict.fromList categories_)
+    CatalogMask (OrderedDict.fromList categories_)
 
 
 {-| For right now, a CatalogMask is fetched as a Doc from the server and as
@@ -78,27 +78,27 @@ fromDoc doc =
 
 isEmpty : CatalogMask -> Bool
 isEmpty (CatalogMask mask) =
-    Dict.isEmpty mask
+    OrderedDict.isEmpty mask
 
 
 categoryOf : String -> CatalogMask -> Maybe String
 categoryOf projectName (CatalogMask mask) =
-    Dict.get projectName mask
+    OrderedDict.get projectName mask
 
 
 categories : CatalogMask -> List String
 categories (CatalogMask mask) =
-    Dict.values mask |> ListE.unique
+    OrderedDict.values mask |> ListE.unique
 
 
 projectNames : CatalogMask -> List String
 projectNames (CatalogMask mask) =
-    Dict.keys mask
+    OrderedDict.keys mask
 
 
 toList : CatalogMask -> List ( String, String )
 toList (CatalogMask mask) =
-    Dict.toList mask
+    OrderedDict.toList mask
 
 
 

--- a/tests/UnisonShare/Catalog/CatalogMaskTests.elm
+++ b/tests/UnisonShare/Catalog/CatalogMaskTests.elm
@@ -11,8 +11,8 @@ fromDoc =
     describe "CatalogMask.fromDoc"
         [ test "Creates a CatalogMask from a Doc" <|
             \_ ->
-                Expect.equal (List.sort rawMask)
-                    (CatalogMask.fromDoc doc |> CatalogMask.toList |> List.sort)
+                Expect.equal rawMask
+                    (CatalogMask.fromDoc doc |> CatalogMask.toList)
         ]
 
 
@@ -25,8 +25,8 @@ fromList =
                     catalogMask =
                         CatalogMask.fromList rawMask
                 in
-                Expect.equal (List.sort rawMask)
-                    (CatalogMask.toList catalogMask |> List.sort)
+                Expect.equal rawMask
+                    (CatalogMask.toList catalogMask)
         ]
 
 
@@ -53,14 +53,12 @@ categories =
                         CatalogMask.fromList rawMask
                 in
                 Expect.equal
-                    (List.sort
-                        [ "Featured"
-                        , "Web & Networking"
-                        , "Parsers & Text Manipulation"
-                        , "Datatypes"
-                        ]
-                    )
-                    (CatalogMask.categories catalogMask |> List.sort)
+                    [ "Featured"
+                    , "Web & Networking"
+                    , "Parsers & Text Manipulation"
+                    , "Datatypes"
+                    ]
+                    (CatalogMask.categories catalogMask)
         ]
 
 
@@ -74,15 +72,13 @@ projectNames =
                         CatalogMask.fromList rawMask
                 in
                 Expect.equal
-                    (List.sort
-                        [ "unison.base"
-                        , "unison.distributed"
-                        , "unison.http"
-                        , "hojberg.textExtra"
-                        , "hojberg.nanoid"
-                        ]
-                    )
-                    (CatalogMask.projectNames catalogMask |> List.sort)
+                    [ "unison.base"
+                    , "unison.distributed"
+                    , "unison.http"
+                    , "hojberg.textExtra"
+                    , "hojberg.nanoid"
+                    ]
+                    (CatalogMask.projectNames catalogMask)
         ]
 
 


### PR DESCRIPTION
## Problem
Projects in the catalog should be sorted by the fetched Catalog doc

## Solution
Using the categories CategoryMask (and OrderedDict), sort the Catalog
such that it matches the original order in the catalog Doc.