### PR TITLE
Add search for all projects, not just catalog

### DIFF
--- a/src/Project.elm
+++ b/src/Project.elm
@@ -36,6 +36,11 @@ ownerToString (Owner o) =
     o
 
 
+equals : Project a -> Project b -> Bool
+equals a b =
+    Hash.equals a.hash b.hash
+
+
 
 -- View
 


### PR DESCRIPTION
## Problem
We want to show all projects that match a search query

## Solution
Extend the search on the catalog page to search everything