### PR TITLE
Use normal hrefs for the App title click

### DIFF
--- a/src/UI/AppHeader.elm
+++ b/src/UI/AppHeader.elm
@@ -1,17 +1,17 @@
 module UI.AppHeader exposing (..)
 
-import Html exposing (Html, a, header, section, span)
+import Html exposing (Html, a, header, section)
 import Html.Attributes exposing (class, id)
 import Html.Events exposing (onClick)
 import UI
 import UI.Banner as Banner exposing (Banner)
 import UI.Button as Button exposing (Button)
+import UI.Click as Click exposing (Click)
 import UI.Icon as Icon
 
 
 type AppTitle msg
-    = Clickable msg (Html msg)
-    | Disabled (Html msg)
+    = AppTitle (Click msg) (Html msg)
 
 
 type alias MenuToggle msg =
@@ -70,13 +70,8 @@ view appHeader_ =
 
 
 viewAppTitle : AppTitle msg -> Html msg
-viewAppTitle title =
-    case title of
-        Clickable clickMsg content ->
-            a [ class "app-title", onClick clickMsg ] [ content ]
-
-        Disabled content ->
-            span [ class "app-title" ] [ content ]
+viewAppTitle (AppTitle click content) =
+    Click.view [ class "app-title" ] [ content ] click
 
 
 view_ : List (Html msg) -> Html msg

--- a/src/UnisonLocal/App.elm
+++ b/src/UnisonLocal/App.elm
@@ -451,36 +451,20 @@ subscriptions model =
 -- VIEW
 
 
-appTitle : Maybe msg -> AppHeader.AppTitle msg
-appTitle clickMsg =
-    let
-        appTitle_ =
-            case clickMsg of
-                Nothing ->
-                    AppHeader.Disabled
-
-                Just msg ->
-                    AppHeader.Clickable msg
-    in
-    appTitle_ (h1 [] [ text "Unison", span [ class "context unison-local" ] [ text "Local" ] ])
+appTitle : Click msg -> AppHeader.AppTitle msg
+appTitle click =
+    AppHeader.AppTitle click
+        (h1 []
+            [ text "Unison"
+            , span [ class "context unison-local" ] [ text "Local" ]
+            ]
+        )
 
 
-viewAppHeader : Model -> AppHeader.AppHeader Msg
-viewAppHeader model =
-    let
-        changePerspectiveMsg =
-            case model.env.perspective of
-                Codebase codebaseHash ->
-                    ChangePerspective (Codebase codebaseHash)
-
-                Namespace { codebaseHash } ->
-                    ChangePerspective (Codebase codebaseHash)
-
-        appTitle_ =
-            appTitle (Just changePerspectiveMsg)
-    in
+appHeader : AppHeader.AppHeader Msg
+appHeader =
     { menuToggle = Just ToggleSidebar
-    , appTitle = appTitle_
+    , appTitle = appTitle (Click.Href "/")
     , banner = Nothing
     , rightButton = Just (Button.button (ShowModal PublishModal) "Publish on Unison Share" |> Button.share)
     }
@@ -746,7 +730,7 @@ viewModal model =
 viewAppLoading : Html msg
 viewAppLoading =
     div [ id "app" ]
