### PR TITLE
Add color token aliases

### DIFF
--- a/src/css/code/definition-doc.css
+++ b/src/css/code/definition-doc.css
@@ -1,30 +1,47 @@
 .definition-doc {
+  --color-doc-text: var(--u-color_text);
+  --color-doc-bg: var(--u-color_container);
+  --color-doc-aside-bg: var(--u-color_container_subdued);
+  --color-doc-aside-source-bg: var(--u-color_element_emphasized);
+  --color-doc-callout-bg: var(--u-color_info_container_subdued);
+  --color-doc-callout-source-bg: var(--u-color_element_emphasized);
+  --color-doc-subtle-text: var(--u-color_text__very-subdued);
+  --color-doc-source-bg: var(--u-color_container_subdued);
+  --color-doc-content-border: var(--u-color_border_subdued);
+  --color-doc-divider: var(--u-color_divider);
+
+  --color-doc-focus-text: var(--u-color_text);
+  --color-doc-focus-bg: var(--u-color_container_selected);
+  --color-doc-focus-aside-bg: var(--u-color_container_subdued_selected);
+  --color-doc-focus-aside-source-bg: var(--u-color_element_emphasized_selected);
+  --color-doc-focus-callout-bg: var(--u-color_info_container_subdued);
+  --color-doc-focus-callout-source-bg: var(
+    --u-color_element_emphasized_selected
+  );
+  --color-doc-focus-subtle-text: var(--u-color_text_very-subdued);
+  --color-doc-focus-source-bg: var(--u-color_container_subdued_selected);
+  --color-doc-focus-content-border: var(--u-color_border_subdued);
+
   position: relative;
   display: flex;
   line-height: 1.5;
   flex-direction: column;
   font-size: var(--font-size-medium);
-  color: var(--color-doc-fg);
+  color: var(--color-doc-text);
   background: var(--color-doc-bg);
 }
 
 /* When the parent wrapper (typically .workspace-item is focused and has a
  * slightly darker background, we want to use focus colors */
 .focused .definition-doc {
-  --color-doc-fg: var(--color-doc-focus-fg);
+  --color-doc-text: var(--color-doc-focus-text);
   --color-doc-bg: var(--color-doc-focus-bg);
   --color-doc-aside-bg: var(--color-doc-focus-aside-bg);
   --color-doc-aside-source-bg: var(--color-doc-focus-aside-source-bg);
   --color-doc-callout-bg: var(--color-doc-focus-callout-bg);
   --color-doc-callout-source-bg: var(--color-doc-focus-callout-source-bg);
-  --color-doc-subtle-fg: var(--color-doc-focus-subtle-fg);
+  --color-doc-subtle-text: var(--color-doc-focus-subtle-text);
   --color-doc-source-bg: var(--color-doc-focus-source-bg);
-  --color-doc-source-mg: var(--color-doc-focus-source-mg);
-  --color-doc-fold-hover-fg: var(--color-doc-focus-fold-hover-fg);
-  --color-doc-fold-hover-bg: var(--color-doc-focus-fold-hover-bg);
-  --color-doc-link: var(--color-doc-focus-link);
-  --color-doc-link-active: var(--color-doc-focus-link-active);
-  --color-doc-link-hover: var(--color-doc-focus-link-hover);
   --color-doc-content-border: var(--color-doc-focus-content-border);
 }
 
@@ -51,7 +68,7 @@
   border-radius: var(--border-radius-base);
   margin-bottom: 1rem;
   scrollbar-width: auto;
-  scrollbar-color: var(--color-workspace-item-subtle-fg)
+  scrollbar-color: var(--color-workspace-item-subtle-text)
     var(--color-transparent);
   overflow: auto;
 }
@@ -68,6 +85,7 @@
 .definition-doc .source.signatures .signature::-webkit-scrollbar {
   height: 0.375rem;
 }
+
 .definition-doc .source.code::-webkit-scrollbar-track,
 .definition-doc .sources .source::-webkit-scrollbar-track,
 .definition-doc .folded-sources .source::-webkit-scrollbar-track,
@@ -76,13 +94,14 @@
 .definition-doc .source.signatures .signature::-webkit-scrollbar-track {
   background: var(--color-transparent);
 }
+
 .definition-doc .source.code::-webkit-scrollbar-thumb,
 .definition-doc .sources .source::-webkit-scrollbar-thumb,
 .definition-doc .folded-sources .source::-webkit-scrollbar-thumb,
 .definition-doc .source.example::-webkit-scrollbar-thumb,
 .definition-doc .source.eval::-webkit-scrollbar-thumb,
 .definition-doc .source.signatures .signature::-webkit-scrollbar-thumb {
-  background-color: var(--color-workspace-item-subtle-fg);
+  background-color: var(--color-workspace-item-subtle-text);
   border-radius: var(--border-radius-base);
 }
 
@@ -101,6 +120,7 @@
   border-radius: var(--border-radius-base);
   white-space: nowrap;
 }
+
 .definition-doc
   .group
   .join
@@ -131,7 +151,7 @@
 
 .definition-doc .eval .result .icon,
 .definition-doc .eval-inline .result .icon {
-  color: var(--color-doc-subtle-fg);
+  color: var(--color-doc-subtle-text);
 }
 
 .definition-doc strong {
@@ -144,18 +164,6 @@
 
 .definition-doc .strikethrough {
   text-decoration: line-through;
-}
-
-.definition-doc .named-link:not(.invalid-href),
-.definition-doc .named-link:not(.invalid-href):visited {
-  color: var(--color-doc-link);
-}
-.definition-doc .named-link:not(.invalid-href):active {
-  color: var(--color-doc-link-active);
-}
-.definition-doc .named-link:not(.invalid-href):hover {
-  color: var(--color-doc-link-hover);
-  text-decoration: none;
 }
 
 .definition-doc blockquote {
@@ -177,12 +185,12 @@
 }
 
 .definition-doc hr {
-  background: var(--color-doc-content-border);
+  background: var(--color-doc-divider);
   margin: 1.5rem 0;
 }
 
 .definition-doc .tooltip-trigger {
-  text-decoration: underline dotted var(--color-doc-subtle-fg);
+  text-decoration: underline dotted var(--color-doc-subtle-text);
   text-underline-offset: 2px;
   /* Other tooltip styling is handled by elements/tooltip */
 }
@@ -223,9 +231,11 @@
 .definition-doc aside .source.signatures .signature {
   background: var(--color-doc-aside-source-bg);
   padding: 0.375rem;
-  max-width: 14rem; /* accounting for the aside padding */
+  max-width: 14rem;
+  /* accounting for the aside padding */
   overflow: auto;
 }
+
 .definition-doc
   aside
   .source:is(.inline-code, .example-inline, .eval-inline, .signature-inline) {
@@ -304,7 +314,6 @@
 .definition-doc .source.folded .badge {
   margin-left: auto;
   justify-self: flex-end;
-  background: var(--color-doc-source-mg);
   border: 0;
   font-size: 0.75rem;
   height: 1.25rem;
@@ -350,6 +359,7 @@
 .definition-doc section:last-child {
   margin-bottom: 0;
 }
+
 .definition-doc section:last-child .source:last-child {
   margin-bottom: 0;
 }
@@ -365,6 +375,7 @@
   margin-top: 1.5rem;
   margin-bottom: 0.75rem;
 }
+
 .definition-doc h1:first-child {
   margin-top: 0;
   line-height: 1.1;
@@ -481,3 +492,4 @@
     width: calc(100vw - 9.25rem);
   }
 }
+

--- a/src/css/code/finder.css
+++ b/src/css/code/finder.css
@@ -1,4 +1,5 @@
 #finder {
+  --color-search-field: var(--u-color_element_subdued);
   position: relative;
   width: 50rem;
   margin-top: 7rem;
@@ -17,7 +18,7 @@
 
 #finder header {
   border-radius: var(--border-radius-base);
-  background: var(--color-modal-mg);
+  background: var(--color-search-field);
   display: flex;
   align-items: center;
   position: relative;
@@ -121,6 +122,7 @@
   padding: 0.75rem;
   border-top: 1px solid var(--color-modal-inner-border);
 }
+
 #finder .results + header {
   border-radius: 0;
   border-top-left-radius: var(--border-radius-base);
@@ -173,11 +175,6 @@
 
 #finder .definition-match td:last-child {
   border-radius: 0 var(--border-radius-base) var(--border-radius-base) 0;
-}
-
-#finder .definition-match mark {
-  color: var(--color-modal-mark-fg);
-  background: var(--color-modal-mark-bg);
 }
 
 #finder .definition-match .category {

--- a/src/css/code/fully-qualified-name.css
+++ b/src/css/code/fully-qualified-name.css
@@ -3,12 +3,13 @@
   align-items: center;
   height: 1.5rem;
   font-weight: bold;
-  color: var(--color-main-fg);
+  color: var(--u-color_text);
 }
+
 .fully-qualified-name .fully-qualified-name-separator {
   /* em instead of rem to have the margin be relative to the font-size of
    * .fully-qualified-name
   */
   margin: 0 0.25em;
-  color: var(--color-main-subtle-fg);
+  color: var(--u-color_text_very-subdued);
 }

