### PR TITLE
Prefer https over ssh in download modal

### DIFF
--- a/src/UnisonShare/AppModal.elm
+++ b/src/UnisonShare/AppModal.elm
@@ -131,7 +131,7 @@ viewDownloadModal fqn =
             FQN.unqualifiedName fqn
 
         pullCommand =
-            "pull git@github.com:unisonweb/share.git:." ++ prettyName ++ " ." ++ unqualified
+            "pull https://github.com/unisonweb/share:." ++ prettyName ++ " ." ++ unqualified
 
         content =
             Modal.Content


### PR DESCRIPTION
## Problem
Folks without a GitHub account can't download libraries from
Unison Share via the suggested pull command.

Fixes: https://github.com/unisonweb/codebase-ui/issues/322

## Solution
Update the download modal to use https for the pull command.