-        [ AppHeader.view (AppHeader.appHeader (appTitle Nothing))
+        [ AppHeader.view (AppHeader.appHeader (appTitle Click.Disabled))
         , PageLayout.view
             (PageLayout.SidebarLayout
                 { sidebar = []
@@ -760,7 +744,7 @@ viewAppLoading =
 viewAppError : Http.Error -> Html msg
 viewAppError error =
     div [ id "app" ]
-        [ AppHeader.view (AppHeader.appHeader (appTitle Nothing))
+        [ AppHeader.view (AppHeader.appHeader (appTitle Click.Disabled))
         , PageLayout.view
             (PageLayout.SidebarLayout
                 { sidebar = []
@@ -801,5 +785,5 @@ view model =
                 }
     in
     { title = "Unison Local"
-    , body = [ div [ id "app" ] [ AppHeader.view (viewAppHeader model), PageLayout.view page, viewModal model ] ]
+    , body = [ div [ id "app" ] [ AppHeader.view appHeader, PageLayout.view page, viewModal model ] ]
     }

--- a/src/UnisonShare/App.elm
+++ b/src/UnisonShare/App.elm
@@ -494,34 +494,19 @@ subscriptions model =
 -- VIEW
 
 
-appTitle : Maybe msg -> AppHeader.AppTitle msg
-appTitle clickMsg =
+appTitle : Click msg -> AppHeader.AppTitle msg
+appTitle click =
+    AppHeader.AppTitle click
+        (h1 []
+            [ text "Unison"
+            , span [ class "context unison-share" ] [ text "Share" ]
+            ]
+        )
+
+
+appHeader : AppHeader.AppHeader Msg
+appHeader =
     let
-        appTitle_ =
-            case clickMsg of
-                Nothing ->
-                    AppHeader.Disabled
-
-                Just msg ->
-                    AppHeader.Clickable msg
-    in
-    appTitle_ (h1 [] [ text "Unison", span [ class "context unison-share" ] [ text "Share" ] ])
-
-
-viewAppHeader : Model -> AppHeader.AppHeader Msg
-viewAppHeader model =
-    let
-        changePerspectiveMsg =
-            case model.env.perspective of
-                Codebase codebaseHash ->
-                    ChangePerspective (Codebase codebaseHash)
-
-                Namespace { codebaseHash } ->
-                    ChangePerspective (Codebase codebaseHash)
-
-        appTitle_ =
-            appTitle (Just changePerspectiveMsg)
-
         banner =
             Just
                 (Banner.promotion "article"
@@ -531,7 +516,7 @@ viewAppHeader model =
                 )
     in
     { menuToggle = Just ToggleSidebar
-    , appTitle = appTitle_
+    , appTitle = appTitle (Click.Href "/")
     , banner = banner
     , rightButton = Just (Button.button (ShowModal AppModal.PublishModal) "Publish on Unison Share" |> Button.share)
     }
@@ -675,7 +660,7 @@ viewMainSidebar model =
 viewAppLoading : Html msg
 viewAppLoading =
     div [ id "app" ]
-        [ AppHeader.view (AppHeader.appHeader (appTitle Nothing))
+        [ AppHeader.view (AppHeader.appHeader (appTitle Click.Disabled))
         , PageLayout.view
             (PageLayout.FullLayout
                 { content = PageLayout.PageContent [] }
@@ -686,7 +671,7 @@ viewAppLoading =
 viewAppError : Http.Error -> Html msg
 viewAppError error =
     div [ id "app" ]
-        [ AppHeader.view (AppHeader.appHeader (appTitle Nothing))
+        [ AppHeader.view (AppHeader.appHeader (appTitle Click.Disabled))
         , PageLayout.view
             (PageLayout.FullLayout
                 { content =
@@ -705,9 +690,6 @@ viewAppError error =
 view : Model -> Browser.Document Msg
 view model =
     let
-        appHeader =
-            AppHeader.view (viewAppHeader model)
-
         withSidebar pageContent =
             PageLayout.SidebarLayout
                 { sidebar = viewMainSidebar model
@@ -748,7 +730,7 @@ view model =
     { title = "Unison Share"
     , body =
         [ div [ id "app", class pageId ]
-            [ appHeader
+            [ AppHeader.view appHeader
             , page
             , Html.map AppModalMsg (AppModal.view model.env model.appModal)
             ]


### PR DESCRIPTION
## Problem
When click the app title on pages like the catalog or the user page, the url isn't changed appropriately

## Solution
When clicking the title of the app ("Unison Share" / "Unison Local"), simply use a `Click.Href` of `"/"` to navigate to the root page of the application instead of a complicated perspective change.
