### PR TITLE
Add position: relative to hashvatar

### DIFF
--- a/src/css/elements/hashvatar.css
+++ b/src/css/elements/hashvatar.css
@@ -1,3 +1,4 @@
 .hashvatar {
+  position: relative;
   display: inline-flex;
 }


### PR DESCRIPTION
## Problem
#324 (possibly #310 as well?)

## Solution
This adds `position: relative` to the parent element (`.hashvatar`) of the `svg::after` pseudo-element that renders the shadow (which has `position: absolute`) so that the absolute positioning is relative to the parent.

## Screenshot

<details><summary><strong>Before</strong></summary>
<img width="1792" alt="Screen Shot 2022-03-27 at 1 48 41 PM" src="https://user-images.githubusercontent.com/26548438/160294363-610a75ff-8c02-4c2d-a879-47cb5af59c54.png">

</details>

<details><summary><strong>After</strong></summary>
<img width="1792" alt="Screen Shot 2022-03-27 at 1 49 41 PM" src="https://user-images.githubusercontent.com/26548438/160294376-69c6a89a-e0f7-41ba-b258-3eef88a446f0.png">

</details>