--- a/src/css/code/project-listing.css
+++ b/src/css/code/project-listing.css
@@ -1,4 +1,3 @@
-
 .project-listing {
   display: flex;
   flex-direction: row;
@@ -10,9 +9,10 @@
 
 .project-listing:hover {
   text-decoration: none;
-  background: var(--color-main-hover-bg);
+  background: var(--u-color_element_hovered);
 }
 
 .project-listing .hashvatar {
   margin-right: 0.5rem;
 }
+

--- a/src/css/code/workspace-item.css
+++ b/src/css/code/workspace-item.css
@@ -1,6 +1,28 @@
 /* -- WorkspaceItem -------------------------------------------------------- */
 
 .workspace-item {
+  /* @color-todo */
+  --color-workspace-item-fg: var(--color-gray-darken-30);
+  --color-workspace-item-gutter: var(--color-gray-lighten-60);
+  --color-workspace-item-bg: var(--color-gray-lighten-100);
+  --color-workspace-item-bg-faded: var(--color-gray-lighten-100-50pct);
+  --color-workspace-item-info-item-fg: var(--color-gray-lighten-30);
+  --color-workspace-item-info-item-icon-fg: var(--color-gray-lighten-30);
+  --color-workspace-item-info-item-bg: var(--color-transparent);
+  --color-workspace-item-info-item-hover-fg: var(--color-gray-darken-30);
+  --color-workspace-item-info-item-hover-icon-fg: var(--color-gray-base);
+  --color-workspace-item-info-item-hover-bg: var(--color-gray-lighten-50);
+  --color-workspace-item-source-bg: var(--color-transparent);
+  --color-workspace-item-subtle-fg: var(--color-gray-lighten-30);
+  --color-workspace-item-border: var(--color-transparent);
+  --color-workspace-item-focus-fg: var(--color-gray-darken-30);
+  --color-workspace-item-focus-subtle-fg: var(--color-gray-lighten-30);
+  --color-workspace-item-focus-source-bg: var(--color-transparent);
+  --color-workspace-item-focus-gutter: var(--color-gray-lighten-55);
+  --color-workspace-item-focus-bg: var(--color-gray-lighten-60);
+  --color-workspace-item-focus-bg-faded: var(--color-gray-lighten-60-50pct);
+  --color-workspace-item-focus-border: var(--color-gray-lighten-50);
+
   position: relative;
   color: var(--color-workspace-item-fg);
   background: var(--color-workspace-item-bg);
@@ -10,7 +32,7 @@
   margin-bottom: 1.5rem;
   font-size: var(--font-size-medium);
   /* gutter */
-  box-shadow: inset 2rem 0 0 var(--color-workspace-item-mg);
+  box-shadow: inset 2rem 0 0 var(--color-workspace-item-gutter);
 }
 
 .workspace-item .inner-row {
@@ -49,7 +71,7 @@
   top: 0.75rem;
   right: 1rem;
   height: 1.25rem;
-  background: var(--color-workspace-item-bg-em);
+  background: var(--u-color_action_subdued);
   border-radius: var(--border-radius-base);
   display: flex;
   flex-direction: row;
@@ -71,13 +93,17 @@
   cursor: pointer;
 }
 
+.workspace-item .actions:hover {
+  background: var(--u-color_action_subdued_hovered);
+}
+
 .workspace-item .actions .close .icon {
-  color: var(--color-workspace-item-subtle-fg);
+  color: var(--u-color_icon-on-action-subdued);
   font-size: 0.75rem;
 }
 
 .workspace-item .actions .close:hover .icon {
-  color: var(--color-workspace-item-fg);
+  color: var(--u-color_icon-on-action-subdued-hovered);
 }
 
 .workspace-item header .info {
@@ -119,7 +145,7 @@
 }
 
 .workspace-item header .info .info-items .info-item > .icon {
-  color: var(--color-workspace-item-info-item-subtle-fg);
+  color: var(--color-workspace-item-info-item-icon-fg);
   font-size: var(--font-size-base);
   margin-right: 0.25rem;
 }
@@ -134,7 +160,9 @@
   line-height: 0.875rem;
   transition: 0.2s background;
   border-radius: var(--border-radius-base);
+  background: var(--color-workspace-item-info-item-bg);
 }
+
 .workspace-item header .info .info-items .info-item > label {
   transition: 0.2s all;
 }
@@ -147,7 +175,7 @@
 
 .workspace-item header .info .info-items .info-item:hover > .icon,
 .workspace-item header .info .info-items .tooltip:hover + .info-item > .icon {
-  color: var(--color-workspace-item-info-item-hover-sublte-fg);
+  color: var(--color-workspace-item-info-item-hover-icon-fg);
 }
 
 .workspace-item header .info .info-items .tooltip {
@@ -157,6 +185,7 @@
 .workspace-item header .error-header {
   flex-direction: row;
   align-items: center;
+  color: var(--u-color_text);
 }
 
 .workspace-item header .error-header .icon {
@@ -170,7 +199,7 @@
 
 .workspace-item header .error-header .icon.warn {
   font-size: 1rem;
-  color: var(--color-main-alert-fg);
+  color: var(--u-color_critical_icon);
 }
 
 .workspace-item .content .gutter {
@@ -255,10 +284,6 @@
   margin-left: 1.25rem;
 }
 
-.workspace-item .content .badge {
-  background: var(--color-workspace-item-mg);
-}
-
 .workspace-item .content .definition-source {
   position: relative;
   padding-left: 1.5rem;
@@ -331,15 +356,14 @@
   --color-workspace-item-bg: var(--color-workspace-item-focus-bg);
   --color-workspace-item-bg-faded: var(--color-workspace-item-focus-bg-faded);
   --color-workspace-item-subtle-fg: var(--color-workspace-item-focus-subtle-fg);
-  --color-workspace-item-subtle-bg: var(--color-workspace-item-focus-subtle-bg);
-  --color-workspace-item-content-border: var(
-    --color-workspace-item-focus-content-border
-  );
   --color-workspace-item-border: var(--color-workspace-item-focus-border);
-  --color-workspace-item-mg: var(--color-workspace-item-focus-mg);
+  --color-workspace-item-gutter: var(--color-workspace-item-gutter);
   --color-workspace-item-bg: var(--color-workspace-item-focus-bg);
-  --color-workspace-item-bg-em: var(--color-workspace-item-focus-bg-em);
   --color-workspace-item-source-bg: var(--color-workspace-item-focus-source-bg);
+}
+
+.workspace-item.focused .badge {
+  background: var(--color-workspace-item-focus-gutter);
 }
 
 .workspace-item.focused .actions {

--- a/src/css/code/workspace.css
+++ b/src/css/code/workspace.css
@@ -1,12 +1,9 @@
-/* -- Workspace ------------------------------------------------------------ */
-
 #workspace {
+  --color-workspace-gutter: var(--u-color_container_subdued);
+  --workspace-content-width: var(--main-content-width);
+
   display: flex;
   flex-direction: column;
-  background: var(--color-workspace-bg);
-  color: var(--color-workspace-fg);
-
-  --workspace-content-width: var(--main-content-width);
 }
 
 #workspace-content {
@@ -15,10 +12,9 @@
   padding-top: 2rem;
   scroll-behavior: smooth;
   scrollbar-width: auto;
-  scrollbar-color: var(--color-workspace-item-subtle-fg)
-    var(--color-workspace-item-bg);
+  scrollbar-color: var(--u-color_scrollbar) var(--u-color_scrollbar-track);
   /* gutter */
-  box-shadow: inset 2rem 0 0 var(--color-workspace-subtle-bg);
+  box-shadow: inset 2rem 0 0 var(--color-workspace-gutter);
 }
 
 #workspace-content::-webkit-scrollbar {
@@ -27,11 +23,11 @@
 }
 
 #workspace-content::-webkit-scrollbar-track {
-  background: var(--color-workspace-item-bg);
+  background: var(--u-color_scrollbar-track);
 }
 
 #workspace-content::-webkit-scrollbar-thumb {
-  background-color: var(--color-workspace-item-subtle-fg);
+  background-color: var(--u-color_scrollbar);
   border-radius: var(--border-radius-base);
 }
 

