### PR TITLE
Move route specific keyboardshortcuts to pages

### DIFF
--- a/src/UnisonLocal/App.elm
+++ b/src/UnisonLocal/App.elm
@@ -384,24 +384,11 @@ keydown model keyboardEvent =
             ( { model | sidebarToggled = not model.sidebarToggled }, Cmd.none )
     in
     case shortcut of
-        KeyboardShortcut.Chord Ctrl (K _) ->
-            showFinder model Nothing
-
-        KeyboardShortcut.Chord Meta (K _) ->
-            if model.env.operatingSystem == Env.MacOS then
-                showFinder model Nothing
-
-            else
-                noOp
-
         KeyboardShortcut.Chord Ctrl (B _) ->
             toggleSidebar
 
         KeyboardShortcut.Chord Meta (B _) ->
             toggleSidebar
-
-        KeyboardShortcut.Sequence _ ForwardSlash ->
-            showFinder model Nothing
 
         KeyboardShortcut.Chord Shift QuestionMark ->
             ( { model | modal = HelpModal }, Cmd.none )

--- a/src/Workspace.elm
+++ b/src/Workspace.elm
@@ -175,7 +175,7 @@ update env msg ({ workspaceItems } as model) =
                     KeyboardShortcut.fromKeyboardEvent model.keyboardShortcut event
 
                 ( nextModel, cmd, out ) =
-                    handleKeyboardShortcut { model | keyboardShortcut = keyboardShortcut } shortcut
+                    handleKeyboardShortcut env { model | keyboardShortcut = keyboardShortcut } shortcut
             in
             ( nextModel, Cmd.batch [ cmd, Cmd.map KeyboardShortcutMsg kCmd ], out )
 
@@ -313,8 +313,8 @@ openDefinitionsFocusToOutMsg openDefs =
         |> Maybe.withDefault Emptied
 
 
-handleKeyboardShortcut : Model -> KeyboardShortcut -> ( Model, Cmd Msg, OutMsg )
-handleKeyboardShortcut ({ workspaceItems } as model) shortcut =
+handleKeyboardShortcut : Env -> Model -> KeyboardShortcut -> ( Model, Cmd Msg, OutMsg )
+handleKeyboardShortcut env ({ workspaceItems } as model) shortcut =
     let
         scrollToCmd =
             WorkspaceItems.focus
@@ -351,6 +351,19 @@ handleKeyboardShortcut ({ workspaceItems } as model) shortcut =
             ( { model | workspaceItems = next }, scrollToCmd next, openDefinitionsFocusToOutMsg next )
     in
     case shortcut of
+        KeyboardShortcut.Chord Ctrl (K _) ->
+            ( model, Cmd.none, ShowFinderRequest Nothing )
+
+        KeyboardShortcut.Chord Meta (K _) ->
+            if env.operatingSystem == Env.MacOS then
+                ( model, Cmd.none, ShowFinderRequest Nothing )
+
+            else
+                ( model, Cmd.none, None )
+
+        Sequence _ ForwardSlash ->
+            ( model, Cmd.none, ShowFinderRequest Nothing )
+
         Chord Alt ArrowDown ->
             moveDown
 


### PR DESCRIPTION
## Problem
We don't want Workspace keyboard shortcuts to trigger when on another page like the Catalog.

## Solution
Only pass submessages down to sub pages if the corresponding route is active.

Notably this also means that things like the Finder are no longer an App concern, by a Workspace shortcut. There's a few other things that should be moved down a layer like toggling the sidebar, but this should only happen for Share and not for Local (this is not tackled in this effort).

## Caveats/Notes
Issues that address things you didn't get to or general notes
