### PR TITLE
Add keyboard support to catalog search

### DIFF
--- a/src/Env.elm
+++ b/src/Env.elm
@@ -1,6 +1,7 @@
 module Env exposing (..)
 
 import Api exposing (ApiBasePath(..))
+import Browser.Navigation as Nav
 import Env.AppContext as AppContext exposing (AppContext)
 import Perspective exposing (Perspective)
 
@@ -19,6 +20,7 @@ type alias Env =
     , basePath : String
     , apiBasePath : ApiBasePath
     , appContext : AppContext
+    , navKey : Nav.Key
     , perspective : Perspective
     }
 
@@ -31,12 +33,13 @@ type alias Flags =
     }
 
 
-init : Flags -> Perspective -> Env
-init flags perspective =
+init : Flags -> Nav.Key -> Perspective -> Env
+init flags navKey perspective =
     { operatingSystem = operatingSystemFromString flags.operatingSystem
     , basePath = flags.basePath
     , apiBasePath = ApiBasePath flags.apiBasePath
     , appContext = AppContext.fromString flags.appContext
+    , navKey = navKey
     , perspective = perspective
     }
 

--- a/src/SearchResults.elm
+++ b/src/SearchResults.elm
@@ -1,6 +1,7 @@
 module SearchResults exposing
     ( Matches
     , SearchResults(..)
+    , empty
     , focus
     , focusOn
     , from
@@ -30,6 +31,11 @@ import Maybe.Extra exposing (unwrap)
 type SearchResults a
     = Empty
     | SearchResults (Matches a)
+
+
+empty : SearchResults a
+empty =
+    Empty
 
 
 isEmpty : SearchResults a -> Bool

--- a/src/UnisonLocal/App.elm
+++ b/src/UnisonLocal/App.elm
@@ -48,8 +48,7 @@ type Modal
 
 
 type alias Model =
-    { navKey : Nav.Key
-    , route : Route
+    { route : Route
     , codebaseTree : CodebaseTree.Model
     , workspace : Workspace.Model
     , perspectiveLanding : PerspectiveLanding.Model
@@ -63,8 +62,8 @@ type alias Model =
     }
 
 
-init : Env -> Route -> Nav.Key -> ( Model, Cmd Msg )
-init env route navKey =
+init : Env -> Route -> ( Model, Cmd Msg )
+init env route =
     let
         ( workspace, workspaceCmd ) =
             case route of
@@ -84,8 +83,7 @@ init env route navKey =
                 |> Maybe.withDefault Cmd.none
 
         model =
-            { navKey = navKey
-            , route = route
+            { route = route
             , workspace = workspace
             , perspectiveLanding = PerspectiveLanding.init
             , codebaseTree = codebaseTree
@@ -132,7 +130,7 @@ update msg ({ env } as model) =
         LinkClicked urlRequest ->
             case urlRequest of
                 Browser.Internal url ->
-                    ( model, Nav.pushUrl model.navKey (Url.toString url) )
+                    ( model, Nav.pushUrl env.navKey (Url.toString url) )
 
                 -- External links are handled via target blank and never end up
                 -- here
@@ -298,7 +296,7 @@ update msg ({ env } as model) =
 
 navigateToDefinition : Model -> Reference -> ( Model, Cmd Msg )
 navigateToDefinition model ref =
-    ( model, Route.navigateToDefinition model.navKey model.route ref )
+    ( model, Route.navigateToDefinition model.env.navKey model.route ref )
 
 
 navigateToPerspective : Model -> Perspective -> ( Model, Cmd Msg )
@@ -318,7 +316,7 @@ navigateToPerspective model perspective =
                 |> Maybe.withDefault model.route
 
         changeRouteCmd =
-            Route.replacePerspective model.navKey (Perspective.toParams perspective) focusedReferenceRoute
+            Route.replacePerspective model.env.navKey (Perspective.toParams perspective) focusedReferenceRoute
     in
     ( { model | workspace = workspace }, changeRouteCmd )
 
@@ -351,7 +349,7 @@ fetchPerspectiveAndCodebaseTree oldPerspective ({ env } as model) =
 
 
 handleWorkspaceOutMsg : Model -> Workspace.OutMsg -> ( Model, Cmd Msg )
-handleWorkspaceOutMsg model out =
+handleWorkspaceOutMsg ({ env } as model) out =
     case out of
         Workspace.None ->
             ( model, Cmd.none )
@@ -360,10 +358,10 @@ handleWorkspaceOutMsg model out =
             showFinder model withinNamespace
 
         Workspace.Focused ref ->
-            ( model, Route.navigateToDefinition model.navKey model.route ref )
+            ( model, Route.navigateToDefinition env.navKey model.route ref )
 
         Workspace.Emptied ->
-            ( model, Route.navigateToCurrentPerspective model.navKey model.route )
+            ( model, Route.navigateToCurrentPerspective env.navKey model.route )
 
         Workspace.ChangePerspectiveToNamespace fqn ->
             fqn

--- a/src/UnisonLocal/PreApp.elm
+++ b/src/UnisonLocal/PreApp.elm
@@ -42,10 +42,10 @@ init flags url navKey =
         perspectiveToAppInit perspective =
             let
                 env =
-                    Env.init preEnv.flags perspective
+                    Env.init preEnv.flags preEnv.navKey perspective
 
                 ( app, cmd ) =
-                    App.init env preEnv.route preEnv.navKey
+                    App.init env preEnv.route
             in
             ( Initialized app, Cmd.map AppMsg cmd )
 
@@ -79,7 +79,7 @@ update msg model =
                 Ok perspective ->
                     let
                         env =
-                            Env.init preEnv.flags perspective
+                            Env.init preEnv.flags preEnv.navKey perspective
 
                         newRoute =
                             perspective
@@ -87,7 +87,7 @@ update msg model =
                                 |> Route.updatePerspectiveParams preEnv.route
 
                         ( app, cmd ) =
-                            App.init env newRoute preEnv.navKey
+                            App.init env newRoute
                     in
                     ( Initialized app, Cmd.map AppMsg cmd )
 

--- a/src/UnisonShare/App.elm
+++ b/src/UnisonShare/App.elm
@@ -40,8 +40,7 @@ import Workspace.WorkspaceItems as WorkspaceItems
 
 
 type alias Model =
-    { navKey : Nav.Key
-    , route : Route
+    { route : Route
     , codebaseTree : CodebaseTree.Model
     , workspace : Workspace.Model
     , perspectiveLanding : PerspectiveLanding.Model
@@ -56,8 +55,8 @@ type alias Model =
     }
 
 
-init : Env -> Route -> Nav.Key -> ( Model, Cmd Msg )
-init env route navKey =
+init : Env -> Route -> ( Model, Cmd Msg )
+init env route =
     let
         -- TODO: This whole thing should be route driven
         ( workspace, workspaceCmd ) =
@@ -81,8 +80,7 @@ init env route navKey =
             Catalog.init env
 
         model =
-            { navKey = navKey
-            , route = route
+            { route = route
             , workspace = workspace
             , perspectiveLanding = PerspectiveLanding.init
             , codebaseTree = codebaseTree
@@ -131,7 +129,7 @@ update msg ({ env } as model) =
         ( _, LinkClicked urlRequest ) ->
             case urlRequest of
                 Browser.Internal url ->
-                    ( model, Nav.pushUrl model.navKey (Url.toString url) )
+                    ( model, Nav.pushUrl env.navKey (Url.toString url) )
 
                 -- External links are handled via target blank and never end up
                 -- here
@@ -230,7 +228,7 @@ update msg ({ env } as model) =
         ( Route.Catalog, CatalogMsg cMsg ) ->
             let
                 ( catalog, cmd ) =
-                    Catalog.update cMsg model.catalog
+                    Catalog.update env cMsg model.catalog
             in
             ( { model | catalog = catalog }, Cmd.map CatalogMsg cmd )
 
@@ -310,7 +308,7 @@ update msg ({ env } as model) =
 
 navigateToDefinition : Model -> Reference -> ( Model, Cmd Msg )
 navigateToDefinition model ref =
-    ( model, Route.navigateToDefinition model.navKey model.route ref )
+    ( model, Route.navigateToDefinition model.env.navKey model.route ref )
 
 
 navigateToPerspective : Model -> Perspective -> ( Model, Cmd Msg )
@@ -330,7 +328,7 @@ navigateToPerspective model perspective =
                 |> Maybe.withDefault model.route
 
         changeRouteCmd =
-            Route.replacePerspective model.navKey (Perspective.toParams perspective) focusedReferenceRoute
+            Route.replacePerspective model.env.navKey (Perspective.toParams perspective) focusedReferenceRoute
     in
     ( { model | workspace = workspace }, changeRouteCmd )
 
@@ -363,7 +361,7 @@ fetchPerspectiveAndCodebaseTree oldPerspective ({ env } as model) =
 
 
 handleWorkspaceOutMsg : Model -> Workspace.OutMsg -> ( Model, Cmd Msg )
-handleWorkspaceOutMsg model out =
+handleWorkspaceOutMsg ({ env } as model) out =
     case out of
         Workspace.None ->
             ( model, Cmd.none )
@@ -372,14 +370,14 @@ handleWorkspaceOutMsg model out =
             showFinder model withinNamespace
 
         Workspace.Focused ref ->
-            ( model, Route.navigateToDefinition model.navKey model.route ref )
+            ( model, Route.navigateToDefinition env.navKey model.route ref )
 
         Workspace.Emptied ->
-            ( model, Route.navigateToCurrentPerspective model.navKey model.route )
+            ( model, Route.navigateToCurrentPerspective env.navKey model.route )
 
         Workspace.ChangePerspectiveToNamespace fqn ->
             fqn
-                |> Perspective.toNamespacePerspective model.env.perspective
+                |> Perspective.toNamespacePerspective env.perspective
                 |> navigateToPerspective model
 
 

--- a/src/UnisonShare/PreApp.elm
+++ b/src/UnisonShare/PreApp.elm
@@ -47,10 +47,10 @@ init flags url navKey =
         perspectiveToAppInit perspective =
             let
                 env =
-                    Env.init preEnv.flags perspective
+                    Env.init preEnv.flags preEnv.navKey perspective
 
                 ( app, cmd ) =
-                    App.init env preEnv.route preEnv.navKey
+                    App.init env preEnv.route
             in
             ( Initialized app, Cmd.map AppMsg cmd )
 
@@ -84,7 +84,7 @@ update msg model =
                 Ok perspective ->
                     let
                         env =
-                            Env.init preEnv.flags perspective
+                            Env.init preEnv.flags preEnv.navKey perspective
 
                         newRoute =
                             perspective
@@ -92,7 +92,7 @@ update msg model =
                                 |> Route.updatePerspectiveParams preEnv.route
 
                         ( app, cmd ) =
-                            App.init env newRoute preEnv.navKey
+                            App.init env newRoute
                     in
                     ( Initialized app, Cmd.map AppMsg cmd )
 

--- a/src/UnisonShare/Route.elm
+++ b/src/UnisonShare/Route.elm
@@ -8,6 +8,7 @@ module UnisonShare.Route exposing
     , navigateToDefinition
     , navigateToLatestCodebase
     , navigateToPerspective
+    , navigateToProject
     , perspectiveParams
     , replacePerspective
     , toDefinition
@@ -284,6 +285,11 @@ navigate navKey route =
     route
         |> toUrlString
         |> Nav.pushUrl navKey
+
+
+navigateToProject : Nav.Key -> Project a -> Cmd msg
+navigateToProject navKey project =
+    navigate navKey (forProject project)
 
 
 

--- a/src/css/elements/card.css
+++ b/src/css/elements/card.css
@@ -11,6 +11,6 @@
 .card .card-title {
   color: var(--color-card-title);
   text-transform: uppercase;
-  font-size: var(--font-size-medium);
+  font-size: var(--font-size-small);
   font-weight: normal;
 }

--- a/src/css/unison-share/page/catalog.css
+++ b/src/css/unison-share/page/catalog.css
@@ -116,33 +116,67 @@
   background: var(--color-main-bg);
   border-top: 1px solid var(--color-gray-lighten-50);
   border-radius: 0 0 var(--border-radius-base) var(--border-radius-base);
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
   padding: 0.75rem;
 }
 
-.catalog-hero .catalog-search .search-results .search-result {
-  display: flex;
-  flex-direction: row;
-  padding: 0.5rem 1rem;
-  align-items: center;
+.catalog-hero .catalog-search .search-results table {
+  width: 100%;
+}
+
+.catalog-hero .catalog-search .search-results .search-result td {
+  padding: 0.5rem 0.75rem;
   height: 3rem;
-  border-radius: var(--border-radius-base);
   font-size: 1rem;
 }
 
-.catalog-hero .catalog-search .search-results .search-result:hover {
-  background: var(--color-gray-lighten-55);
-  text-decoration: none;
+.catalog-hero .catalog-search .search-results td:first-child {
+  border-radius: var(--border-radius-base) 0 0 var(--border-radius-base);
 }
 
-.catalog-hero .catalog-search .search-results .search-result .category {
+.catalog-hero .catalog-search .search-results td:last {
+  border-radius: 0 var(--border-radius-base) var(--border-radius-base) 0;
+}
+
+.catalog-hero .catalog-search .search-results .search-result td.project-name {
+  width: 20em;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.catalog-hero .catalog-search .search-results .search-result td.category {
   color: var(--color-main-subtle-fg);
-  font-size: var(--font-size-medium);
-  margin-left: auto;
-  justify-self: flex-end;
+  font-size: var(--font-size-small);
   text-transform: uppercase;
+}
+
+.catalog-hero .catalog-search .search-results .search-result .shortcut {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.catalog-hero .catalog-search .search-results .search-result .key {
+  color: var(--color-modal-subtle-fg-em);
+  background: var(--color-modal-subtle-bg);
+}
+
+.catalog-hero .catalog-search .search-results .search-result .key.active {
+  color: var(--color-modal-focus-subtle-fg);
+  background: var(--color-modal-focus-subtle-bg);
+}
+
+.catalog-hero .catalog-search .search-results .search-result.focused {
+  background: var(--color-gray-lighten-55);
+}
+
+.catalog-hero .catalog-search .search-results .search-result.focused .key {
+  color: var(--color-modal-focus-subtle-fg);
+  background: var(--color-modal-focus-subtle-bg);
+}
+
+.catalog-hero .catalog-search .search-results .search-result:hover {
+  background: var(--color-gray-lighten-60);
+  text-decoration: none;
 }
 
 .catalog-hero .catalog-search .search-results .empty-state {


### PR DESCRIPTION
## Problem
The user should be able to select search results by using the keyboard.

## Solution
When searching through the catalog support keyboard navigation with up
and down arrows as well as selection with enter and indexed selection
with ; followed by an index number. This mirrors the functionality of
the Finder.