--- a/src/css/themes/unison-light.css
+++ b/src/css/themes/unison-light.css
@@ -1,175 +1,95 @@
 :root {
-  /* -- Default Theme -------------------------------------------------------*/
+  /*
 
-  --color-main-fg: var(--color-gray-darken-30);
-  --color-main-bg: var(--color-gray-lighten-100);
-  --color-main-subtle-fg: var(--color-gray-lighten-30);
-  --color-main-subtle-fg-em: var(--color-gray-lighten-20);
-  --color-main-subtle-bg: var(--color-gray-lighten-60);
-  --color-main-subtle-border: var(--color-gray-lighten-45);
-  --color-main-hover-bg: var(--color-gray-lighten-55);
-  --color-main-border: var(--color-gray-lighten-40);
-  --color-main-divider: var(--color-gray-lighten-55);
-  --color-main-focus-fg: var(--color-blue-2);
-  --color-main-focus-outline: var(--color-blue-2-25-pct);
-  --color-main-focus-border: var(--color-blue-1);
-  --color-main-focus-bg: var(--color-blue-2);
-  --color-main-mark-fg: var(--color-blue-2);
-  --color-main-mark-bg: var(--color-transparent);
-  --color-main-alert-fg: var(--color-pink-1);
-  --color-main-alert-subtle-fg: var(--color-pink-3);
+  --u-color_[sentiment]_[target]_[emphasis]_[state]
 
-  --color-keyboard-shortcut-key-fg: var(--color-gray-base);
-  --color-keyboard-shortcut-key-bg: var(--color-gray-lighten-50);
-  --color-keyboard-shortcut-then: var(--color-gray-lighten-20);
-  --color-keyboard-shortcut-separator: var(--color-gray-lighten-30);
+  sentiment
+  ---------
+  none, info, critical, positive, search-highlight
 
-  --color-modal-fg: var(--color-main-fg);
-  --color-modal-mg: var(--color-gray-lighten-60);
-  --color-modal-bg: var(--color-gray-lighten-100);
-  --color-modal-inner-border: var(--color-gray-lighten-50);
-  --color-modal-separator: var(--color-gray-lighten-55);
-  --color-modal-shadow: var(--gray-darken-30-20%);
-  --color-modal-overlay: var(--gray-darken-30-50%);
-  --color-modal-border: var(--color-transparent);
-  --color-modal-subtle-fg: var(--color-main-subtle-fg);
-  --color-modal-subtle-fg-em: var(--color-gray-lighten-20);
-  --color-modal-subtle-mg: var(--color-gray-lighten-55);
-  --color-modal-subtle-bg: var(--color-gray-lighten-60);
-  --color-modal-focus-fg: var(--color-main-fg);
-  --color-modal-focus-bg: var(--color-gray-lighten-55);
-  --color-modal-focus-subtle-fg: var(--color-gray-base);
-  --color-modal-focus-subtle-bg: var(--color-gray-lighten-50);
-  --color-modal-title-fg: var(--color-gray-lighten-20);
-  --color-modal-title-bg: var(--color-transparent);
-  --color-modal-mark-fg: var(--color-blue-2);
-  --color-modal-mark-bg: var(--color-transparent);
-  --color-modal-error-fg: var(--color-pink-1);
+  target 
+  ------
+  background, text, text-on-[token], icon, icon-on-[token], border, container,
+  element, interactive, focus-border, focus-outline, divider, caret, backdrop,
+  scrollbar, scrollbar-track
 
-  /* FoldToggle */
+  emphasis
+  --------
+  none, very-subdued, subdued, emphasized
 
-  --color-fold-toggle-fg: var(--color-gray-lighten-30);
-  --color-fold-toggle-bg: var(--color-transparent);
-  --color-fold-toggle-hover-fg: var(--color-gray-base);
-  --color-fold-toggle-hover-bg: var(--color-gray-lighten-45);
+  state
+  -----
+  none, hovered, pressed, selected, disabled
 
-  /* Buttons */
+  "none" are left off from the token when applicable.
 
-  --color-button-default-fg: var(--color-main-fg);
-  --color-button-default-bg: var(--color-gray-lighten-50);
-  --color-button-default-hover-fg: var(--color-main-fg);
-  --color-button-default-hover-bg: var(--color-gray-lighten-40);
+  */
 
-  --color-button-primary-mono-fg: var(--color-gray-lighten-60);
-  --color-button-primary-mono-bg: var(--color-gray-darken-20);
-  --color-button-primary-mono-hover-fg: var(--color-gray-lighten-60);
-  --color-button-primary-mono-hover-bg: var(--color-gray-darken-10);
+  --u-color_background: var(--color-gray-lighten-100);
+  --u-color_caret: var(--color-gray-lighten-100);
+  --u-color_focus-border: var(--color-blue-1);
+  --u-color_focus-outline: var(--color-blue-2-25pct);
+  --u-color_backdrop: var(--color-gray-darken-30-50pct);
+  --u-color_scrollbar: var(--color-gray-lighten-30);
+  --u-color_scrollbar-track: var(--color-transparent);
 
-  --color-button-primary-fg: var(--color-gray-lighten-60);
-  --color-button-primary-bg: var(--color-blue-2);
-  --color-button-primary-hover-fg: var(--color-gray-lighten-60);
-  --color-button-primary-hover-bg: var(--color-blue-1);
+  --u-color_search-highlight_text: var(--color-gray-blue-2);
+  --u-color_search-highlight_background: var(--color-transparent);
 
-  --color-button-share-fg: var(--color-purple-1);
-  --color-button-share-bg: var(--color-purple-4);
-  --color-button-share-hover-fg: var(--color-purple-2);
-  --color-button-share-hover-bg: var(--color-purple-4);
+  --u-color_text: var(--color-gray-darken-20);
+  --u-color_text_very-subdued: var(--color-gray-lighten-30);
+  --u-color_text_subdued: var(--color-gray-lighten-20);
+  --u-color_text_emphasized: var(--color-gray-darken-30);
+  --u-color_icon: var(--color-gray-lighten-20);
+  --u-color_icon_subdued: var(--color-gray-lighten-30);
+  --u-color_icon_emphasized: var(--color-gray-darken-20);
+  --u-color_divider: var(--color-gray-lighten-55);
+  --u-color_border: var(--color-gray-lighten-40);
+  --u-color_border_subdued: var(--color-gray-lighten-45);
+  --u-color_interactive: var(--color-blue-1);
+  --u-color_interactive_hovered: var(--color-blue-2);
+  --u-color_interactive_pressed: var(--color-pink-1);
+  --u-color_action: var(--color-gray-lighten-50);
+  --u-color_text-on-action: var(--color-gray-darken-30);
+  --u-color_icon-on-action: var(--color-gray-lighten-20);
+  --u-color_action_hovered: var(--color-gray-lighten-40);
+  --u-color_text-on-action_hovered: var(--color-gray-darken-30);
+  --u-color_icon-on-action_hovered: var(--color-gray-lighten-20);
+  --u-color_action_subdued: var(--color-transparent);
+  --u-color_text-on-action-subdued: var(--color-blue-1);
+  --u-color_icon-on-action-subdued: var(--color-gray-lighten-20);
+  --u-color_action_subdued_hovered: var(--color-gray-lighten-45);
+  --u-color_icon-action_subdued-hovered: var(--color-gray-base);
+  --u-color_action_emphasized: var(--color-gray-darken-20);
+  --u-color_text-on-action-emphasized: var(--color-gray-lighten-60);
+  --u-color_icon-on-action-emphasized: var(--color-gray-lighten-30);
+  --u-color_container: var(--color-gray-lighten-100);
+  --u-color_container_hovered: var(--color-gray-lighten-60);
+  --u-color_container_selected: var(--color-gray-lighten-60);
+  --u-color_container_subdued: var(--color-gray-lighten-60);
+  --u-color_container_subdued_hovered: var(--color-gray-lighten-55);
+  --u-color_container_subdued_selected: var(--color-gray-lighten-55);
+  --u-color_element: var(--color-gray-lighten-100);
+  --u-color_element_hovered: var(--color-gray-lighten-60);
+  --u-color_element_selected: var(--color-gray-lighten-55);
+  --u-color_element_disabled: var(--color-gray-lighten-55);
+  --u-color_element_subdued: var(--color-gray-lighten-60);
+  --u-color_element_subdued_hovered: var(--color-gray-lighten-55);
+  --u-color_element_subdued_selected: var(--color-gray-lighten-55);
+  --u-color_element_emphasized: var(--color-gray-lighten-55);
+  --u-color_text-on-element-emphasized: var(--color-gray-base);
+  --u-color_element_emphasized_hovered: var(--color-gray-lighten-50);
+  --u-color_element_emphasized_selected: var(--color-gray-lighten-50);
 
-  --color-button-danger-fg: var(--color-gray-lighten-100);
-  --color-button-danger-bg: var(--color-pink-1);
-  --color-button-danger-hover-fg: var(--color-gray-lighten-100);
-  --color-button-danger-hover-bg: var(--color-pink-2);
+  --u-color_critical_text: var(--color-pink-1);
+  --u-color_critical_text_subdued: var(--color-pink-3);
+  --u-color_critical_icon: var(--color-pink-3);
 
-  /* Card */
-  --color-card-bg: var(--color-gray-lighten-100);
-  --color-card-fg: var(--color-gray-darken-30);
-  --color-card-title: var(--color-gray-lighten-30);
-  --color-card-border: var(--color-gray-lighten-50);
-
-  /* Badge */
-  --color-badge-fg: var(--color-gray-base);
-  --color-badge-bg: var(--color-gray-lighten-60);
-  --color-badge-border: var(--color-gray-lighten-50);
-
-  /* CopyField */
-  --color-copy-field-fg: var(--color-gray-darken-25);
-  --color-copy-field-bg: var(--color-gray-lighten-60);
-  --color-copy-field-border: var(--color-gray-lighten-40);
-  --color-copy-field-focus-fg: var(--color-main-focus-fg);
-  --color-copy-field-focus-bg: var(--color-gray-lighten-60);
-  --color-copy-field-focus-border: var(--color-main-focus-border);
-  --color-copy-field-focus-outline: var(--color-main-focus-outline);
-  --color-copy-field-prefix: var(--color-main-subtle-em);
-  --color-copy-field-button-border: var(--color-gray-lighten-40);
-  --color-copy-field-button-hover-border: var(--color-gray-lighten-30);
-
-  --color-workspace-fg: var(--color-main-fg);
-  --color-workspace-bg: var(--color-main-bg);
-  --color-workspace-subtle-bg: var(--color-gray-lighten-60);
-  --color-workspace-border: var(--color-gray-lighten-50);
-
-  --color-workspace-item-fg: var(--color-gray-darken-30);
-  --color-workspace-item-mg: var(--color-gray-lighten-60);
-  --color-workspace-item-bg: var(--color-gray-lighten-100);
-  --color-workspace-item-bg-faded: var(--color-gray-lighten-100-50pct);
-  --color-workspace-item-source-bg: var(--color-transparent);
-  --color-workspace-item-subtle-fg: var(--color-gray-lighten-30);
-  --color-workspace-item-subtle-bg: var(--color-gray-lighten-60);
-  --color-workspace-item-bg-em: var(--color-gray-lighten-55);
-  --color-workspace-item-content-border: var(--color-gray-lighten-55);
-  --color-workspace-item-border: var(--color-transparent);
-  --color-workspace-item-info-item-fg: var(--color-gray-lighten-30);
-  --color-workspace-item-info-item-subtle-fg: var(--color-gray-lighten-30);
-  --color-workspace-item-info-item-hover-fg: var(--color-gray-darken-30);
-  --color-workspace-item-info-item-hover-subtle-fg: var(--color-gray-base);
-  --color-workspace-item-info-item-hover-bg: var(--color-gray-lighten-50);
-  --color-workspace-item-focus-fg: var(--color-gray-darken-30);
-  --color-workspace-item-focus-subtle-fg: var(--color-gray-lighten-30);
-  --color-workspace-item-focus-subtle-bg: var(--color-gray-lighten-50);
-  --color-workspace-item-focus-mg: var(--color-gray-lighten-55);
-  --color-workspace-item-focus-source-bg: var(--color-transparent);
-  --color-workspace-item-focus-bg: var(--color-gray-lighten-60);
-  --color-workspace-item-focus-bg-faded: var(--color-gray-lighten-60-50pct);
-  --color-workspace-item-focus-bg-em: var(--color-gray-lighten-50);
-  --color-workspace-item-focus-content-border: var(--color-gray-lighten-50);
-  --color-workspace-item-focus-border: var(--color-gray-lighten-50);
-  --color-workspace-item-cropped-control-border: var(--color-gray-lighten-30);
-  --color-workspace-item-cropped-control-shadow: var(--color-gray-lighten-45);
-
-  --color-doc-fg: var(--color-gray-darken-30);
-  --color-doc-bg: var(--color-gray-lighten-100);
-  --color-doc-aside-bg: var(--color-gray-lighten-60);
-  --color-doc-aside-source-bg: var(--color-gray-lighten-55);
-  --color-doc-callout-bg: var(--color-blue-5);
-  --color-doc-callout-source-bg: var(--color-lighten-50);
-  --color-doc-subtle-fg: var(--color-gray-lighten-30);
-  --color-doc-source-bg: var(--color-gray-lighten-60);
-  --color-doc-source-mg: var(--color-gray-lighten-45);
-  --color-doc-fold-hover-fg: var(--color-gray-base);
-  --color-doc-fold-hover-bg: var(--color-gray-lighten-45);
-  --color-doc-link: var(--color-blue-1);
-  --color-doc-link-active: var(--color-pink-1);
-  --color-doc-link-hover: var(--color-pink-2);
-  --color-doc-content-border: var(--color-gray-lighten-50);
-
-  --color-doc-focus-fg: var(--color-gray-darken-30);
-  --color-doc-focus-bg: var(--color-gray-lighten-60);
-  --color-doc-focus-aside-bg: var(--color-gray-lighten-55);
-  --color-doc-focus-aside-source-bg: var(--color-gray-lighten-50);
-  --color-doc-focus-callout-bg: var(--color-blue-5);
-  --color-doc-focus-callout-source-bg: var(--color-gray-lighten-50);
-  --color-doc-focus-subtle-fg: var(--color-gray-lighten-30);
-  --color-doc-focus-source-bg: var(--color-gray-lighten-55);
-  --color-doc-focus-source-mg: var(--color-gray-lighten-45);
-  --color-doc-focus-fold-hover-fg: var(--color-gray-base);
-  --color-doc-focus-fold-hover-bg: var(--color-gray-lighten-45);
-  --color-doc-focus-link: var(--color-blue-1);
-  --color-doc-focus-link-active: var(--color-pink-1);
-  --color-doc-focus-link-hover: var(--color-pink-2);
-  --color-doc-focus-content-border: var(--color-gray-lighten-50);
+  --u-color_info_container_subdued: var(--color-blue-5);
 
   /* Syntax */
-  /* Icons */
+  --color-syntax-plain: var(--u-color_text);
+
   --color-icon-type: var(--color-orange-1);
   --color-icon-data-constructor: var(--color-orange-1);
   --color-icon-test: var(--color-green-1);
@@ -194,93 +114,12 @@
   --color-syntax-text: var(--color-green-1);
   --color-syntax-link-hover-bg: var(--color-gray-lighten-50);
 
-  --color-syntax-monochrome-subtle: var(--color-main-subtle-fg);
-  --color-syntax-monochrome-base: var(--color-gray-base);
-  --color-syntax-monochrome-em: var(--color-main-fg);
-
-  --color-syntax-plain: var(--color-main-fg);
+  --color-syntax-monochrome-subtle: var(--u-color_very-subued);
+  --color-syntax-monochrome-base: var(--u-color_subdued);
+  --color-syntax-monochrome-em: var(--u-color_text);
 }
 
