### PR TITLE
Temporarily hide the _catalog doc

### DIFF
--- a/src/CodebaseTree.elm
+++ b/src/CodebaseTree.elm
@@ -194,11 +194,17 @@ viewListingRow clickMsg label_ category icon =
                 |> Maybe.map (\msg -> a [ containerClass, onClick msg ])
                 |> Maybe.withDefault (span [ containerClass ])
     in
-    container
-        [ Icon.view icon
-        , viewListingLabel label_
-        , span [ class "definition-category" ] [ text category ]
-        ]
+    -- TODO: Temporary work around to avoid the hidden catalog definition to
+    -- show up on Share while the catalog page is being worked on
+    if label_ == "_catalog" then
+        UI.nothing
+
+    else
+        container
+            [ Icon.view icon
+            , viewListingLabel label_
+            , span [ class "definition-category" ] [ text category ]
+            ]
 
 
 viewListingLabel : String -> Html msg


### PR DESCRIPTION
## Problem
Unison Share will have a new front page that features a catalog which is derived from a Unison Doc. This page will mean that users will never see a tree view of the top of the Unison Share like they do now.

While the Catalog page is being worked on, but not switched over to, we want to hide the _catalog doc from the top level codebase tree to avoid any confusion. 

This will enable us to merge https://github.com/unisonweb/share/pull/30 and to start exploring the catalog on a url that isn't linked to from anywhere.

## Solution
Add a simple check to hide codebase tree entries named `_catalog`.

## Caveats/Notes
* This should be removed later when the Catalog page is in place.
* This catches **any** definitions named `_catalog` regardless of where in the tree they are, but this is deemed ok since its temporary.