-/* inverse colors */
+/* Shadows */
 :root {
-  --color-app-header-fg: var(--color-gray-lighten-100);
-  --color-app-header-bg: var(--color-gray-darken-10);
-  --color-app-header-subtle-fg: var(--color-gray-lighten-20);
-  --color-app-header-subtle-fg-em: var(--color-gray-lighten-50);
-  --color-app-header-context-unison-share-fg: var(--color-purple-4);
-  --color-app-header-context-unison-local-fg: var(--color-pink-3);
-  --color-app-header-border: transparent;
-
-  --color-sidebar-fg: var(--color-gray-lighten-50);
-  --color-sidebar-fg-em: var(--color-gray-lighten-100);
-  --color-sidebar-bg: var(--color-gray-darken-20);
-  /* see color files for why this is needed */
-  --color-sidebar-bg-transparent: var(--color-gray-darken-20-transparent);
-  --color-sidebar-border: var(--color-gray-base);
-  --color-sidebar-subtle-fg: var(--color-gray-lighten-20);
-  --color-sidebar-subtle-fg-em: var(--color-gray-lighten-30);
-  --color-sidebar-subtle-bg: var(--color-transparent);
-  --color-sidebar-focus-fg: var(--color-gray-lighten-60);
-  --color-sidebar-focus-bg: var(--color-gray-darken-10);
-  --color-sidebar-keyboard-shortcut-key-fg: var(--color-gray-lighten-30);
-  --color-sidebar-keyboard-shortcut-key-bg: var(--color-gray-base);
-  --color-sidebar-keyboard-shortcut-then: var(--color-gray-lighten-20);
-  --color-sidebar-keyboard-shortcut-separator: var(--color-gray-base);
-  --color-sidebar-keyboard-shortcut-hover-key-fg: var(--color-gray-lighten-50);
-  --color-sidebar-keyboard-shortcut-hover-key-bg: var(--color-gray-base);
-  --color-sidebar-keyboard-shortcut-hover-then: var(--color-gray-lighten-20);
-  --color-sidebar-keyboard-shortcut-hover-separator: var(--color-gray-base);
-  --color-sidebar-button-default-fg: var(--color-gray-lighten-30);
-  --color-sidebar-button-default-bg: var(--color-gray-base);
-  --color-sidebar-button-default-hover-fg: var(--color-gray-lighten-50);
-  --color-sidebar-button-default-hover-bg: var(--color-gray-base);
-  --color-sidebar-divider: var(--color-gray-darken-10);
-
-  --color-sidebar-tooltip-fg: var(--color-gray-lighten-60);
-  --color-sidebar-tooltip-bg: var(--color-gray-darken-30);
-  --color-sidebar-tooltip-border: var(--color-gray-darken-10);
-
-  --color-option-badge-fg: var(--color-gray-lighten-40);
-  --color-option-badge-subtle-fg: var(--color-gray-lighten-20);
-  --color-option-badge-icon: var(--color-gray-lighten-30);
-  --color-option-badge-hover-icon: var(--color-gray-100);
-  --color-option-badge-bg: var(--color-gray-darken-30);
-  --color-option-badge-border: var(--color-transparent);
-
-  /* Tooltip */
-  --color-tooltip-fg: var(--color-gray-lighten-60);
-  --color-tooltip-subtle-fg: var(--color-gray-lighten-20);
-  --color-tooltip-bg: var(--color-gray-darken-30);
-  --color-tooltip-source-bg: var(--color-gray-darken-20);
-  --color-tooltip-source-mg: var(--color-gray-darken-10);
-  --color-tooltip-fold-hover-bg: var(--color-gray-darken-10);
-  --color-tooltip-link: var(--color-blue-3);
-  --color-tooltip-link-active: var(--color-pink-2);
-  --color-tooltip-link-hover: var(--color-pink-3);
-  --color-tooltip-syntax-base: var(--color-gray-lighten-60);
-  --color-tooltip-syntax-subtle: var(--color-gray-lighten-20);
-  --color-tooltip-syntax-subtle-em: var(--color-gray-lighten-30);
-  --color-tooltip-syntax-keyword: var(--color-pink-3);
-  --color-tooltip-syntax-operator: var(--color-gray-lighten-20);
-  --color-tooltip-syntax-term: var(--color-purple-3);
-  --color-tooltip-syntax-term-namespace: var(--color-purple-4);
-  --color-tooltip-syntax-ability: var(--color-pink-2);
-  --color-tooltip-syntax-type: var(--color-blue-2);
-  --color-tooltip-syntax-type-namespace: var(--color-blue-3);
-  --color-tooltip-syntax-constructor: var(--color-blue-2);
-  --color-tooltip-syntax-constructor-namespace: var(--color-blue-3);
-  --color-tooltip-syntax-text: var(--color-green-2);
-
-  /* ActionMenu (should probably be moved out of tooltip) */
-  --color-tooltip-item-fg: var(--color-gray-lighten-60);
-  --color-tooltip-item-subtle-fg: var(--color-gray-lighten-20);
-  --color-tooltip-item-bg: var(--color-transparent);
-  --color-tooltip-item-hover-fg: var(--color-gray-lighten-60);
-  --color-tooltip-item-hover-subtle-fg: var(--color-gray-lighten-30);
-  --color-tooltip-item-hover-bg: var(--color-gray-darken-10);
-
-  /* Page Hero Layout */
-  --color-page-hero-fg: var(--color-gray-lighten-100);
-  --color-page-hero-bg: var(--color-gray-darken-10);
+  --u-shadow: var(--color-gray-darken-30-20pct);
 }
-

--- a/src/css/ui/base.css
+++ b/src/css/ui/base.css
@@ -29,7 +29,8 @@ html {
   font-family: var(--font-sans-serif);
   /* TODO: Make configurable by users */
   /* https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures */
-  font-variant-ligatures: none; /* normal */
+  font-variant-ligatures: none;
+  /* normal */
   -moz-text-size-adjust: none;
   -webkit-text-size-adjust: none;
   text-size-adjust: none;
@@ -38,21 +39,26 @@ html {
 body {
   font-size: 1rem;
   line-height: 1.4;
-  background: var(--color-main-bg);
-  color: var(--color-main-fg);
+  background: var(--u-color_background);
+  color: var(--u-color_text);
 }
 
 input {
   border: 0;
   border-radius: 0;
   font-family: var(--font-sans-serif);
-  caret-color: var(--color-main-focus-fg);
+  caret-color: var(--u-color_caret);
 }
 
 ::placeholder {
-  color: var(--color-main-subtle-fg);
+  color: var(--u-color_text_subdued);
 }
 
 li::marker {
-  color: var(--color-main-subtle-fg-em);
+  color: var(--u-color_icon);
+}
+
+mark {
+  color: var(--u-color_search-highlight_text);
+  background: var(--u-color_search-highlight_background);
 }

--- a/src/css/ui/colors.css
+++ b/src/css/ui/colors.css
@@ -50,7 +50,7 @@
   --color-blue-3: #9ec5ff;
   --color-blue-4: #cbe0ff;
   --color-blue-5: #ecf2fa;
-  --color-blue-2-25-pct: rgba(85, 149, 255, 0.25);
+  --color-blue-2-25pct: rgba(85, 149, 255, 0.25);
 
   /* Oranges */
   --color-orange-1: #ff8800;

--- a/src/css/ui/components/app-header.css
+++ b/src/css/ui/components/app-header.css
@@ -1,6 +1,14 @@
 /* -- App Header ---------------------------------------------------------- */
 
 #app-header {
+  /* @color-todo @inverse */
+  --color-app-header-fg: var(--color-gray-lighten-100);
+  --color-app-header-bg: var(--color-gray-darken-10);
+  --color-app-header-subtle-fg: var(--color-gray-lighten-20);
+  --color-app-header-subtle-fg-em: var(--color-gray-lighten-50);
+  --color-app-header-context-unison-share-fg: var(--color-purple-4);
+  --color-app-header-context-unison-local-fg: var(--color-pink-3);
+  --color-app-header-border: transparent;
   grid-area: app-header;
   padding: 0 1rem 0 1.5rem;
   background: var(--color-app-header-bg);

--- a/src/css/ui/components/badges.css
+++ b/src/css/ui/components/badges.css
@@ -1,5 +1,9 @@
 .badge {
-  color: var(--color-badge-fg);
+  --color-badge-text: var(--u-color_text-on-element-emphasized);
+  --color-badge-bg: var(--u-color_element_emphasized);
+  --color-badge-border: var(--u-color_border);
+
+  color: var(--color-badge-text);
   background: var(--color-badge-bg);
   border: 1px solid var(--color-badge-border);
   font-size: var(--font-size-small);
@@ -11,6 +15,14 @@
 }
 
 .option-badge {
+  /* @color-todo @inverse */
+  --color-option-badge-text: var(--color-gray-lighten-40);
+  --color-option-badge-subtle-text: var(--color-gray-lighten-20);
+  --color-option-badge-icon: var(--color-gray-lighten-30);
+  --color-option-badge-hover-icon: var(--color-gray-100);
+  --color-option-badge-bg: var(--color-gray-darken-30);
+  --color-option-badge-border: var(--color-transparent);
+
   padding: 0 0.75rem;
   align-items: center;
   display: inline-flex;
@@ -19,7 +31,7 @@
   border-radius: calc(1.5rem / 2);
   border: 1px solid var(--color-option-badge-border);
   background: var(--color-option-badge-bg);
-  color: var(--color-option-badge-fg);
+  color: var(--color-option-badge-text);
   font-size: var(--font-size-small);
   cursor: pointer;
 }
@@ -36,5 +48,5 @@
 }
 
 .option-badge .subtle {
-  color: var(--color-option-badge-subtle-fg);
+  color: var(--color-option-badge-subtle-text);
 }

--- a/src/css/ui/components/button.css
+++ b/src/css/ui/components/button.css
@@ -1,4 +1,34 @@
 .button {
+  /* @color-todo */
+  --color-button-default-text: var(--u-color_text-on-action);
+  --color-button-default-icon: var(--u-color_icon-on-action);
+  --color-button-default-bg: var(--u-color_action);
+  --color-button-default-hover-text: var(--u-color_text-on-action_hovered);
+  --color-button-default-hover-icon: var(--u-color_text-on-action_hovered);
+  --color-button-default-hover-bg: var(--u-color_action_hovered);
+
+  --color-button-primary-mono-text: var(--color-gray-lighten-60);
+  --color-button-primary-mono-bg: var(--color-gray-darken-20);
+  --color-button-primary-mono-hover-text: var(--color-gray-lighten-60);
+  --color-button-primary-mono-hover-bg: var(--color-gray-darken-10);
+
+  /* @deprecate */
+  --color-button-primary-text: var(--color-gray-lighten-60);
+  --color-button-primary-bg: var(--color-blue-2);
+  --color-button-primary-hover-text: var(--color-gray-lighten-60);
+  --color-button-primary-hover-bg: var(--color-blue-1);
+
+  /* @decorative */
+  --color-button-share-text: var(--color-purple-1);
+  --color-button-share-bg: var(--color-purple-4);
+  --color-button-share-hover-text: var(--color-purple-2);
+  --color-button-share-hover-bg: var(--color-purple-4);
+
+  --color-button-danger-text: var(--color-gray-lighten-100);
+  --color-button-danger-bg: var(--color-pink-1);
+  --color-button-danger-hover-text: var(--color-gray-lighten-100);
+  --color-button-danger-hover-bg: var(--color-pink-2);
+
   display: inline-flex;
   font-family: var(--font-sans-serif);
   border: 0;
@@ -73,87 +103,87 @@ a.button:hover {
 /* -- Contained & Colors --------------------------------------------------- */
 
 .button.contained.default {
-  color: var(--color-button-default-fg);
+  color: var(--color-button-default-text);
   background: var(--color-button-default-bg);
 }
 .button.contained.default .icon {
-  color: var(--color-button-default-fg);
+  color: var(--color-button-default-text);
 }
 
 .button.contained.default:hover {
-  color: var(--color-button-default-hover-fg);
+  color: var(--color-button-default-hover-text);
   background: var(--color-button-default-hover-bg);
 }
 
 .button.contained.default:hover .icon {
-  color: var(--color-button-default-hover-fg);
+  color: var(--color-button-default-hover-text);
 }
 
 .button.contained.primary-mono {
-  color: var(--color-button-primary-mono-fg);
+  color: var(--color-button-primary-mono-text);
   background: var(--color-button-primary-mono-bg);
 }
 
 .button.contained.primary-mono .icon {
-  color: var(--color-button-primary-mono-fg);
+  color: var(--color-button-primary-mono-text);
 }
 
 .button.contained.primary-mono:hover {
-  color: var(--color-button-primary-mono-hover-fg);
+  color: var(--color-button-primary-mono-hover-text);
   background: var(--color-button-primary-mono-hover-bg);
 }
 .button.contained.primary-mono:hover .icon {
-  color: var(--color-button-primary-mono-hover-fg);
+  color: var(--color-button-primary-mono-hover-text);
 }
 
 .button.contained.primary {
-  color: var(--color-button-primary-fg);
+  color: var(--color-button-primary-text);
   background: var(--color-button-primary-bg);
 }
 .button.contained.primary .icon {
-  color: var(--color-button-primary-fg);
+  color: var(--color-button-primary-text);
 }
 
 .button.contained.primary:hover {
-  color: var(--color-button-primary-hover-fg);
+  color: var(--color-button-primary-hover-text);
   background: var(--color-button-primary-hover-bg);
 }
 .button.contained.primary:hover .icon {
-  color: var(--color-button-primary-hover-fg);
+  color: var(--color-button-primary-hover-text);
 }
 
 .button.contained.share {
-  color: var(--color-button-share-fg);
+  color: var(--color-button-share-text);
   background: var(--color-button-share-bg);
 }
 
 .button.contained.share .icon {
-  color: var(--color-button-share-fg);
+  color: var(--color-button-share-text);
 }
 
 .button.contained.share:hover {
-  color: var(--color-button-share-hover-fg);
+  color: var(--color-button-share-hover-text);
   background: var(--color-button-share-hover-bg);
 }
 
 .button.contained.share:hover .icon {
-  color: var(--color-button-share-hover-fg);
+  color: var(--color-button-share-hover-text);
 }
 
 .button.contained.danger {
-  color: var(--color-button-danger-fg);
+  color: var(--color-button-danger-text);
   background: var(--color-button-danger-bg);
 }
 .button.contained.danger .icon {
-  color: var(--color-button-danger-fg);
+  color: var(--color-button-danger-text);
 }
 
 .button.contained.danger:hover {
-  color: var(--color-button-danger-fg);
+  color: var(--color-button-danger-text);
   background: var(--color-button-danger-bg);
 }
 .button.contained.danger:hover .icon {
-  color: var(--color-button-danger-fg);
+  color: var(--color-button-danger-text);
 }
 
 /* -- Uncontained & Colors ------------------------------------------------- */
@@ -163,68 +193,68 @@ a.button:hover {
 
 .button.uncontained.default,
 .button.uncontained.default .icon {
-  color: var(--color-button-default-fg);
+  color: var(--color-button-default-text);
 }
 
 .button.uncontained.default:hover {
-  color: var(--color-button-default-hover-fg);
+  color: var(--color-button-default-hover-text);
   background: var(--color-button-default-hover-bg);
 }
 
 .button.uncontained.default:hover .icon {
-  color: var(--color-button-default-hover-fg);
+  color: var(--color-button-default-hover-text);
 }
 
 .button.uncontained.primary-mono,
 .button.uncontained.primary-mono .icon {
-  color: var(--color-button-primary-mono-fg);
+  color: var(--color-button-primary-mono-text);
 }
 
 .button.uncontained.primary-mono:hover {
-  color: var(--color-button-primary-mono-hover-fg);
+  color: var(--color-button-primary-mono-hover-text);
   background: var(--color-button-primary-mono-hover-bg);
 }
 
 .button.uncontained.primary-mono:hover .icon {
-  color: var(--color-button-primary-mono-hover-fg);
+  color: var(--color-button-primary-mono-hover-text);
 }
 
 .button.uncontained.primary,
 .button.uncontained.primary .icon {
-  color: var(--color-button-primary-fg);
+  color: var(--color-button-primary-text);
 }
 
 .button.uncontained.primary:hover {
-  color: var(--color-button-primary-hover-fg);
+  color: var(--color-button-primary-hover-text);
   background: var(--color-button-primary-hover-bg);
 }
 .button.uncontained.primary:hover .icon {
-  color: var(--color-button-primary-hover-fg);
+  color: var(--color-button-primary-hover-text);
 }
 
 .button.uncontained.share,
 .button.uncontained.share .icon {
-  color: var(--color-button-share-fg);
+  color: var(--color-button-share-text);
 }
 
 .button.uncontained.share:hover {
-  color: var(--color-button-share-hover-fg);
+  color: var(--color-button-share-hover-text);
   background: var(--color-button-share-hover-bg);
 }
 
 .button.uncontained.share:hover .icon {
-  color: var(--color-button-share-hover-fg);
+  color: var(--color-button-share-hover-text);
 }
 
 .button.uncontained.danger,
 .button.uncontained.danger .icon {
-  color: var(--color-button-danger-fg);
+  color: var(--color-button-danger-text);
 }
 
 .button.uncontained.danger:hover {
-  color: var(--color-button-danger-fg);
+  color: var(--color-button-danger-text);
   background: var(--color-button-danger-bg);
 }
 .button.uncontained.danger:hover .icon {
-  color: var(--color-button-danger-fg);
+  color: var(--color-button-danger-text);
 }

--- a/src/css/ui/components/card.css
+++ b/src/css/ui/components/card.css
@@ -1,9 +1,14 @@
 .card {
+  --color-card-bg: var(--u-color_container);
+  --color-card-text: var(--u-color_text);
+  --color-card-title: var(--u-color_text_very-subdued);
+  --color-card-border: var(--u-color_border_subdued);
+
   padding: 1rem 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  color: var(--color-card-fg);
+  color: var(--color-card-text);
   border-radius: var(--border-radius-base);
   background: var(--color-card-bg);
 }

--- a/src/css/ui/components/codebase-tree.css
+++ b/src/css/ui/components/codebase-tree.css
@@ -21,13 +21,13 @@
   flex-direction: row;
   align-items: center;
   margin: 0.5rem 0;
-  color: var(--color-main-alert-subtle-fg);
+  color: var(--u-color_critical_text);
 }
 
 .codebase-tree .error .icon {
   font-size: 1rem;
   margin-right: 0.25rem;
-  color: var(--color-main-alert-fg);
+  color: var(--u-color_critical_icon);
 }
 
 .codebase-tree .loading {
@@ -113,4 +113,3 @@
 .codebase-tree .namespace-tree .namespace-content {
   margin-left: 1rem;
 }
-

--- a/src/css/ui/components/copy-field.css
+++ b/src/css/ui/components/copy-field.css
@@ -1,4 +1,13 @@
 .copy-field {
+  --color-copy-field-text: var(--u-color_text);
+  --color-copy-field-bg: var(--u-color_element_disabled);
+  --color-copy-field-border: var(--u-color_border);
+  --color-copy-field-focus-border: var(--u-color_focus-border);
+  --color-copy-field-focus-outline: var(--u-color_focus-outline);
+  --color-copy-field-prefix: var(--u-color_text_subdued);
+  --color-copy-field-button-border: var(--u-color_border);
+  --color-copy-field-button-hover-border: var(--color-gray-lighten-30);
+
   position: relative;
   display: flex;
   flex-direction: row;
@@ -19,7 +28,7 @@
 }
 
 .copy-field .copy-field-field:focus-within {
-  box-shadow: 0 0 0 2px var(--color-copy-field-focus-glow);
+  box-shadow: 0 0 0 2px var(--color-copy-field-focus-outline);
   border-color: var(--color-copy-field-focus-border);
   border-right: 1px solid var(--color-copy-field-focus-border);
   /* z-index is to help cover the left border of the button when focused */
@@ -46,7 +55,7 @@
   font-size: var(--font-size-medium);
   font-weight: 600;
   background: transparent;
-  color: var(--color-copy-field-fg);
+  color: var(--color-copy-field-text);
 }
 
 .copy-field input:focus {

--- a/src/css/ui/components/divider.css
+++ b/src/css/ui/components/divider.css
@@ -1,5 +1,5 @@
 .divider {
-  background: var(--color-main-divider);
+  background: var(--u-color_divider);
   border: 0;
   margin: 1.5rem 0;
   height: 2px;

--- a/src/css/ui/components/fold-toggle.css
+++ b/src/css/ui/components/fold-toggle.css
@@ -1,4 +1,9 @@
 .fold-toggle {
+  --color-fold-toggle-icon: var(--u-color_icon-on-action-subdued);
+  --color-fold-toggle-bg: var(--u-color_action_subdued);
+  --color-fold-toggle-hover-icon: var(--u-color_icon-on-action-subdued-hovered);
+  --color-fold-toggle-hover-bg: var(--u-color_action_subdued_hovered);
+
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -20,7 +25,7 @@
 
 /* ▶ */
 .fold-toggle .icon {
-  color: var(--color-fold-toggle-fg);
+  color: var(--color-fold-toggle-icon);
   transition: color 0.2s, transform 0.1s ease-out;
 }
 
@@ -34,5 +39,5 @@
 }
 
 .fold-toggle:not(.disabled):hover .icon {
-  color: var(--color-fold-toggle-hover-fg);
+  color: var(--color-fold-toggle-hover-icon);
 }

--- a/src/css/ui/components/icon.css
+++ b/src/css/ui/components/icon.css
@@ -3,7 +3,7 @@
   font-size: 0.875rem;
   width: 1em;
   height: 1em;
-  color: var(--color-main-fg);
+  color: var(--u-color_icon);
   transition: all 0.2s;
 }
 

--- a/src/css/ui/components/keyboard-shortcuts.css
+++ b/src/css/ui/components/keyboard-shortcuts.css
@@ -1,4 +1,9 @@
 .keyboard-shortcuts {
+  --color-keyboard-shortcut-key-text: var(--u-color_text-on-element-emphasized);
+  --color-keyboard-shortcut-key-bg: var(--u-color_element_emphasized);
+  --color-keyboard-shortcut-then: var(--u-color_text_subdued);
+  --color-keyboard-shortcut-separator: var(--u-color_text_subdued);
+
   display: flex;
   flex-direction: row;
   justify-self: flex-end;
@@ -44,7 +49,7 @@
   justify-content: center;
   align-content: center;
   align-items: center;
-  color: var(--color-keyboard-shortcut-key-fg);
+  color: var(--color-keyboard-shortcut-key-text);
   background: var(--color-keyboard-shortcut-key-bg);
   transition: all 0.2s;
 }

--- a/src/css/ui/components/loading-placeholder.css
+++ b/src/css/ui/components/loading-placeholder.css
@@ -1,8 +1,10 @@
 .loading-placeholder {
+  --color-placeholder: var(--u-color_text_very-subdued);
+
   display: inline-block;
   height: calc(var(--font-size-base) * 0.65);
   border-radius: calc(var(--font-size-base) / 2);
-  background: var(--color-main-subtle-fg);
+  background: var(--color-placeholder);
   min-width: calc(var(--font-size-base) * 3);
 }
 

--- a/src/css/ui/components/modal.css
+++ b/src/css/ui/components/modal.css
@@ -1,4 +1,25 @@
 #modal-overlay {
+  /* @color-todo */
+  --color-modal-fg: var(--u-color_text);
+  --color-modal-mg: var(--u-color_element_subdued);
+  --color-modal-bg: var(--u-color_container);
+  --color-modal-inner-border: var(--color-gray-lighten-50);
+  --color-modal-separator: var(--u-color_divider);
+  --color-modal-shadow: var(--u-shadow);
+  --color-modal-overlay: var(--u-color_backdrop);
+  --color-modal-border: var(--color-transparent);
+  --color-modal-subtle-fg: var(--u-color_text_very-subdued);
+  --color-modal-subtle-fg-em: var(--u-color-text-subdued);
+  --color-modal-subtle-mg: var(--color-gray-lighten-55);
+  --color-modal-subtle-bg: var(--u-color_container_subdued);
+  --color-modal-focus-fg: var(--u-color_text);
+  --color-modal-focus-bg: var(--color-gray-lighten-55);
+  --color-modal-focus-subtle-fg: var(--color-gray-base);
+  --color-modal-focus-subtle-bg: var(--color-gray-lighten-50);
+  --color-modal-title-fg: var(--color-gray-lighten-20);
+  --color-modal-title-bg: var(--color-transparent);
+  --color-modal-error-fg: var(--color-pink-1);
+
   position: fixed;
   top: 0;
   left: 0;
@@ -22,8 +43,7 @@
   height: -moz-fit-content;
   height: fit-content;
   animation: slide-up 0.2s var(--anim-elastic);
-  box-shadow: 0 0.375rem 1rem var(--color-modal-shadow),
-    0 0 0 1px var(--color-modal-border);
+  box-shadow: 0 0.375rem 1rem var(--color-modal-shadow);
   z-index: var(--layer-modal);
   font-size: var(--font-size-medium);
 }
@@ -32,7 +52,6 @@
   padding: 1.5rem;
   display: flex;
   flex-direction: row;
-  color: var(--color-modal-title-bg);
 }
 
 .modal-header + .modal-content {
@@ -58,6 +77,7 @@
 .modal-header .close-modal .icon {
   color: var(--color-modal-subtle-fg);
 }
+
 .modal-header .close-modal:hover .icon {
   color: var(--color-modal-fg);
 }

--- a/src/css/ui/components/text.css
+++ b/src/css/ui/components/text.css
@@ -3,11 +3,15 @@ a:visited {
   text-decoration: none;
   cursor: pointer;
   transition: all 0.2s;
-  color: var(--color-main-fg);
+  color: var(--u-color_interactive);
 }
 
 a:hover {
-  text-decoration: underline;
+  color: var(--u-color_interactive_hovered);
+}
+
+a:active {
+  color: var(--u-color_interactive_pressed);
 }
 
 h1 {
@@ -27,9 +31,9 @@ p {
 }
 
 .error-message {
-  color: var(--color-main-alert-fg);
+  color: var(--u-color_critical_text);
 }
 
 .subtle {
-  color: var(--color-main-subtle-fg);
+  color: var(--u-color_text_subdued);
 }

--- a/src/css/ui/components/toolbar.css
+++ b/src/css/ui/components/toolbar.css
@@ -1,10 +1,13 @@
 .toolbar {
+  --color-toolbar: var(--u-color_container);
+  --color-toolbar-border: var(--u-color_border_subdued);
+
   height: var(--toolbar-height);
   padding-left: 2.625rem;
   padding-right: 1rem;
   font-size: var(--font-size-medium);
-  background: var(--color-main-bg);
-  border-bottom: 1px solid var(--color-main-border);
+  background: var(--color-toolbar);
+  border-bottom: 1px solid var(--color-toolbar-border);
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/src/css/ui/components/tooltip.css
+++ b/src/css/ui/components/tooltip.css
@@ -1,6 +1,38 @@
 /* -- Core ------------------------------------------------------------------*/
 
 .tooltip {
+  /* @color-todo @inverse */
+  --color-tooltip-text: var(--color-gray-lighten-60);
+  --color-tooltip-subtle-text: var(--color-gray-lighten-20);
+  --color-tooltip-bg: var(--color-gray-darken-30);
+  --color-tooltip-source-bg: var(--color-gray-darken-20);
+  --color-tooltip-source-mg: var(--color-gray-darken-10);
+  --color-tooltip-fold-hover-bg: var(--color-gray-darken-10);
+  --color-tooltip-link: var(--color-blue-3);
+  --color-tooltip-link-active: var(--color-pink-2);
+  --color-tooltip-link-hover: var(--color-pink-3);
+  --color-tooltip-syntax-base: var(--color-gray-lighten-60);
+  --color-tooltip-syntax-subtle: var(--color-gray-lighten-20);
+  --color-tooltip-syntax-subtle-em: var(--color-gray-lighten-30);
+  --color-tooltip-syntax-keyword: var(--color-pink-3);
+  --color-tooltip-syntax-operator: var(--color-gray-lighten-20);
+  --color-tooltip-syntax-term: var(--color-purple-3);
+  --color-tooltip-syntax-term-namespace: var(--color-purple-4);
+  --color-tooltip-syntax-ability: var(--color-pink-2);
+  --color-tooltip-syntax-type: var(--color-blue-2);
+  --color-tooltip-syntax-type-namespace: var(--color-blue-3);
+  --color-tooltip-syntax-constructor: var(--color-blue-2);
+  --color-tooltip-syntax-constructor-namespace: var(--color-blue-3);
+  --color-tooltip-syntax-text: var(--color-green-2);
+
+  /* ActionMenu (should probably be moved out of tooltip) */
+  --color-tooltip-item-text: var(--color-gray-lighten-60);
+  --color-tooltip-item-subtle-text: var(--color-gray-lighten-20);
+  --color-tooltip-item-bg: var(--color-transparent);
+  --color-tooltip-item-hover-text: var(--color-gray-lighten-60);
+  --color-tooltip-item-hover-subtle-text: var(--color-gray-lighten-30);
+  --color-tooltip-item-hover-bg: var(--color-gray-darken-10);
+
   position: absolute;
   opacity: 0;
   pointer-events: none;
@@ -24,8 +56,6 @@
   --color-doc-link-active: var(--color-tooltip-link-active);
   --color-doc-link-hover: var(--color-tooltip-link-hover);
   --color-doc-source-bg: var(--color-tooltip-source-bg);
-  --color-doc-source-mg: var(--color-tooltip-source-mg);
-  --color-doc-fold-hover-bg: var(--color-tooltip-fold-hover-bg);
 
   /* Syntax (via Docs) can be rendered inside tooltips */
   --color-syntax-base: var(--color-tooltip-syntax-base);
@@ -50,7 +80,7 @@
 .tooltip-bubble {
   position: relative;
   font-size: var(--font-size-medium);
-  color: var(--color-tooltip-fg);
+  color: var(--color-tooltip-text);
   background: var(--color-tooltip-bg);
   padding: 0.5rem 0.75rem;
   border-radius: var(--border-radius-base);
@@ -237,7 +267,7 @@
   align-items: center;
   flex: 1;
   height: 2rem;
-  color: var(--color-tooltip-item-fg);
+  color: var(--color-tooltip-item-text);
   background: var(--color-tooltip-item-bg);
   white-space: nowrap;
   padding: 0 0.5rem;
@@ -248,16 +278,17 @@
 .tooltip .tooltip-menu-items .tooltip-menu-item .icon {
   font-size: var(--font-size-base);
   margin-right: 0.5rem;
-  color: var(--color-tooltip-item-subtle-fg);
+  color: var(--color-tooltip-item-subtle-text);
   margin-top: -1px;
 }
 
 .tooltip .tooltip-menu-items .tooltip-menu-item:hover {
   text-decoration: none;
-  color: var(--color-tooltip-item-hover-fg);
+  color: var(--color-tooltip-item-hover-text);
   background: var(--color-tooltip-item-hover-bg);
 }
 
 .tooltip .tooltip-menu-items .tooltip-menu-item:hover .icon {
-  color: var(--color-tooltip-item-hover-subtle-fg);
+  color: var(--color-tooltip-item-hover-subtle-text);
 }
+

--- a/src/css/ui/page-layout.css
+++ b/src/css/ui/page-layout.css
@@ -18,6 +18,10 @@
 }
 
 .page.hero-layout {
+  /* @color-todo @inverse */
+  --color-page-hero-fg: var(--color-gray-lighten-100);
+  --color-page-hero-bg: var(--color-gray-darken-10);
+
   grid-template-rows: var(--page-hero-height) auto;
   grid-template-columns: auto;
   grid-template-areas:
@@ -31,7 +35,7 @@
   grid-area: page-content;
   scroll-behavior: smooth;
   scrollbar-width: auto;
-  scrollbar-color: var(--color-main-subtle-fg) var(--color-main-bg);
+  scrollbar-color: var(--u-color_scrollbar) var(--u-color_scrollbar-track);
 }
 
 .page-content::-webkit-scrollbar {
@@ -40,11 +44,11 @@
 }
 
 .page-content::-webkit-scrollbar-track {
-  background: var(--color-main-bg);
+  background: var(--u-color_scrollbar-track);
 }
 
 .page-content::-webkit-scrollbar-thumb {
-  background-color: var(--color-main-subtle-fg);
+  background-color: var(--u-color_scrollbar);
   border-radius: var(--border-radius-base);
 }
 
@@ -56,6 +60,36 @@
 }
 
 #main-sidebar {
+  /* @color-todo @inverse */
+  --color-sidebar-fg: var(--color-gray-lighten-50);
+  --color-sidebar-fg-em: var(--color-gray-lighten-100);
+  --color-sidebar-bg: var(--color-gray-darken-20);
+  /* see color files for why this is needed */
+  --color-sidebar-bg-transparent: var(--color-gray-darken-20-transparent);
+  --color-sidebar-border: var(--color-gray-base);
+  --color-sidebar-subtle-fg: var(--color-gray-lighten-20);
+  --color-sidebar-subtle-fg-em: var(--color-gray-lighten-30);
+  --color-sidebar-subtle-bg: var(--color-transparent);
+  --color-sidebar-focus-fg: var(--color-gray-lighten-60);
+  --color-sidebar-focus-bg: var(--color-gray-darken-10);
+  --color-sidebar-keyboard-shortcut-key-fg: var(--color-gray-lighten-30);
+  --color-sidebar-keyboard-shortcut-key-bg: var(--color-gray-base);
+  --color-sidebar-keyboard-shortcut-then: var(--color-gray-lighten-20);
+  --color-sidebar-keyboard-shortcut-separator: var(--color-gray-base);
+  --color-sidebar-keyboard-shortcut-hover-key-fg: var(--color-gray-lighten-50);
+  --color-sidebar-keyboard-shortcut-hover-key-bg: var(--color-gray-base);
+  --color-sidebar-keyboard-shortcut-hover-then: var(--color-gray-lighten-20);
+  --color-sidebar-keyboard-shortcut-hover-separator: var(--color-gray-base);
+  --color-sidebar-button-default-text: var(--color-gray-lighten-30);
+  --color-sidebar-button-default-bg: var(--color-gray-base);
+  --color-sidebar-button-default-hover-text: var(--color-gray-lighten-50);
+  --color-sidebar-button-default-hover-bg: var(--color-gray-base);
+  --color-sidebar-divider: var(--color-gray-darken-10);
+
+  --color-sidebar-tooltip-fg: var(--color-gray-lighten-60);
+  --color-sidebar-tooltip-bg: var(--color-gray-darken-30);
+  --color-sidebar-tooltip-border: var(--color-gray-darken-10);
+
   grid-area: main-sidebar;
   display: flex;
   flex-direction: column;
@@ -69,19 +103,23 @@
   font-size: var(--font-size-medium);
   z-index: var(--layer-popover);
 
-  --color-main-fg: var(--color-sidebar-fg);
-  --color-main-subtle-fg: var(--color-sidebar-subtle-fg);
+  --u-color_text: var(--color-sidebar-fg);
+  --u-color_text_subdued: var(--color-sidebar-subtle-fg);
 
-  --color-button-default-fg: var(--color-sidebar-button-default-fg);
-  --color-button-default-bg: var(--color-sidebar-button-default-bg);
-  --color-button-default-hover-fg: var(--color-sidebar-button-default-hover-fg);
-  --color-button-default-hover-bg: var(--color-sidebar-button-default-hover-bg);
-
-  --color-tooltip-fg: var(--color-sidebar-tooltip-fg);
+  --color-tooltip-text: var(--color-sidebar-tooltip-fg);
   --color-tooltip-bg: var(--color-sidebar-tooltip-bg);
   --color-tooltip-border: var(--color-sidebar-tooltip-border);
 
-  --color-main-divider: var(--color-sidebar-divider);
+  --u-color_divider: var(--color-sidebar-divider);
+}
+
+#main-sidebar .button {
+  --color-button-default-text: var(--color-sidebar-button-default-text);
+  --color-button-default-bg: var(--color-sidebar-button-default-bg);
+  --color-button-default-hover-text: var(
+    --color-sidebar-button-default-hover-text
+  );
+  --color-button-default-hover-bg: var(--color-sidebar-button-default-hover-bg);
 }
 
 #main-sidebar a:hover {
@@ -160,7 +198,7 @@
   height: 1.875rem;
 }
 
-#main-sidebar .sidebar-item>label {
+#main-sidebar .sidebar-item > label {
   color: var(--color-sidebar-fg);
   transition: all 0.2s;
   cursor: pointer;
@@ -234,9 +272,11 @@
   bottom: -2rem;
   height: 1.75rem;
   content: "";
-  background: linear-gradient(var(--color-sidebar-bg),
-      var(--color-sidebar-bg),
-      var(--color-sidebar-bg-transparent));
+  background: linear-gradient(
+    var(--color-sidebar-bg),
+    var(--color-sidebar-bg),
+    var(--color-sidebar-bg-transparent)
+  );
 }
 
 #main-sidebar .sidebar-header .hasvatar {
@@ -250,10 +290,12 @@
   bottom: 0;
   content: "";
   width: 1.5rem;
-  background: linear-gradient(90deg,
-      var(--color-sidebar-bg),
-      var(--color-sidebar-bg),
-      var(--color-sidebar-bg-transparent));
+  background: linear-gradient(
+    90deg,
+    var(--color-sidebar-bg),
+    var(--color-sidebar-bg),
+    var(--color-sidebar-bg-transparent)
+  );
 }
 
 #main-sidebar .sidebar-header .namespace {
@@ -397,7 +439,8 @@
   }
 
   .page.sidebar-toggled .collapse-sidebar-button {
-    animation: collapse-sidebar-button var(--transition-sidebar-collapse-time) ease-in-out;
+    animation: collapse-sidebar-button var(--transition-sidebar-collapse-time)
+      ease-in-out;
     transition: none;
     animation-fill-mode: forwards;
   }
@@ -474,3 +517,4 @@
     display: none;
   }
 }
+

--- a/src/css/unison-local.css
+++ b/src/css/unison-local.css
@@ -16,12 +16,12 @@
   align-items: center;
   padding-top: 8rem;
   font-weight: 600;
-  color: var(--color-main-mg);
+  color: var(--u-color_text);
 }
 
 .app-error .icon {
   font-size: 4rem;
-  color: var(--color-main-alert);
+  color: var(--u-color_critical_icon);
 }
 
 @import "./ui.css";

--- a/src/css/unison-local/perspective-landing.css
+++ b/src/css/unison-local/perspective-landing.css
@@ -1,12 +1,17 @@
 #perspective-landing {
+  --color-perspective-landing-text: var(--u-color_text_subdued);
+  --color-perspective-landing-bg: var(--u-color_background);
+  --color-perspective-landing-placeholder-text: var(--u-color_border_subdued);
+  --color-perspective-landing-subtle-text: var(--u-color_text_very-subdued);
+  --color-perspective-landing-subtle-border: var(--u-color_border_subdued);
+
   display: flex;
   flex-direction: column;
   background: var(--color-perspective-landing-bg);
-  color: var(--color-perspective-landing-fg);
+  color: var(--color-perspective-landing-text);
   overflow: auto;
   scrollbar-width: auto;
-  scrollbar-color: var(--color-perspective-landing-subtle-fg)
-    var(--color-perspective-landing-bg);
+  scrollbar-color: var(--u-color_scrollbar) var(--u-color_scrollbar-track);
 }
 
 #perspective-landing-content {
@@ -15,8 +20,7 @@
   height: calc(100vh - var(--main-header-height));
   width: var(--main-content-width);
   scrollbar-width: auto;
-  scrollbar-color: var(--color-perspective-landing-subtle-fg)
-    var(--color-perspective-landing-bg);
+  scrollbar-color: var(--u-color_scrollbar) var(--u-color_scrollbar-track);
 }
 
 #perspective-landing::-webkit-scrollbar,
@@ -27,18 +31,18 @@
 
 #perspective-landing::-webkit-scrollbar-track,
 #perspective-landing-content::-webkit-scrollbar-track {
-  background: var(--color-perspective-landing-bg);
+  background: var(--u-color_scrollbar-track);
 }
 
 #perspective-landing::-webkit-scrollbar-thumb,
 #perspective-landing-content::-webkit-scrollbar-thumb {
-  background-color: var(--color-perspective-landing-subtle-fg);
+  background-color: var(--u-color_scrollbar);
   border-radius: var(--border-radius-base);
 }
 
 #perspective-landing .loading .loading-placeholder {
   width: 50%;
-  background: var(--color-perspective-landing-subtle-fg);
+  background: var(--color-perspective-landing-subtle-text);
 }
 
 #perspective-landing .loading .loading-placeholder-row {
@@ -50,7 +54,7 @@
   .loading-placeholder-row:last-child
   .loading-placeholder {
   width: 80%;
-  background: var(--color-perspective-landing-subtle-fg);
+  background: var(--color-perspective-landing-subtle-text);
 }
 
 #perspective-landing .perspective-landing-error header {
@@ -86,13 +90,13 @@
   padding-bottom: 4rem;
   display: flex;
   justify-content: center;
-  color: var(--color-perspective-landing-subtle-fg-em);
+  color: var(--color-perspective-landing-text);
 }
 
 .perspective-landing-empty-state h2 {
   font-size: 1.5rem;
   margin-bottom: 1.5rem;
-  color: var(--color-perspective-landing-fg);
+  color: var(--color-perspective-landing-text);
 }
 
 .perspective-landing-empty-state .content {
@@ -120,7 +124,7 @@
 }
 
 .perspective-landing-empty-state .faux-empty-state-item .loading-placeholder {
-  background: var(--color-perspective-landing-subtle-fg);
+  background: var(--color-perspective-landing-placeholder-text);
   height: 1rem;
   width: 5rem;
 }
@@ -134,7 +138,6 @@
   .faux-empty-state-item
   .loading-placeholder-row:last-child
   .loading-placeholder {
-  background: var(--color-perspective-landing-bg-em);
   width: 12rem;
 }
 

--- a/src/css/unison-share.css
+++ b/src/css/unison-share.css
@@ -16,12 +16,12 @@
   align-items: center;
   padding-top: 8rem;
   font-weight: 600;
-  color: var(--color-main-mg);
+  color: var(--u-color_text);
 }
 
 .app-error .icon {
   font-size: 4rem;
-  color: var(--color-main-alert);
+  color: var(--u-color_critical_icon);
 }
 
 @import "./ui.css";

--- a/src/css/unison-share/page/catalog.css
+++ b/src/css/unison-share/page/catalog.css
@@ -1,4 +1,7 @@
 .catalog-hero {
+  /* @color-todo @decorative */
+  --color-catalog-search-field: var(--u-color_container);
+  --color-catalog-search-field-text: var(--u-color_text);
   --color-catalog-hero-bg: var(--color-gray-darken-10);
   --color-catalog-hero-bg-transparent: var(--color-gray-darken-10-transparent);
   --color-catalog-hero-explore: var(--color-green-4);
@@ -56,8 +59,8 @@
 
 .catalog-hero .catalog-search {
   width: 50rem;
-  background: var(--color-main-bg);
-  color: var(--color-main-fg);
+  background: var(--color-catalog-search-field);
+  color: var(--color-catalog-search-field-text);
   border-radius: var(--border-radius-base);
   position: absolute;
   top: calc(var(--page-hero-height) - 1.75rem);
@@ -72,8 +75,8 @@
 }
 
 .catalog-hero .catalog-search:focus-within {
-  border-color: var(--color-main-focus-fg);
-  box-shadow: 0 0 0 2px var(--color-main-focus-outline);
+  border-color: var(--u-color_focus-border);
+  box-shadow: 0 0 0 2px var(--u-color_focus-outline);
 }
 
 .catalog-hero .catalog-search .search-field {
@@ -92,7 +95,7 @@
 .catalog-hero .catalog-search .search-field .icon {
   font-size: 1.5rem;
   margin-top: -3px;
-  color: var(--color-main-subtle-fg);
+  color: var(--u-color_icon_subdued);
 }
 
 .catalog-hero .catalog-search .search-field input {
@@ -114,7 +117,7 @@
 }
 
 .catalog-hero .catalog-search .search-results {
-  background: var(--color-main-bg);
+  background: var(-u-color_container);
   border-top: 1px solid var(--color-gray-lighten-50);
   border-radius: 0 0 var(--border-radius-base) var(--border-radius-base);
   padding: 0.75rem;
@@ -147,7 +150,7 @@
 }
 
 .catalog-hero .catalog-search .search-results .search-result td.category {
-  color: var(--color-main-subtle-fg);
+  color: var(--u-color_text_very-subdued);
   font-size: var(--font-size-small);
   text-transform: uppercase;
 }
@@ -207,8 +210,8 @@
   width: 1.5rem;
   height: 1.5rem;
   margin-right: 0.5rem;
-  background: var(--color-main-subtle-bg);
-  border: 1px solid var(--color-main-border);
+  background: var(--u-color_element_subdued);
+  border: 1px solid var(--u-color_border);
   border-radius: 0.75rem;
   display: flex;
   flex-direction: row;
@@ -216,6 +219,7 @@
   justify-content: center;
   overflow: hidden;
 }
+
 .catalog-hero
   .catalog-search
   .search-results
@@ -224,12 +228,12 @@
   .avatar
   .icon {
   font-size: 1rem;
-  color: var(--color-main-border);
+  color: var(--u-color_icon_subdued);
 }
 
 .catalog-hero .catalog-search .search-results .empty-state {
   font-size: var(--font-size-base);
-  color: var(--color-main-subtle-fg);
+  color: var(--u-color_text_very-subdued);
   text-align: center;
   padding: 1rem 0;
 }
@@ -281,6 +285,7 @@
   .catalog-hero .catalog-search .search-results .search-result td.category {
     display: none;
   }
+
   .catalog-hero
     .catalog-search
     .search-results
@@ -289,3 +294,4 @@
     display: none;
   }
 }
+

--- a/src/css/unison-share/perspective-landing.css
+++ b/src/css/unison-share/perspective-landing.css
@@ -1,12 +1,17 @@
 #perspective-landing {
+  --color-perspective-landing-text: var(--u-color_text_subdued);
+  --color-perspective-landing-bg: var(--u-color_background);
+  --color-perspective-landing-placeholder-text: var(--u-color_border_subdued);
+  --color-perspective-landing-subtle-text: var(--u-color_text_very-subdued);
+  --color-perspective-landing-subtle-border: var(--u-color_border_subdued);
+
   display: flex;
   flex-direction: column;
   background: var(--color-perspective-landing-bg);
-  color: var(--color-perspective-landing-fg);
+  color: var(--color-perspective-landing-text);
   overflow: auto;
   scrollbar-width: auto;
-  scrollbar-color: var(--color-perspective-landing-subtle-fg)
-    var(--color-perspective-landing-bg);
+  scrollbar-color: var(--u-color_scrollbar) var(--u-color_scrollbar-track);
 }
 
 #perspective-landing-content {
@@ -15,8 +20,7 @@
   height: calc(100vh - var(--main-header-height));
   width: var(--main-content-width);
   scrollbar-width: auto;
-  scrollbar-color: var(--color-perspective-landing-subtle-fg)
-    var(--color-perspective-landing-bg);
+  scrollbar-color: var(--u-color_scrollbar) var(--u-color_scrollbar-track);
 }
 
 #perspective-landing::-webkit-scrollbar,
@@ -27,18 +31,18 @@
 
 #perspective-landing::-webkit-scrollbar-track,
 #perspective-landing-content::-webkit-scrollbar-track {
-  background: var(--color-perspective-landing-bg);
+  background: var(--u-color_scrollbar-track);
 }
 
 #perspective-landing::-webkit-scrollbar-thumb,
 #perspective-landing-content::-webkit-scrollbar-thumb {
-  background-color: var(--color-perspective-landing-subtle-fg);
+  background-color: var(--u-color_scrollbar);
   border-radius: var(--border-radius-base);
 }
 
 #perspective-landing .loading .loading-placeholder {
   width: 50%;
-  background: var(--color-perspective-landing-subtle-fg);
+  background: var(--color-perspective-landing-subtle-text);
 }
 
 #perspective-landing .loading .loading-placeholder-row {
@@ -50,7 +54,7 @@
   .loading-placeholder-row:last-child
   .loading-placeholder {
   width: 80%;
-  background: var(--color-perspective-landing-subtle-fg);
+  background: var(--color-perspective-landing-subtle-text);
 }
 
 #perspective-landing .perspective-landing-error header {
@@ -86,13 +90,13 @@
   padding-bottom: 4rem;
   display: flex;
   justify-content: center;
-  color: var(--color-perspective-landing-subtle-fg-em);
+  color: var(--color-perspective-landing-text);
 }
 
 .perspective-landing-empty-state h2 {
   font-size: 1.5rem;
   margin-bottom: 1.5rem;
-  color: var(--color-perspective-landing-fg);
+  color: var(--color-perspective-landing-text);
 }
 
 .perspective-landing-empty-state .content {
@@ -120,7 +124,7 @@
 }
 
 .perspective-landing-empty-state .faux-empty-state-item .loading-placeholder {
-  background: var(--color-perspective-landing-subtle-fg);
+  background: var(--color-perspective-landing-placeholder-text);
   height: 1rem;
   width: 5rem;
 }
@@ -134,7 +138,6 @@
   .faux-empty-state-item
   .loading-placeholder-row:last-child
   .loading-placeholder {
-  background: var(--color-perspective-landing-bg-em);
   width: 12rem;
 }
 


### PR DESCRIPTION
## Overview
Add a layer between color tokens and component color tokens; namely
color token aliases.

This allows components to define their own tokens from aliases instead
of directly from colors which facilitates theming and a better
separation of the ui library, the code library, and the 2 apps: share
and local.